### PR TITLE
Prevent FSWatch errors by limiting the scope of `require.context`

### DIFF
--- a/packages/example/.storybook/config.js
+++ b/packages/example/.storybook/config.js
@@ -1,7 +1,7 @@
 import { configure } from '@storybook/react';
 
 // automatically import all story.js files
-const req = require.context('../', true, /^(?!.*@bufferapp\/*).*(story\.jsx)$/);
+const req = require.context('../components/', true, /story\.jsx$/);
 
 function loadStories() {
   req.keys().forEach(req);

--- a/packages/web/.storybook/config.js
+++ b/packages/web/.storybook/config.js
@@ -1,7 +1,7 @@
 import { configure } from '@storybook/react';
 
 // automatically import all story.js files, excluding buffer components
-const req = require.context('../', true, /^(?!.*@bufferapp\/*).*(story\.jsx)$/);
+const req = require.context('../components/', true, /story\.jsx$/);
 
 function loadStories() {
   req.keys().forEach(req);


### PR DESCRIPTION
I was seeing the [same errors/issues mentioned here](https://github.com/webpack/webpack/issues/2356) when trying to run `npm run start` (i.e., Storybook) on my WIP `profile-sidebar` package, which was just a copy of the `example` package with minor tweaks.

It looks like because our Storybook config file passes the entire directory to `require.context`, which includes `node_modules`, there is some massive recursion of file watching that happens and ends up causing all kinds of bugs/errors. This doesn't apply to `components`/`shared-components` since they have no internally lerna-linked dependencies.

This PR changes the regex in the `context` call to only watch the `components` folder inside a package. Everything should work the same as before, just be sure you keep your components in that folder or Storybook won't be able to pick up their stories.