### PR TITLE
Task/cleanup cicd deploy name

### DIFF
--- a/buffer-publish/templates/deployment.yaml
+++ b/buffer-publish/templates/deployment.yaml
@@ -3,10 +3,11 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ .Chart.Name }}
     service: app
-    track: stable
+    track: {{ .Values.track }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    branch: {{ .Values.branchName }}
   namespace: buffer
 spec:
   minReadySeconds: 10
@@ -15,7 +16,7 @@ spec:
     matchLabels:
       app: {{ template "fullname" . }}
       service: app
-      track: stable
+      track: {{ .Values.track }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -27,7 +28,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
         service: app
-        track: stable
+        track: {{ .Values.track }}
     spec:
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/buffer-publish/templates/ingress.yaml
+++ b/buffer-publish/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: "{{ .Values.branchName }}.publish.buffer.com"
+    - host: "{{ .Values.branchSubdomain }}publish.buffer.com"
       http:
         paths:
           - path: /

--- a/buffer-publish/templates/ingress.yaml
+++ b/buffer-publish/templates/ingress.yaml
@@ -6,10 +6,12 @@ kind: Ingress
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ .Chart.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    branch: {{ .Values.branchName }}
+    track: {{ .Values.track }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/buffer-publish/templates/service.yaml
+++ b/buffer-publish/templates/service.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app: {{ .Chart.Name }}
     service: web
+    branch: {{ .Values.branchName }}
+    track: {{ .Values.track }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
   {{ if not .Values.ingress.enabled }}
   annotations:

--- a/buffer-publish/values.yaml
+++ b/buffer-publish/values.yaml
@@ -36,4 +36,5 @@ resources:
     cpu: 100m
     memory: 50Mi
 branchName: master
+branchSubdomain: ''
 track: stable

--- a/buffer-publish/values.yaml
+++ b/buffer-publish/values.yaml
@@ -4,8 +4,8 @@
 replicaCount: 1
 image:
   repository: bufferapp/buffer-publish
-  tag: stable
-  pullPolicy: IfNotPresent
+  tag: latest
+  pullPolicy: Always
 service:
   name: nginx
   type: ClusterIP
@@ -36,3 +36,4 @@ resources:
     cpu: 100m
     memory: 50Mi
 branchName: master
+track: stable


### PR DESCRIPTION
### Purpose
This PR should add a few more labels to deployment, ingress and service

* Track - branch deploys as staging, master deploy as stable
* App - always going to be `buffer-publish`
* Branch - where the deploy is from

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
