### PR TITLE
Import schedule-related data for posts

### DIFF
--- a/packages/queue/components/ComposerWrapper/index.jsx
+++ b/packages/queue/components/ComposerWrapper/index.jsx
@@ -34,6 +34,9 @@ const ComposerWrapper = ({
     updateId: post ? post.id : undefined,
     update: { ...post, images: post.imageUrls },
     subprofileId: post ? post.subprofile_id : undefined,
+    due_at: post ? post.due_at : undefined,
+    scheduled_at: post ? post.scheduled_at : undefined,
+    pinned: post ? post.pinned : undefined,
   };
   const formattedData = formatInputData({
     env: metaData.application,

--- a/packages/utils/postParser.js
+++ b/packages/utils/postParser.js
@@ -109,5 +109,8 @@ module.exports = (post) => {
     media,
     extra_media: post.extra_media,
     subprofile_id: post.subprofile_id,
+    due_at: post.due_at,
+    scheduled_at: post.scheduled_at,
+    pinned: post.pinned,
   };
 };


### PR DESCRIPTION
### Purpose

Import a few schedule-related pieces of data for MC to display them and allow their editing.

![image](https://user-images.githubusercontent.com/2307365/31036819-f179d4c8-a53b-11e7-9e5f-0d7714328537.png)

Flow: https://app.getflow.com/organizations/369191/teams/339227/tasks/25406941#activities/83949742

### Notes

Publish doesn't support custom-time updates or pinned updates yet (i.e. there are no empty slots to click on, no calendar, etc), but by tweaking the MC store I was able to save pinned and custom-timed updates anyway, so those three pieces of data should be future-proof whenever such functionality lands in Publish

### Review

Hey @alvarezmelissa87, should be a quick one to review 😄 

Two things to note:

- I tested those changes with the main field (`due_at`), it was working great, and then added the two others but for some reason my dev env is broken in a new way now – I'm confident they work too though, there's nothing crazy about those changes :)
- I needed to rebuild publish for those changes to reflect on my machine. Not sure why, mentioning this in case you need to do that too.

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
