### PR TITLE
remove outline from tabs

### DIFF
--- a/packages/components/LinkStateless/index.jsx
+++ b/packages/components/LinkStateless/index.jsx
@@ -44,7 +44,7 @@ const Link = ({
     block: {
       display: 'block',
     },
-    focused: focusedStyle,
+    focused: unstyled ? '' : focusedStyle,
   }, {
     hovered,
     unstyled,


### PR DESCRIPTION
### Purpose
This PR removes the outline from unstyled links! Some sort of indicator that the link has focus should be custom built in on our end, in this case for Tabs, we've got the lovely blue underline! :D 

### Notes

### Review
@hharnisc 

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
