### PR TITLE
Fix error notifications when 'Share Now' fails

### DIFF
--- a/packages/server/rpc/sharePostNow/index.js
+++ b/packages/server/rpc/sharePostNow/index.js
@@ -4,13 +4,25 @@ const rp = require('request-promise');
 module.exports = method(
   'sharePostNow',
   'share post now',
-  ({ updateId, profileId }, { session }) =>
-    rp({
-      uri: `${process.env.API_ADDR}/1/updates/${updateId}/share.json`,
-      method: 'POST',
-      strictSSL: !(process.env.NODE_ENV === 'development'),
-      qs: {
-        access_token: session.accessToken,
-      },
-    }),
+  async ({ updateId, profileId }, { session }) => {
+    let result;
+    try {
+      result = await rp({
+        uri: `${process.env.API_ADDR}/1/updates/${updateId}/share.json`,
+        method: 'POST',
+        strictSSL: !(process.env.NODE_ENV === 'development'),
+        qs: {
+          access_token: session.accessToken,
+        },
+      });
+    } catch (err) {
+      if (err.error) {
+        const { message } = JSON.parse(err.error);
+        throw new Error(message);
+      }
+      throw err;
+    }
+    result = JSON.parse(result);
+    return Promise.resolve(result);
+  },
 );


### PR DESCRIPTION
### Purpose

This PR massages the error data a bit before passing it to the front end so it can be properly displayed as a notification toast! 🍞 

### Review

@hharnisc I'm wondering how this feels, this is a bit of a pattern now, [similar to how I handled errors in the `composerApiProxy`](https://github.com/bufferapp/buffer-publish/pull/168/files#diff-da43fc2dca049c032da20252e45b8981) and I wonder if we should think a bit more about how errors bubble up. A lot of it's still quite unknown to me, from what I can tell, somewhere along the line the error gets prefixed with the response code ("500 - ", "400 - ") followed by the JSON response from the Buffer API... the prefixed part is key since it makes it unparseable. Happy to chat more/pair if this doesn't make sense.

Oh, and fwiw the debugging support I dropped in #168 was quite helpful here! 👍 

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
