### PR TITLE
Share now success notification ✅ 🗯

### DIFF
--- a/packages/components/Notification/index.jsx
+++ b/packages/components/Notification/index.jsx
@@ -45,7 +45,7 @@ const Notification = ({
     >
       <div
         style={{
-          margin: '1.5rem',
+          margin: '1rem',
         }}
       >
         <NotificationIcon
@@ -55,11 +55,11 @@ const Notification = ({
       <div
         style={{
           flexGrow: 1,
-          margin: '1.5rem 0',
+          margin: '1rem 0',
         }}
       >
         <Text
-          size={'large'}
+          size={'mini'}
         >
           {children}
         </Text>

--- a/packages/components/__snapshots__/snapshot.test.js.snap
+++ b/packages/components/__snapshots__/snapshot.test.js.snap
@@ -20981,7 +20981,7 @@ exports[`Snapshots Notification default 1`] = `
       <div
         style={
           Object {
-            "margin": "1.5rem",
+            "margin": "1rem",
           }
         }
       >
@@ -21013,7 +21013,7 @@ exports[`Snapshots Notification default 1`] = `
         style={
           Object {
             "flexGrow": 1,
-            "margin": "1.5rem 0",
+            "margin": "1rem 0",
           }
         }
       >
@@ -21022,7 +21022,7 @@ exports[`Snapshots Notification default 1`] = `
             Object {
               "color": "#59626a",
               "fontFamily": "\\"Open Sans\\", sans-serif",
-              "fontSize": "1.25rem",
+              "fontSize": "0.9rem",
               "fontWeight": 400,
             }
           }
@@ -21125,7 +21125,7 @@ exports[`Snapshots Notification error 1`] = `
       <div
         style={
           Object {
-            "margin": "1.5rem",
+            "margin": "1rem",
           }
         }
       >
@@ -21157,7 +21157,7 @@ exports[`Snapshots Notification error 1`] = `
         style={
           Object {
             "flexGrow": 1,
-            "margin": "1.5rem 0",
+            "margin": "1rem 0",
           }
         }
       >
@@ -21166,7 +21166,7 @@ exports[`Snapshots Notification error 1`] = `
             Object {
               "color": "#59626a",
               "fontFamily": "\\"Open Sans\\", sans-serif",
-              "fontSize": "1.25rem",
+              "fontSize": "0.9rem",
               "fontWeight": 400,
             }
           }
@@ -21269,7 +21269,7 @@ exports[`Snapshots Notification handle close click 1`] = `
       <div
         style={
           Object {
-            "margin": "1.5rem",
+            "margin": "1rem",
           }
         }
       >
@@ -21301,7 +21301,7 @@ exports[`Snapshots Notification handle close click 1`] = `
         style={
           Object {
             "flexGrow": 1,
-            "margin": "1.5rem 0",
+            "margin": "1rem 0",
           }
         }
       >
@@ -21310,7 +21310,7 @@ exports[`Snapshots Notification handle close click 1`] = `
             Object {
               "color": "#59626a",
               "fontFamily": "\\"Open Sans\\", sans-serif",
-              "fontSize": "1.25rem",
+              "fontSize": "0.9rem",
               "fontWeight": 400,
             }
           }
@@ -21413,7 +21413,7 @@ exports[`Snapshots Notification long text 1`] = `
       <div
         style={
           Object {
-            "margin": "1.5rem",
+            "margin": "1rem",
           }
         }
       >
@@ -21445,7 +21445,7 @@ exports[`Snapshots Notification long text 1`] = `
         style={
           Object {
             "flexGrow": 1,
-            "margin": "1.5rem 0",
+            "margin": "1rem 0",
           }
         }
       >
@@ -21454,7 +21454,7 @@ exports[`Snapshots Notification long text 1`] = `
             Object {
               "color": "#59626a",
               "fontFamily": "\\"Open Sans\\", sans-serif",
-              "fontSize": "1.25rem",
+              "fontSize": "0.9rem",
               "fontWeight": 400,
             }
           }

--- a/packages/notifications/__snapshots__/snapshot.test.js.snap
+++ b/packages/notifications/__snapshots__/snapshot.test.js.snap
@@ -91,7 +91,7 @@ exports[`Snapshots Notifications 1 notification 1`] = `
             <div
               style={
                 Object {
-                  "margin": "1.5rem",
+                  "margin": "1rem",
                 }
               }
             >
@@ -123,7 +123,7 @@ exports[`Snapshots Notifications 1 notification 1`] = `
               style={
                 Object {
                   "flexGrow": 1,
-                  "margin": "1.5rem 0",
+                  "margin": "1rem 0",
                 }
               }
             >
@@ -132,7 +132,7 @@ exports[`Snapshots Notifications 1 notification 1`] = `
                   Object {
                     "color": "#59626a",
                     "fontFamily": "\\"Open Sans\\", sans-serif",
-                    "fontSize": "1.25rem",
+                    "fontSize": "0.9rem",
                     "fontWeight": 400,
                   }
                 }
@@ -267,7 +267,7 @@ exports[`Snapshots Notifications default 1`] = `
             <div
               style={
                 Object {
-                  "margin": "1.5rem",
+                  "margin": "1rem",
                 }
               }
             >
@@ -299,7 +299,7 @@ exports[`Snapshots Notifications default 1`] = `
               style={
                 Object {
                   "flexGrow": 1,
-                  "margin": "1.5rem 0",
+                  "margin": "1rem 0",
                 }
               }
             >
@@ -308,7 +308,7 @@ exports[`Snapshots Notifications default 1`] = `
                   Object {
                     "color": "#59626a",
                     "fontFamily": "\\"Open Sans\\", sans-serif",
-                    "fontSize": "1.25rem",
+                    "fontSize": "0.9rem",
                     "fontWeight": 400,
                   }
                 }
@@ -416,7 +416,7 @@ exports[`Snapshots Notifications default 1`] = `
             <div
               style={
                 Object {
-                  "margin": "1.5rem",
+                  "margin": "1rem",
                 }
               }
             >
@@ -448,7 +448,7 @@ exports[`Snapshots Notifications default 1`] = `
               style={
                 Object {
                   "flexGrow": 1,
-                  "margin": "1.5rem 0",
+                  "margin": "1rem 0",
                 }
               }
             >
@@ -457,7 +457,7 @@ exports[`Snapshots Notifications default 1`] = `
                   Object {
                     "color": "#59626a",
                     "fontFamily": "\\"Open Sans\\", sans-serif",
-                    "fontSize": "1.25rem",
+                    "fontSize": "0.9rem",
                     "fontWeight": 400,
                   }
                 }

--- a/packages/queue/middleware.js
+++ b/packages/queue/middleware.js
@@ -46,6 +46,12 @@ export default ({ dispatch, getState }) => next => (action) => {
         },
       }));
       break;
+    case `sharePostNow_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      dispatch(notificationActions.createNotification({
+        notificationType: 'success',
+        message: 'Yay, your post has been shared! 🎉',
+      }));
+      break;
     case `sharePostNow_${dataFetchActionTypes.FETCH_FAIL}`:
       dispatch(notificationActions.createNotification({
         notificationType: 'error',


### PR DESCRIPTION
### Purpose

Show a success notification when your posts are successfully 'Share Now'd.

Also includes some minor tweaks to the design of the notifications; adjusted spacing and font size to [better match the mockups](https://buffer.wake.com/set/3/31)

cc @hharnisc Wake made the notification look bigger because of the @2x source image.