### PR TITLE
WIP: add editClickHandler to queue

### DIFF
--- a/packages/composer/action-creators/AppActionCreators.js
+++ b/packages/composer/action-creators/AppActionCreators.js
@@ -373,6 +373,12 @@ const AppActionCreators = {
       actionType: ActionTypes.APP_LOADED,
     });
   },
+
+  resetData: () => {
+    AppDispatcher.handleViewAction({
+      actionType: ActionTypes.APP_RESET,
+    });
+  },
 };
 
 export default AppActionCreators;

--- a/packages/composer/components/App.jsx
+++ b/packages/composer/components/App.jsx
@@ -224,6 +224,8 @@ class App extends React.Component {
     window.removeEventListener('dragover', (e) => e.preventDefault());
 
     if (this.dragMe) this.dragMe.cleanup();
+
+    AppActionCreators.resetData();
   }
 
   onStoreChange = () => this.setState(getState());

--- a/packages/composer/components/App.jsx
+++ b/packages/composer/components/App.jsx
@@ -193,8 +193,6 @@ class App extends React.Component {
     AppActionCreators.trackUserAction(['viewed'], {
       timeToRender: (new Date() - window.pageStartTime),
     });
-
-    window.addEventListener('click', this.onDocumentClick);
   }
 
   componentDidMount() {
@@ -224,16 +222,8 @@ class App extends React.Component {
     NotificationStore.removeChangeListener(this.onStoreChange);
     window.removeEventListener('drop', (e) => e.preventDefault());
     window.removeEventListener('dragover', (e) => e.preventDefault());
-    window.removeEventListener('click', this.onDocumentClick);
 
     if (this.dragMe) this.dragMe.cleanup();
-  }
-
-  onDocumentClick = (ev) => {
-    // on document click, if not from MC or Edit button, execute callback from options
-    if (!this.appElement.contains(ev.target) && ev.target.innerText !== 'Edit') {
-      AppStore.getOptions().onSave();
-    }
   }
 
   onStoreChange = () => this.setState(getState());

--- a/packages/composer/components/App.jsx
+++ b/packages/composer/components/App.jsx
@@ -230,8 +230,8 @@ class App extends React.Component {
   }
 
   onDocumentClick = (ev) => {
-    // on document click, if not from MC, execute callback from options
-    if (!this.appElement.contains(ev.target)) {
+    // on document click, if not from MC or Edit button, execute callback from options
+    if (!this.appElement.contains(ev.target) && ev.target.innerText !== 'Edit') {
       AppStore.getOptions().onSave();
     }
   }

--- a/packages/composer/stores/AppStore.js
+++ b/packages/composer/stores/AppStore.js
@@ -4,8 +4,7 @@ import debounce from 'lodash.debounce';
 import escapeRegExp from 'lodash.escaperegexp';
 import moment from 'moment-timezone';
 import AppDispatcher from '../dispatcher';
-import { ActionTypes, AsyncOperationStates, Services, QueueingTypes, AppEnvironments }
-  from '../AppConstants';
+import { ActionTypes, AsyncOperationStates, Services, QueueingTypes } from '../AppConstants';
 import ComposerStore from './ComposerStore';
 import ComposerActionCreators from '../action-creators/ComposerActionCreators';
 import AppActionCreators from '../action-creators/AppActionCreators';
@@ -41,6 +40,7 @@ const getInitialState = () => ({
 });
 
 let state = getInitialState();
+
 
 const getNewProfile = (data) => ({
   id: data.id,

--- a/packages/composer/utils/DataImportUtils.js
+++ b/packages/composer/utils/DataImportUtils.js
@@ -188,7 +188,7 @@ const DataImportUtils = {
           images: (
             (update.media && update.media.picture &&
               [update.media.picture].concat(
-                (update.extra_media || []).map((extraMedia) => extraMedia.picture)
+                (update.extra_media || []).map((extraMedia) => extraMedia.picture || extraMedia.photo)
               )) ||
             null
           ),

--- a/packages/composer/utils/WebAPIUtils.js
+++ b/packages/composer/utils/WebAPIUtils.js
@@ -412,12 +412,16 @@ function getFormattedAPIData(serviceName, unformattedData) {
   const isUsingCustomScheduleTime = unformattedData.customScheduleTime !== null;
 
   const getFormattedMediaFields = () => {
-    let formattedMediaFields;
+    let formattedMediaFields = {
+      media: null,
+      extra_media: null,
+    };
 
     if (hasEnabledLinkAttachment) {
       const doesLinkAttachmentHaveThumbnail = serviceDraft.link.thumbnail !== null;
 
       formattedMediaFields = {
+        ...formattedMediaFields,
         media: {
           link: serviceDraft.link.url,
           title: serviceDraft.link.title,
@@ -447,6 +451,7 @@ function getFormattedAPIData(serviceName, unformattedData) {
         const [firstImage] = images.splice(0, 1);
 
         formattedMediaFields = {
+          ...formattedMediaFields,
           media: getFormattedImageFields(firstImage),
         };
 
@@ -462,6 +467,7 @@ function getFormattedAPIData(serviceName, unformattedData) {
         const gif = serviceDraft.gif.url;
 
         formattedMediaFields = {
+          ...formattedMediaFields,
           media: {
             progress: 100,
             uploaded: true,
@@ -474,6 +480,7 @@ function getFormattedAPIData(serviceName, unformattedData) {
         const video = serviceDraft.video;
 
         formattedMediaFields = {
+          ...formattedMediaFields,
           media: {
             progress: 100,
             uploaded: true,
@@ -496,8 +503,6 @@ function getFormattedAPIData(serviceName, unformattedData) {
           },
         };
       }
-    } else {
-      formattedMediaFields = {};
     }
 
     return formattedMediaFields;

--- a/packages/composer/utils/lifecycle-hooks/WebDashboardHooks.js
+++ b/packages/composer/utils/lifecycle-hooks/WebDashboardHooks.js
@@ -15,17 +15,18 @@ const WebDashboardHooks = {
   },
 
   handleSavedDrafts: () => {
-    const onNewPublish = AppStore.getUserData();
-    if (onNewPublish) {
-      AppActionCreators.resetData();
-      AppStore.getOptions().onSave();
-      return;
-    }
-    const { environment } = AppStore.getMetaData();
+    const { onNewPublish } = AppStore.getUserData();
 
-    window.parent.postMessage({
-      type: 'drafts-saved',
-    }, bufferOrigins.get(environment));
+    if (onNewPublish) {
+      AppStore.getOptions().onSave();
+      AppActionCreators.resetData();
+    } else {
+      const { environment } = AppStore.getMetaData();
+
+      window.parent.postMessage({
+        type: 'drafts-saved',
+      }, bufferOrigins.get(environment));
+    }
   },
 
 };

--- a/packages/composer/utils/lifecycle-hooks/WebDashboardHooks.js
+++ b/packages/composer/utils/lifecycle-hooks/WebDashboardHooks.js
@@ -19,7 +19,6 @@ const WebDashboardHooks = {
 
     if (onNewPublish) {
       AppStore.getOptions().onSave();
-      AppActionCreators.resetData();
     } else {
       const { environment } = AppStore.getMetaData();
 

--- a/packages/composer/utils/lifecycle-hooks/WebDashboardHooks.js
+++ b/packages/composer/utils/lifecycle-hooks/WebDashboardHooks.js
@@ -1,6 +1,7 @@
 /* global window */
 
 import AppStore from '../../stores/AppStore';
+import AppActionCreators from '../../action-creators/AppActionCreators';
 import { bufferOrigins } from '../../AppConstants';
 
 const WebDashboardHooks = {
@@ -17,6 +18,7 @@ const WebDashboardHooks = {
     const onNewPublish = AppStore.getUserData();
     if (onNewPublish) {
       AppStore.getOptions().onSave();
+      AppActionCreators.resetData();
       return;
     }
     const { environment } = AppStore.getMetaData();

--- a/packages/composer/utils/lifecycle-hooks/WebDashboardHooks.js
+++ b/packages/composer/utils/lifecycle-hooks/WebDashboardHooks.js
@@ -17,8 +17,8 @@ const WebDashboardHooks = {
   handleSavedDrafts: () => {
     const onNewPublish = AppStore.getUserData();
     if (onNewPublish) {
-      AppStore.getOptions().onSave();
       AppActionCreators.resetData();
+      AppStore.getOptions().onSave();
       return;
     }
     const { environment } = AppStore.getMetaData();

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -7,6 +7,7 @@ export const actionTypes = {
 const initialState = {
   profiles: [],
   lockedProfiles: [],
+  selectedProfileId: '',
   loading: false,
 };
 
@@ -29,7 +30,7 @@ export default (state = initialState, action) => {
     }
     case actionTypes.SELECT_PROFILE: {
       return {
-        ...state,
+        selectedProfileId: action.profileId,
         profiles: state.profiles
           .map(profile => ({
             ...profile,

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -36,6 +36,11 @@ export default (state = initialState, action) => {
             ...profile,
             open: profile.id === action.profileId,
           })),
+        lockedProfiles: state.lockedProfiles
+          .map(profile => ({
+            ...profile,
+            open: profile.id === action.profileId,
+          })),
       };
     }
     default:

--- a/packages/profile-sidebar/reducer.test.js
+++ b/packages/profile-sidebar/reducer.test.js
@@ -9,6 +9,7 @@ describe('reducer', () => {
       profiles: [],
       lockedProfiles: [],
       loading: false,
+      selectedProfileId: '',
     };
     const action = {
       type: 'INIT',

--- a/packages/queue/components/ComposerPopover/index.jsx
+++ b/packages/queue/components/ComposerPopover/index.jsx
@@ -5,10 +5,13 @@ import ComposerWrapper from '../ComposerWrapper';
 
 const ComposerPopover = ({
   onSave,
+  transparentOverlay,
 }) => (
   <Popover
     left={'25rem'}
     top={'10rem'}
+    transparentOverlay={transparentOverlay}
+    onOverlayClick={onSave}
   >
     <ComposerWrapper
       onSave={onSave}
@@ -18,6 +21,11 @@ const ComposerPopover = ({
 
 ComposerPopover.propTypes = {
   onSave: PropTypes.func.isRequired,
+  transparentOverlay: PropTypes.bool,
+};
+
+ComposerPopover.defaultProps = {
+  transparentOverlay: false,
 };
 
 export default ComposerPopover;

--- a/packages/queue/components/ComposerPopover/index.jsx
+++ b/packages/queue/components/ComposerPopover/index.jsx
@@ -8,8 +8,8 @@ const ComposerPopover = ({
   transparentOverlay,
 }) => (
   <Popover
-    left={'25rem'}
-    top={'10rem'}
+    left={'21rem'}
+    top={'4.7rem'}
     transparentOverlay={transparentOverlay}
     onOverlayClick={onSave}
   >

--- a/packages/queue/components/ComposerPopover/index.jsx
+++ b/packages/queue/components/ComposerPopover/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Popover } from '@bufferapp/components';
+import ComposerWrapper from '../ComposerWrapper';
+
+const ComposerPopover = ({
+  onSave,
+}) => (
+  <Popover
+    left={'25rem'}
+    top={'10rem'}
+  >
+    <ComposerWrapper
+      onSave={onSave}
+    />
+  </Popover>
+);
+
+ComposerPopover.propTypes = {
+  onSave: PropTypes.func.isRequired,
+};
+
+export default ComposerPopover;

--- a/packages/queue/components/ComposerWrapper/index.jsx
+++ b/packages/queue/components/ComposerWrapper/index.jsx
@@ -11,10 +11,14 @@ const ComposerWrapper = ({
   accessToken,
   onSave,
   environment,
+  editMode,
+  post,
 }) => {
+  const saveButtons = editMode ? ['SAVE'] : ['ADD_TO_QUEUE', 'SHARE_NOW'];
+
   const options = {
-    canSelectProfiles: true,
-    saveButtons: ['ADD_TO_QUEUE', 'SHARE_NOW'],
+    canSelectProfiles: !editMode,
+    saveButtons,
     position: { top: '10rem', left: '10rem' },
     onSave,
   };
@@ -26,7 +30,11 @@ const ComposerWrapper = ({
       userData.features && userData.features.includes('mc_facebook_autocomplete'),
     should_show_twitter_alt_text:
       userData.features && userData.features.includes('twitter_alt_text'),
-    should_use_new_twitter_autocomplete: enabledApplicationModes.includes('web-twitter-typeahead-autocomplete'),
+    // TODO: enabledApplicationModes.includes('web-twitter-typeahead-autocomplete'),
+    should_use_new_twitter_autocomplete: false,
+    updateId: post ? post.id : undefined,
+    update: post,
+    subprofileId: post ? post.subprofile_id : undefined,
   };
 
   const formattedData = formatInputData({
@@ -36,7 +44,7 @@ const ComposerWrapper = ({
       userData,
       metaData,
       csrfToken: '1234', // dummy string for now since MC requires csrfToken
-      update: {}, // post
+      update: post,
       imageDimensionsKey: userData.imageDimensionsKey,
     },
   });
@@ -73,27 +81,30 @@ ComposerWrapper.propTypes = {
   accessToken: PropTypes.string.isRequired,
   onSave: PropTypes.func.isRequired,
   environment: PropTypes.string.isRequired,
-  // post: PropTypes.shape({}),
+  editMode: PropTypes.bool.isRequired,
+  post: PropTypes.shape({}),
 };
 
 ComposerWrapper.defaultProps = {
   profiles: [],
   enabledApplicationModes: [],
   csrfToken: '1234',
-  // post: {},
+  post: {},
 };
 
 export default connect(
   (state) => {
     if (state.appSidebar && state.profileSidebar) {
+      const selectedProfileId = state.profileSidebar.selectedProfileId;
+      const postId = state.queue.editingPostId;
       return ({
         userData: state.appSidebar.user,
         profiles: state.profileSidebar.profiles,
-        enabledApplicationModes: state.queue.enabledApplicationModes,
+        enabledApplicationModes: state.enabledApplicationModes,
         environment: state.queue.environment,
         accessToken: state.login.sessionToken,
         editMode: state.queue.editMode,
-        // post: state.queue.byProfileId[profileId].posts[postId],
+        post: state.queue.byProfileId[selectedProfileId].posts[postId],
       });
     }
     return {};

--- a/packages/queue/components/ComposerWrapper/index.jsx
+++ b/packages/queue/components/ComposerWrapper/index.jsx
@@ -35,8 +35,8 @@ const ComposerWrapper = ({
       profiles,
       userData,
       metaData,
-      csrfToken: '1234',
-      update: {},
+      csrfToken: '1234', // dummy string for now since MC requires csrfToken
+      update: {}, // post
       imageDimensionsKey: userData.imageDimensionsKey,
     },
   });
@@ -73,12 +73,14 @@ ComposerWrapper.propTypes = {
   accessToken: PropTypes.string.isRequired,
   onSave: PropTypes.func.isRequired,
   environment: PropTypes.string.isRequired,
+  // post: PropTypes.shape({}),
 };
 
 ComposerWrapper.defaultProps = {
   profiles: [],
   enabledApplicationModes: [],
   csrfToken: '1234',
+  // post: {},
 };
 
 export default connect(
@@ -90,6 +92,8 @@ export default connect(
         enabledApplicationModes: state.queue.enabledApplicationModes,
         environment: state.queue.environment,
         accessToken: state.login.sessionToken,
+        editMode: state.queue.editMode,
+        // post: state.queue.byProfileId[profileId].posts[postId],
       });
     }
     return {};

--- a/packages/queue/components/ComposerWrapper/index.jsx
+++ b/packages/queue/components/ComposerWrapper/index.jsx
@@ -33,10 +33,9 @@ const ComposerWrapper = ({
     // TODO: enabledApplicationModes.includes('web-twitter-typeahead-autocomplete'),
     should_use_new_twitter_autocomplete: false,
     updateId: post ? post.id : undefined,
-    update: post,
+    update: { ...post, images: post.imageUrls },
     subprofileId: post ? post.subprofile_id : undefined,
   };
-
   const formattedData = formatInputData({
     env: metaData.application,
     data: {
@@ -44,11 +43,10 @@ const ComposerWrapper = ({
       userData,
       metaData,
       csrfToken: '1234', // dummy string for now since MC requires csrfToken
-      update: post,
+      update: { ...post, images: post.imageUrls },
       imageDimensionsKey: userData.imageDimensionsKey,
     },
   });
-
   return (
     <div>
       <Composer

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -15,6 +15,7 @@ import {
   EmptyState,
 } from '@bufferapp/publish-shared-components';
 import ComposerWrapper from '../ComposerWrapper';
+import ComposerPopover from '../ComposerPopover';
 
 const composerStyle = {
   marginBottom: '1.5rem',
@@ -44,6 +45,7 @@ const QueuedPosts = ({
   onImageClickPrev,
   onImageClose,
   showComposer,
+  editMode,
 }) => {
   if (loading) {
     return (
@@ -86,6 +88,9 @@ const QueuedPosts = ({
           heroImg="https://s3.amazonaws.com/buffer-publish/images/fresh-queue%402x.png"
           heroImgSize={{ width: '229px', height: '196px' }}
         />
+      }
+      {showComposer && editMode &&
+        <ComposerPopover onSave={onComposerCreateSuccess} />
       }
       <PostLists
         postLists={postLists}
@@ -132,6 +137,7 @@ QueuedPosts.propTypes = {
   onImageClickPrev: PropTypes.func,
   onImageClose: PropTypes.func,
   showComposer: PropTypes.bool,
+  editMode: PropTypes.bool,
 };
 
 QueuedPosts.defaultProps = {
@@ -143,6 +149,7 @@ QueuedPosts.defaultProps = {
   showComposer: false,
   total: 0,
   enabledApplicationModes: [],
+  editMode: false,
 };
 
 export default QueuedPosts;

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -70,16 +70,17 @@ const QueuedPosts = ({
   return (
     <div>
       <div style={composerStyle}>
-        {showComposer && !editMode ?
-          <ComposerWrapper
+        {showComposer && !editMode &&
+          <ComposerPopover
             onSave={onComposerCreateSuccess}
-          />
-          :
-          <Input
-            placeholder={'What would you like to share?'}
-            onFocus={onComposerPlaceholderClick}
+            transparentOverlay
+            onOverlayClick={onComposerCreateSuccess}
           />
         }
+        <Input
+          placeholder={'What would you like to share?'}
+          onFocus={onComposerPlaceholderClick}
+        />
       </div>
       {total < 1 &&
         <EmptyState

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -70,7 +70,7 @@ const QueuedPosts = ({
   return (
     <div>
       <div style={composerStyle}>
-        {showComposer ?
+        {showComposer && !editMode ?
           <ComposerWrapper
             onSave={onComposerCreateSuccess}
           />

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -14,7 +14,6 @@ import {
   PostLists,
   EmptyState,
 } from '@bufferapp/publish-shared-components';
-import ComposerWrapper from '../ComposerWrapper';
 import ComposerPopover from '../ComposerPopover';
 
 const composerStyle = {

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -39,6 +39,8 @@ export default connect(
         enabledApplicationModes: state.queue.enabledApplicationModes,
         showComposer: state.queue.showComposer,
         environment: state.queue.environment,
+        editMode: state.queue.editMode,
+        editingPostId: state.queue.editingPostId,
       };
     }
     return {};

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -44,6 +44,12 @@ export default connect(
     return {};
   },
   (dispatch, ownProps) => ({
+    onEditClick: (post) => {
+      dispatch(actions.handleEditClick({
+        post: post.post,
+        profileId: ownProps.profileId,
+      }));
+    },
     onDeleteClick: (post) => {
       dispatch(actions.handleDeleteClick({
         post: post.post,

--- a/packages/queue/reducer.js
+++ b/packages/queue/reducer.js
@@ -4,7 +4,6 @@ import { actionTypes as profileSidebarActionTypes } from '@bufferapp/publish-pro
 export const actionTypes = {
   POST_CREATED: 'POST_CREATED',
   POST_UPDATED: 'POST_UPDATED',
-  // POST_CLICKED_EDIT: 'POST_CLICKED_EDIT',
   POST_CLICKED_DELETE: 'POST_CLICKED_DELETE',
   POST_CONFIRMED_DELETE: 'POST_CONFIRMED_DELETE',
   POST_DELETED: 'POST_DELETED',
@@ -25,6 +24,8 @@ const initialState = {
   showComposer: false,
   enabledApplicationModes: [],
   environment: 'production',
+  editMode: false,
+  editingPostId: '',
 };
 
 const profileInitialState = {
@@ -256,6 +257,7 @@ export default (state = initialState, action) => {
         ...state,
         showComposer: true,
         editMode: action.editMode,
+        editingPostId: action.updateId,
       };
     case actionTypes.HIDE_COMPOSER:
       return {
@@ -327,6 +329,7 @@ export const actions = {
   handleComposerPlaceholderClick: () => ({
     type: actionTypes.OPEN_COMPOSER,
   }),
+  // TODO: rename to more representative name
   handleComposerCreateSuccess: () => ({
     type: actionTypes.HIDE_COMPOSER,
   }),

--- a/packages/queue/reducer.js
+++ b/packages/queue/reducer.js
@@ -4,6 +4,7 @@ import { actionTypes as profileSidebarActionTypes } from '@bufferapp/publish-pro
 export const actionTypes = {
   POST_CREATED: 'POST_CREATED',
   POST_UPDATED: 'POST_UPDATED',
+  // POST_CLICKED_EDIT: 'POST_CLICKED_EDIT',
   POST_CLICKED_DELETE: 'POST_CLICKED_DELETE',
   POST_CONFIRMED_DELETE: 'POST_CONFIRMED_DELETE',
   POST_DELETED: 'POST_DELETED',
@@ -254,11 +255,13 @@ export default (state = initialState, action) => {
       return {
         ...state,
         showComposer: true,
+        editMode: action.editMode,
       };
     case actionTypes.HIDE_COMPOSER:
       return {
         ...state,
         showComposer: false,
+        editMode: false,
       };
     default:
       return state;
@@ -266,6 +269,13 @@ export default (state = initialState, action) => {
 };
 
 export const actions = {
+  handleEditClick: ({ post, profileId }) => ({
+    type: actionTypes.OPEN_COMPOSER,
+    updateId: post.id,
+    editMode: true,
+    post,
+    profileId,
+  }),
   handleDeleteClick: ({ post, profileId }) => ({
     type: actionTypes.POST_CLICKED_DELETE,
     updateId: post.id,

--- a/packages/queue/reducer.test.js
+++ b/packages/queue/reducer.test.js
@@ -10,6 +10,8 @@ describe('reducer', () => {
       enabledApplicationModes: [],
       showComposer: false,
       environment: 'production',
+      editMode: false,
+      editingPostId: '',
     };
     const action = {
       type: 'INIT',
@@ -34,6 +36,8 @@ describe('reducer', () => {
       enabledApplicationModes: [],
       showComposer: false,
       environment: 'production',
+      editMode: false,
+      editingPostId: '',
     };
     const action = {
       profileId,
@@ -63,6 +67,8 @@ describe('reducer', () => {
       enabledApplicationModes: [],
       showComposer: false,
       environment: 'production',
+      editMode: false,
+      editingPostId: '',
     };
     const action = {
       profileId,
@@ -95,6 +101,8 @@ describe('reducer', () => {
       enabledApplicationModes: [],
       showComposer: false,
       environment: 'production',
+      editMode: false,
+      editingPostId: '',
     };
     const action = {
       profileId,
@@ -121,6 +129,8 @@ describe('reducer', () => {
       enabledApplicationModes: [],
       showComposer: false,
       environment: 'production',
+      editMode: false,
+      editingPostId: '',
     };
     const action = {
       type: 'POST_CREATED',
@@ -149,6 +159,8 @@ describe('reducer', () => {
       enabledApplicationModes: [],
       showComposer: false,
       environment: 'production',
+      editMode: false,
+      editingPostId: '',
     };
     const stateAfter = {
       byProfileId: {
@@ -164,6 +176,8 @@ describe('reducer', () => {
       enabledApplicationModes: [],
       showComposer: false,
       environment: 'production',
+      editMode: false,
+      editingPostId: '',
     };
     const action = {
       type: 'POST_UPDATED',

--- a/packages/utils/postParser.js
+++ b/packages/utils/postParser.js
@@ -95,5 +95,7 @@ module.exports = (post) => {
     sent: post.status === 'sent',
     text,
     type: getPostType({ post }),
+    media,
+    subprofile_id: post.subprofile_id,
   };
 };

--- a/packages/utils/postParser.js
+++ b/packages/utils/postParser.js
@@ -96,6 +96,7 @@ module.exports = (post) => {
     text,
     type: getPostType({ post }),
     media,
+    extra_media: post.extra_media,
     subprofile_id: post.subprofile_id,
   };
 };


### PR DESCRIPTION
### Purpose
https://app.getflow.com/organizations/369191/teams/339227/tasks/25406941

- open composer in edit mode when 'Edit' is clicked
- show data of post that was selected for editing
- save post edits

TODO:
- [x] Clear out old edit data when selecting new post to edit (perhaps triggered when props change?)
    - [x] ensure this works for create success as well (handled in `WebDashboardHooks.js` `handleSavedDrafts`)
- [x] position of create composer should be over the input placeholder

- [x] Fix: 
   - [x] on edit save, image that was deleted is not actually deleted.
   - [x] on edit save, duplicate of image being created
   - [x] on successful save composer/overlay should disappear



### Notes
Many thanks to @pioul, who will be tackling the final TODO's listed above while I'm out.
### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
