### PR TITLE
remove color contrast test from axe-core tests

### DIFF
--- a/packages/components/lib/a11yTestHelper.js
+++ b/packages/components/lib/a11yTestHelper.js
@@ -42,7 +42,11 @@ const testComponentA11y = (app, config = []) => {
   const node = findDOMNode(wrapper.component);
 
   if (typeof config === 'function') {
-    config = {};
+    config = {
+      rules: {
+        'color-contrast': { enabled: false },
+      },
+    };
   }
   document.body.removeChild(div); //eslint-disable-line
   const oldNode = global.Node;


### PR DESCRIPTION
### Purpose
Removes the color contrast tests from our axe-core tests, which were slowing things down a bit :) Should help solve the timeout issues we were seeing. For now, let's test color contrast with the axe extension! https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
