### PR TITLE
Store profile data by ID

### DIFF
--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -30,6 +30,7 @@ export default (state = initialState, action) => {
 export const actions = {
   selectProfile: ({ profile }) => ({
     type: actionTypes.SELECT_PROFILE,
+    profileId: profile.id,
     profile,
   }),
 };

--- a/packages/profile-sidebar/reducer.test.js
+++ b/packages/profile-sidebar/reducer.test.js
@@ -22,6 +22,7 @@ describe('reducer', () => {
     expect(actions.selectProfile({ profile }))
       .toEqual({
         type: actionTypes.SELECT_PROFILE,
+        profileId: profile.id,
         profile,
       });
   });

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -85,14 +85,10 @@ const QueuedPosts = ({
 };
 
 QueuedPosts.propTypes = {
-  total: PropTypes.number.isRequired,
-  loading: PropTypes.bool.isRequired,
-  loadingMore: PropTypes.bool.isRequired,
-  onCancelConfirmClick: PropTypes.func.isRequired,
-  onDeleteClick: PropTypes.func.isRequired,
-  onDeleteConfirmClick: PropTypes.func.isRequired,
-  onEditClick: PropTypes.func.isRequired,
-  onShareNowClick: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+  loadingMore: PropTypes.bool,
+  moreToLoad: PropTypes.bool, // eslint-disable-line
+  page: PropTypes.number, // eslint-disable-line
   postLists: PropTypes.arrayOf(
     PropTypes.shape({
       listHeader: PropTypes.string,
@@ -103,11 +99,21 @@ QueuedPosts.propTypes = {
       ),
     }),
   ).isRequired,
+  total: PropTypes.number,
+  onCancelConfirmClick: PropTypes.func.isRequired,
+  onDeleteClick: PropTypes.func.isRequired,
+  onDeleteConfirmClick: PropTypes.func.isRequired,
+  onEditClick: PropTypes.func.isRequired,
+  onShareNowClick: PropTypes.func.isRequired,
 };
 
 QueuedPosts.defaultProps = {
-  postLists: [],
+  loading: true,
   loadingMore: false,
+  moreToLoad: false,
+  page: 1,
+  postLists: [],
+  total: 0,
 };
 
 export default QueuedPosts;

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -23,15 +23,21 @@ const formatPostLists = (posts) => {
 
 // default export = container
 export default connect(
-  state => ({
-    loading: state.queue.loading,
-    loadingMore: state.queue.loadingMore,
-    moreToLoad: state.queue.moreToLoad,
-    page: state.queue.page,
-    postLists: formatPostLists(state.queue.posts),
-    total: state.queue.total,
-    translations: state.i18n.translations.example, // all package translations
-  }),
+  (state, ownProps) => {
+    const profileId = ownProps.profileId;
+    const currentProfile = state.queue.profilesById[profileId];
+    if (currentProfile) {
+      return {
+        loading: currentProfile.loading,
+        loadingMore: currentProfile.loadingMore,
+        moreToLoad: currentProfile.moreToLoad,
+        page: currentProfile.page,
+        postLists: formatPostLists(currentProfile.posts),
+        total: currentProfile.total,
+      };
+    }
+    return {};
+  },
 )(QueuedPosts);
 
 // export reducer, actions and action types

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -25,7 +25,7 @@ const formatPostLists = (posts) => {
 export default connect(
   (state, ownProps) => {
     const profileId = ownProps.profileId;
-    const currentProfile = state.queue.profilesById[profileId];
+    const currentProfile = state.queue.byProfileId[profileId];
     if (currentProfile) {
       return {
         loading: currentProfile.loading,

--- a/packages/queue/index.test.jsx
+++ b/packages/queue/index.test.jsx
@@ -20,7 +20,7 @@ describe('Queue', () => {
   it('should render', () => {
     const store = storeFake({
       queue: {
-        profilesById: {
+        byProfileId: {
           abc: {
             loading: true,
             loadingMore: false,

--- a/packages/queue/index.test.jsx
+++ b/packages/queue/index.test.jsx
@@ -20,15 +20,14 @@ describe('Queue', () => {
   it('should render', () => {
     const store = storeFake({
       queue: {
-        loading: false,
-        posts: [],
-        total: 0,
-      },
-      i18n: {
-        translations: {
-          example: {
-            loggedIn: 'Logged In...',
-            loggedOut: 'Logged Out...',
+        profilesById: {
+          abc: {
+            loading: true,
+            loadingMore: false,
+            moreToLoad: false,
+            page: 1,
+            posts: [],
+            total: 0,
           },
         },
       },
@@ -36,6 +35,7 @@ describe('Queue', () => {
     const wrapper = mount(
       <Provider store={store}>
         <Queue
+          profileId="abc"
           postLists={[]}
           onCancelConfirmClick={jest.fn()}
           onDeleteClick={jest.fn()}

--- a/packages/queue/reducer.js
+++ b/packages/queue/reducer.js
@@ -81,7 +81,7 @@ const profileReducer = (state = profileInitialState, action) => {
 };
 
 const initialState = {
-  profilesById: {},
+  byProfileId: {},
 };
 
 const getProfileId = (action) => {
@@ -107,9 +107,9 @@ export default (state = initialState, action) => {
       profileId = getProfileId(action);
       if (profileId) {
         return {
-          profilesById: {
-            ...state.profilesById,
-            [profileId]: profileReducer(state.profilesById[profileId], action),
+          byProfileId: {
+            ...state.byProfileId,
+            [profileId]: profileReducer(state.byProfileId[profileId], action),
           },
         };
       }

--- a/packages/queue/reducer.test.js
+++ b/packages/queue/reducer.test.js
@@ -1,15 +1,12 @@
 import deepFreeze from 'deep-freeze';
 import reducer from './reducer';
 
+const profileId = '123456';
+
 describe('reducer', () => {
   it('should initialize default state', () => {
     const stateAfter = {
-      loading: true,
-      loadingMore: false,
-      moreToLoad: false,
-      page: 1,
-      posts: [],
-      total: 0,
+      profilesById: {},
     };
     const action = {
       type: 'INIT',
@@ -21,16 +18,20 @@ describe('reducer', () => {
 
   it('should handle queuedPosts_FETCH_START action type', () => {
     const stateAfter = {
-      loading: true,
-      loadingMore: false,
-      moreToLoad: false,
-      page: 1,
-      posts: [],
-      total: 0,
+      profilesById: {
+        [profileId]: {
+          loading: true,
+          loadingMore: false,
+          moreToLoad: false,
+          page: 1,
+          posts: [],
+          total: 0,
+        },
+      },
     };
     const action = {
+      profileId,
       type: 'queuedPosts_FETCH_START',
-      posts: [],
       args: {
         isFetchingMore: false,
       },
@@ -40,144 +41,52 @@ describe('reducer', () => {
       .toEqual(stateAfter);
   });
 
-  it('should handle FETCH_POSTS_ERROR action type', () => {
+  it('should handle queuedPosts_FETCH_SUCCESS action type', () => {
+    const post = { id: 'foo', text: 'i love buffer' };
     const stateAfter = {
-      loading: true,
-      loadingMore: false,
-      moreToLoad: false,
-      page: 1,
-      posts: [],
-      total: 0,
+      profilesById: {
+        [profileId]: {
+          loading: false,
+          loadingMore: false,
+          moreToLoad: false,
+          page: 2,
+          posts: [post],
+          total: 1,
+        },
+      },
     };
     const action = {
-      type: 'FETCH_POSTS_ERROR',
-      postLists: [],
+      profileId,
+      type: 'queuedPosts_FETCH_SUCCESS',
+      result: {
+        updates: [post],
+        total: 1,
+      },
+      args: {
+        isFetchingMore: false,
+      },
     };
     deepFreeze(action);
     expect(reducer(undefined, action))
       .toEqual(stateAfter);
   });
 
-  it('should handle POST_CREATED action type', () => {
+  it('should handle queuedPosts_FETCH_FAIL action type', () => {
     const stateAfter = {
-      loading: true,
-      loadingMore: false,
-      moreToLoad: false,
-      page: 1,
-      posts: [],
-      total: 0,
+      profilesById: {
+        [profileId]: {
+          loading: false,
+          loadingMore: false,
+          moreToLoad: false,
+          page: 1,
+          posts: [],
+          total: 0,
+        },
+      },
     };
     const action = {
-      type: 'POST_CREATED',
-      postLists: [],
-    };
-    deepFreeze(action);
-    expect(reducer(undefined, action))
-      .toEqual(stateAfter);
-  });
-
-  it('should handle POST_UPDATED action type', () => {
-    const stateAfter = {
-      loading: true,
-      loadingMore: false,
-      moreToLoad: false,
-      page: 1,
-      posts: [],
-      total: 0,
-    };
-    const action = {
-      type: 'POST_UPDATED',
-      posts: [],
-    };
-    deepFreeze(action);
-    expect(reducer(undefined, action))
-      .toEqual(stateAfter);
-  });
-
-  it('should handle POST_CONFIRM_DELETE action type', () => {
-    const stateAfter = {
-      loading: true,
-      loadingMore: false,
-      moreToLoad: false,
-      page: 1,
-      posts: [],
-      total: 0,
-    };
-    const action = {
-      type: 'POST_CONFIRM_DELETE',
-      posts: [],
-    };
-    deepFreeze(action);
-    expect(reducer(undefined, action))
-      .toEqual(stateAfter);
-  });
-
-  it('should handle POST_DELETED action type', () => {
-    const stateAfter = {
-      loading: true,
-      loadingMore: false,
-      moreToLoad: false,
-      page: 1,
-      posts: [],
-      total: 0,
-    };
-    const action = {
-      type: 'POST_DELETED',
-      posts: [],
-    };
-    deepFreeze(action);
-    expect(reducer(undefined, action))
-      .toEqual(stateAfter);
-  });
-
-  it('should handle POST_DELETE_CANCELED action type', () => {
-    const stateAfter = {
-      loading: true,
-      loadingMore: false,
-      moreToLoad: false,
-      page: 1,
-      posts: [],
-      total: 0,
-    };
-    const action = {
-      type: 'POST_DELETE_CANCELED',
-      posts: [],
-    };
-    deepFreeze(action);
-    expect(reducer(undefined, action))
-      .toEqual(stateAfter);
-  });
-
-  it('should handle POST_ERROR action type', () => {
-    const stateAfter = {
-      loading: true,
-      loadingMore: false,
-      moreToLoad: false,
-      page: 1,
-      posts: [],
-      total: 0,
-    };
-    const action = {
-      type: 'POST_ERROR',
-      posts: [],
-    };
-    deepFreeze(action);
-    expect(reducer(undefined, action))
-      .toEqual(stateAfter);
-  });
-
-  it('should handle REQUESTING_POST_DELETE action type', () => {
-    const stateAfter = {
-      loading: true,
-      loadingMore: false,
-      moreToLoad: false,
-      page: 1,
-      posts: [],
-      total: 0,
-    };
-    const action = {
-      type: 'REQUESTING_POST_DELETE',
-      posts: [],
+      profileId,
+      type: 'queuedPosts_FETCH_FAIL',
     };
     deepFreeze(action);
     expect(reducer(undefined, action))

--- a/packages/queue/reducer.test.js
+++ b/packages/queue/reducer.test.js
@@ -6,7 +6,7 @@ const profileId = '123456';
 describe('reducer', () => {
   it('should initialize default state', () => {
     const stateAfter = {
-      profilesById: {},
+      byProfileId: {},
     };
     const action = {
       type: 'INIT',
@@ -18,7 +18,7 @@ describe('reducer', () => {
 
   it('should handle queuedPosts_FETCH_START action type', () => {
     const stateAfter = {
-      profilesById: {
+      byProfileId: {
         [profileId]: {
           loading: true,
           loadingMore: false,
@@ -44,7 +44,7 @@ describe('reducer', () => {
   it('should handle queuedPosts_FETCH_SUCCESS action type', () => {
     const post = { id: 'foo', text: 'i love buffer' };
     const stateAfter = {
-      profilesById: {
+      byProfileId: {
         [profileId]: {
           loading: false,
           loadingMore: false,
@@ -73,7 +73,7 @@ describe('reducer', () => {
 
   it('should handle queuedPosts_FETCH_FAIL action type', () => {
     const stateAfter = {
-      profilesById: {
+      byProfileId: {
         [profileId]: {
           loading: false,
           loadingMore: false,

--- a/packages/sent/__snapshots__/snapshot.test.js.snap
+++ b/packages/sent/__snapshots__/snapshot.test.js.snap
@@ -5,81 +5,30 @@ exports[`Snapshots SentPosts default 1`] = `
   <div
     style={
       Object {
-        "display": "flex",
-        "height": "70vh",
-        "justifyContent": "center",
+        "height": "100%",
+        "paddingTop": "5rem",
+        "textAlign": "center",
+        "width": "100%",
       }
     }
   >
-    <div
+    <img
+      alt=""
+      src="https://s3.amazonaws.com/buffer-publish/images/black-loading-gif-small.gif"
       style={
         Object {
-          "alignSelf": "center",
-          "textAlign": "center",
-          "width": "700px",
+          "height": undefined,
+          "marginBottom": undefined,
+          "marginTop": "5rem",
+          "maxHeight": undefined,
+          "maxWidth": undefined,
+          "minHeight": undefined,
+          "minWidth": undefined,
+          "objectFit": undefined,
+          "width": "45px",
         }
       }
-    >
-      <img
-        alt=""
-        src="https://s3.amazonaws.com/buffer-publish/images/empty-sent2x.png"
-        style={
-          Object {
-            "height": "150px",
-            "marginBottom": "1.5rem",
-            "marginTop": undefined,
-            "maxHeight": undefined,
-            "maxWidth": undefined,
-            "minHeight": undefined,
-            "minWidth": undefined,
-            "objectFit": undefined,
-            "width": "270px",
-          }
-        }
-      />
-      <div
-        style={
-          Object {
-            "marginBottom": "1.5rem",
-            "width": "100%",
-          }
-        }
-      >
-        <span
-          style={
-            Object {
-              "color": "#59626a",
-              "fontFamily": "\\"Open Sans\\", sans-serif",
-              "fontSize": "1.25rem",
-              "fontWeight": 600,
-            }
-          }
-        >
-          You haven’t published any posts with this account in the past 30 days!
-        </span>
-      </div>
-      <div
-        style={
-          Object {
-            "display": "inline-block",
-            "width": "500px",
-          }
-        }
-      >
-        <span
-          style={
-            Object {
-              "color": "#59626a",
-              "fontFamily": "\\"Open Sans\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-            }
-          }
-        >
-          Once a post has gone live via Buffer, you can track it’s performance here to learn what works best with your audience!
-        </span>
-      </div>
-    </div>
+    />
   </div>
 </span>
 `;

--- a/packages/sent/components/SentPosts/index.jsx
+++ b/packages/sent/components/SentPosts/index.jsx
@@ -78,10 +78,11 @@ const SentPosts = ({
 };
 
 SentPosts.propTypes = {
-  total: PropTypes.number.isRequired,
   header: PropTypes.string,
-  loading: PropTypes.bool.isRequired,
-  loadingMore: PropTypes.bool.isRequired,
+  loading: PropTypes.bool,
+  loadingMore: PropTypes.bool,
+  moreToLoad: PropTypes.bool, // eslint-disable-line
+  page: PropTypes.number, // eslint-disable-line
   postLists: PropTypes.arrayOf(
     PropTypes.shape({
       listHeader: PropTypes.string,
@@ -91,14 +92,18 @@ SentPosts.propTypes = {
         }),
       ),
     }),
-  ).isRequired,
+  ),
+  total: PropTypes.number,
 };
 
 SentPosts.defaultProps = {
   header: null,
-  loading: false,
+  loading: true,
   loadingMore: false,
+  moreToLoad: false,
+  page: 1,
   postLists: [],
+  total: 0,
 };
 
 export default SentPosts;

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -23,15 +23,22 @@ const formatPostLists = (posts) => {
 
 // default export = container
 export default connect(
-  state => ({
-    header: state.sent.header,
-    loading: state.sent.loading,
-    loadingMore: state.sent.loadingMore,
-    page: state.sent.page,
-    postLists: formatPostLists(state.sent.posts),
-    total: state.sent.total,
-    translations: state.i18n.translations.sent, // all package translations
-  }),
+  (state, ownProps) => {
+    const profileId = ownProps.profileId;
+    const currentProfile = state.sent.profilesById[profileId];
+    if (currentProfile) {
+      return {
+        header: currentProfile.header,
+        loading: currentProfile.loading,
+        loadingMore: currentProfile.loadingMore,
+        moreToLoad: currentProfile.moreToLoad,
+        page: currentProfile.page,
+        postLists: formatPostLists(currentProfile.posts),
+        total: currentProfile.total,
+      };
+    }
+    return {};
+  },
 )(SentPosts);
 
 // export reducer, actions and action types

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -25,7 +25,7 @@ const formatPostLists = (posts) => {
 export default connect(
   (state, ownProps) => {
     const profileId = ownProps.profileId;
-    const currentProfile = state.sent.profilesById[profileId];
+    const currentProfile = state.sent.byProfileId[profileId];
     if (currentProfile) {
       return {
         header: currentProfile.header,

--- a/packages/sent/index.test.jsx
+++ b/packages/sent/index.test.jsx
@@ -20,7 +20,7 @@ describe('Sent', () => {
   it('should render', () => {
     const store = storeFake({
       sent: {
-        profilesById: {
+        byProfileId: {
           abc: {
             loading: true,
             loadingMore: false,

--- a/packages/sent/index.test.jsx
+++ b/packages/sent/index.test.jsx
@@ -20,22 +20,23 @@ describe('Sent', () => {
   it('should render', () => {
     const store = storeFake({
       sent: {
-        total: 0,
-        loading: false,
-        posts: [],
-      },
-      i18n: {
-        translations: {
-          example: {
-            loggedIn: 'Logged In...',
-            loggedOut: 'Logged Out...',
+        profilesById: {
+          abc: {
+            loading: true,
+            loadingMore: false,
+            moreToLoad: false,
+            page: 1,
+            posts: [],
+            total: 0,
           },
         },
       },
     });
     const wrapper = mount(
       <Provider store={store}>
-        <Sent />
+        <Sent
+          profileId="abc"
+        />
       </Provider>,
     );
     expect(wrapper.find(SentPosts).length)

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -63,7 +63,7 @@ const profileReducer = (state = profileInitialState, action) => {
 };
 
 const initialState = {
-  profilesById: {},
+  byProfileId: {},
 };
 
 const getProfileId = (action) => {
@@ -82,9 +82,9 @@ export default (state = initialState, action) => {
       profileId = getProfileId(action);
       if (profileId) {
         return {
-          profilesById: {
-            ...state.profilesById,
-            [profileId]: profileReducer(state.profilesById[profileId], action),
+          byProfileId: {
+            ...state.byProfileId,
+            [profileId]: profileReducer(state.byProfileId[profileId], action),
           },
         };
       }

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -1,15 +1,14 @@
 import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
+import { actionTypes as profileSidebarActionTypes } from '@bufferapp/profile-sidebar';
 import {
   header,
 } from './components/SentPosts/postData';
 
-export const actionTypes = {
-};
+export const actionTypes = { };
 
-// TODO remove stubbed data once we have real data coming in
-const initialState = {
+const profileInitialState = {
   header,
-  loading: false,
+  loading: true,
   loadingMore: false,
   moreToLoad: false,
   page: 1,
@@ -33,8 +32,10 @@ const increasePageCount = (page) => {
 const determineIfMoreToLoad = (action, currentPosts) =>
   (action.result.total > (currentPosts.length + action.result.updates.length));
 
-export default (state = initialState, action) => {
+const profileReducer = (state = profileInitialState, action) => {
   switch (action.type) {
+    case profileSidebarActionTypes.SELECT_PROFILE:
+      return profileInitialState;
     case `sentPosts_${dataFetchActionTypes.FETCH_START}`:
       return {
         ...state,
@@ -52,11 +53,45 @@ export default (state = initialState, action) => {
         total: action.result.total,
       };
     case `sentPosts_${dataFetchActionTypes.FETCH_FAIL}`:
+      return {
+        ...state,
+        loading: false,
+      };
+    default:
+      return state;
+  }
+};
+
+const initialState = {
+  profilesById: {},
+};
+
+const getProfileId = (action) => {
+  if (action.profileId) { return action.profileId; }
+  if (action.args) { return action.args.profileId; }
+  if (action.profile) { return action.profile.id; }
+};
+
+export default (state = initialState, action) => {
+  let profileId;
+  switch (action.type) {
+    case profileSidebarActionTypes.SELECT_PROFILE:
+    case `sentPosts_${dataFetchActionTypes.FETCH_START}`:
+    case `sentPosts_${dataFetchActionTypes.FETCH_SUCCESS}`:
+    case `sentPosts_${dataFetchActionTypes.FETCH_FAIL}`:
+      profileId = getProfileId(action);
+      if (profileId) {
+        return {
+          profilesById: {
+            ...state.profilesById,
+            [profileId]: profileReducer(state.profilesById[profileId], action),
+          },
+        };
+      }
       return state;
     default:
       return state;
   }
 };
 
-export const actions = {
-};
+export const actions = {};

--- a/packages/sent/reducer.test.js
+++ b/packages/sent/reducer.test.js
@@ -4,20 +4,95 @@ import {
   header,
 } from './components/SentPosts/postData';
 
-// TODO: revert test back to unstubbed data once async data is coming in
+const profileId = '123456';
+
 describe('reducer', () => {
   it('should initialize default state', () => {
     const stateAfter = {
-      header,
-      loading: false,
-      loadingMore: false,
-      moreToLoad: false,
-      page: 1,
-      posts: [],
-      total: 0,
+      profilesById: {},
     };
     const action = {
       type: 'INIT',
+    };
+    deepFreeze(action);
+    expect(reducer(undefined, action))
+      .toEqual(stateAfter);
+  });
+
+  it('should handle sentPosts_FETCH_START action type', () => {
+    const stateAfter = {
+      profilesById: {
+        [profileId]: {
+          header,
+          loading: true,
+          loadingMore: false,
+          moreToLoad: false,
+          page: 1,
+          posts: [],
+          total: 0,
+        },
+      },
+    };
+    const action = {
+      profileId,
+      type: 'sentPosts_FETCH_START',
+      args: {
+        isFetchingMore: false,
+      },
+    };
+    deepFreeze(action);
+    expect(reducer(undefined, action))
+      .toEqual(stateAfter);
+  });
+
+  it('should handle sentPosts_FETCH_SUCCESS action type', () => {
+    const post = { id: 'foo', text: 'i love buffer' };
+    const stateAfter = {
+      profilesById: {
+        [profileId]: {
+          header,
+          loading: false,
+          loadingMore: false,
+          moreToLoad: false,
+          page: 2,
+          posts: [post],
+          total: 1,
+        },
+      },
+    };
+    const action = {
+      profileId,
+      type: 'sentPosts_FETCH_SUCCESS',
+      result: {
+        updates: [post],
+        total: 1,
+      },
+      args: {
+        isFetchingMore: false,
+      },
+    };
+    deepFreeze(action);
+    expect(reducer(undefined, action))
+      .toEqual(stateAfter);
+  });
+
+  it('should handle sentPosts_FETCH_FAIL action type', () => {
+    const stateAfter = {
+      profilesById: {
+        [profileId]: {
+          header,
+          loading: false,
+          loadingMore: false,
+          moreToLoad: false,
+          page: 1,
+          posts: [],
+          total: 0,
+        },
+      },
+    };
+    const action = {
+      profileId,
+      type: 'sentPosts_FETCH_FAIL',
     };
     deepFreeze(action);
     expect(reducer(undefined, action))

--- a/packages/sent/reducer.test.js
+++ b/packages/sent/reducer.test.js
@@ -9,7 +9,7 @@ const profileId = '123456';
 describe('reducer', () => {
   it('should initialize default state', () => {
     const stateAfter = {
-      profilesById: {},
+      byProfileId: {},
     };
     const action = {
       type: 'INIT',
@@ -21,7 +21,7 @@ describe('reducer', () => {
 
   it('should handle sentPosts_FETCH_START action type', () => {
     const stateAfter = {
-      profilesById: {
+      byProfileId: {
         [profileId]: {
           header,
           loading: true,
@@ -48,7 +48,7 @@ describe('reducer', () => {
   it('should handle sentPosts_FETCH_SUCCESS action type', () => {
     const post = { id: 'foo', text: 'i love buffer' };
     const stateAfter = {
-      profilesById: {
+      byProfileId: {
         [profileId]: {
           header,
           loading: false,
@@ -78,7 +78,7 @@ describe('reducer', () => {
 
   it('should handle sentPosts_FETCH_FAIL action type', () => {
     const stateAfter = {
-      profilesById: {
+      byProfileId: {
         [profileId]: {
           header,
           loading: false,

--- a/packages/web/components/ProfilePage/index.jsx
+++ b/packages/web/components/ProfilePage/index.jsx
@@ -35,11 +35,12 @@ const contentStyle = {
   height: '100vh',
 };
 
-const TabContent = ({ tabId }) => {
+const TabContent = ({ tabId, profileId }) => {
   switch (tabId) {
     case 'queue':
       return (
         <QueuedPosts
+          profileId={profileId}
           onCancelConfirmClick={() => { }}
           onDeleteClick={() => { }}
           onDeleteConfirmClick={() => { }}
@@ -49,7 +50,9 @@ const TabContent = ({ tabId }) => {
       );
     case 'sent':
       return (
-        <SentPosts />
+        <SentPosts
+          profileId={profileId}
+        />
       );
     case 'settings':
       return (
@@ -64,6 +67,7 @@ const TabContent = ({ tabId }) => {
 
 TabContent.propTypes = {
   tabId: PropTypes.string,
+  profileId: PropTypes.string.isRequired,
 };
 
 TabContent.defaultProps = {
@@ -119,7 +123,7 @@ const ProfilePage = ({
           handleScroll,
         })}
       >
-        {TabContent({ tabId })}
+        {TabContent({ tabId, profileId })}
       </ScrollableContainer>
     </div>
   </div>;


### PR DESCRIPTION
### Purpose

To make things easier down the road I've shifted to storing profile data separately, keyed by ID. The biggest change here is in the queue and sent reducers, and then to the components so things are all handled correctly.

#### Example

Essentially our state goes from this:
(⚠️ Note that the key was changed to `byProfileId` instead of `profilesById`)

<img src="https://user-images.githubusercontent.com/809093/29098149-a94f73cc-7c52-11e7-8f10-a687e6dd816f.png" width="200">

To this:

<img src="https://user-images.githubusercontent.com/809093/29098167-bcb7006a-7c52-11e7-9cc6-41e925770d41.png" width="320">


#### Notes

At this point we're still forcing a fetch every time you change profiles, but in a future PR we can prevent that from happening when the data is already present.

#### Staging Deployment

👉  https://store-profile-data-by-id.publish.buffer.com
