### PR TITLE
Add front-end performance tracking

### DIFF
--- a/packages/composer/package-lock.json
+++ b/packages/composer/package-lock.json
@@ -1,0 +1,7594 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@storybook/react": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.1.7.tgz",
+			"integrity": "sha512-Km+vw2Y1L1+zFfVooZs1XMl1RqXp/c5Dut57Ln07TDEALrLOtqsjDqrK3pSHFQAqXb/N3lrkb1JMeQkf/Wg5Fw==",
+			"requires": {
+				"@storybook/addon-actions": "3.2.12",
+				"@storybook/addon-links": "3.2.12",
+				"@storybook/addons": "3.2.12",
+				"@storybook/channel-postmessage": "3.2.12",
+				"@storybook/ui": "3.2.12",
+				"airbnb-js-shims": "1.3.0",
+				"autoprefixer": "7.1.5",
+				"babel-core": "6.26.0",
+				"babel-loader": "7.1.2",
+				"babel-plugin-react-docgen": "1.8.1",
+				"babel-preset-es2015": "6.24.1",
+				"babel-preset-es2016": "6.24.1",
+				"babel-preset-react": "6.24.1",
+				"babel-preset-react-app": "3.0.3",
+				"babel-preset-stage-0": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"case-sensitive-paths-webpack-plugin": "2.1.1",
+				"chalk": "1.1.3",
+				"commander": "2.11.0",
+				"common-tags": "1.4.0",
+				"configstore": "3.1.1",
+				"css-loader": "0.28.7",
+				"express": "4.16.2",
+				"file-loader": "0.11.2",
+				"find-cache-dir": "1.0.0",
+				"glamor": "2.20.40",
+				"glamorous": "3.25.0",
+				"global": "4.3.2",
+				"json-loader": "0.5.7",
+				"json-stringify-safe": "5.0.1",
+				"json5": "0.5.1",
+				"lodash.pick": "4.4.0",
+				"postcss-flexbugs-fixes": "3.2.0",
+				"postcss-loader": "2.0.8",
+				"prop-types": "15.6.0",
+				"qs": "6.5.1",
+				"react-modal": "1.9.7",
+				"redux": "3.7.2",
+				"request": "2.83.0",
+				"serve-favicon": "2.4.5",
+				"shelljs": "0.7.8",
+				"style-loader": "0.17.0",
+				"url-loader": "0.5.9",
+				"util-deprecate": "1.0.2",
+				"uuid": "3.1.0",
+				"webpack": "2.7.0",
+				"webpack-dev-middleware": "1.12.0",
+				"webpack-hot-middleware": "2.20.0"
+			},
+			"dependencies": {
+				"@hypnosphi/fuse.js": {
+					"version": "3.0.9",
+					"resolved": "https://registry.npmjs.org/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz",
+					"integrity": "sha1-6pn2EhtKjwZbTHH4VZXbJxRJiAc="
+				},
+				"@storybook/addon-actions": {
+					"version": "3.2.12",
+					"resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.2.12.tgz",
+					"integrity": "sha512-or4PAzYD2aUQ7E52zZkB97S96r7YUh15ZiLJesMYoJPs44gNFTCuvThO63yvV5IslD0v8gINgS9muOE0aEI+gg==",
+					"requires": {
+						"@storybook/addons": "3.2.12",
+						"deep-equal": "1.0.1",
+						"json-stringify-safe": "5.0.1",
+						"prop-types": "15.6.0",
+						"react-inspector": "2.2.0",
+						"uuid": "3.1.0"
+					}
+				},
+				"@storybook/addon-links": {
+					"version": "3.2.12",
+					"resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.2.12.tgz",
+					"integrity": "sha512-8cv5Pcoersdbp3QrYnzp+vXpCut4EIWEVoqkJUDosC4r+qT36nnq3l+Ot7ic9R4f87CdPM/Wjt2qzgTpamoSvA==",
+					"requires": {
+						"@storybook/addons": "3.2.12"
+					}
+				},
+				"@storybook/addons": {
+					"version": "3.2.12",
+					"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.2.12.tgz",
+					"integrity": "sha512-gbbW68MWfDxsht9v9V/rqx6aVZUBw6akwyv45T5+lM23Sy7GfoOQ0jR7eRl+DM4KmA/74P/rIZRu0mznT9IfCg=="
+				},
+				"@storybook/channel-postmessage": {
+					"version": "3.2.12",
+					"resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.2.12.tgz",
+					"integrity": "sha512-IjSI7Mjf/u+Msf8Jm+zlYlTuzYxj2yvcQV/rFkm7fkhmv2UAZTsb5B8Mi3KKN7Lr9d5eRumLCtUBkzkBOcSzSg==",
+					"requires": {
+						"@storybook/channels": "3.2.12",
+						"global": "4.3.2",
+						"json-stringify-safe": "5.0.1"
+					}
+				},
+				"@storybook/channels": {
+					"version": "3.2.12",
+					"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.2.12.tgz",
+					"integrity": "sha512-smexrg30+mlXIsS/z/0CN+a3Tn/DePZETnu3G42r8Qdm7PbdRo1oC2pcHAEmIjaukRp5qK+txuDJ6WdOvyVsMw=="
+				},
+				"@storybook/components": {
+					"version": "3.2.12",
+					"resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.2.12.tgz",
+					"integrity": "sha512-vMVrPmXKP7Rh3JfHfN7dAf+MJkjyl0iaU4TePsSZD3esqpkr24H+yw0HiLKBsINPJvFlEGLfDT73urXcb4oPQQ==",
+					"requires": {
+						"glamor": "2.20.40",
+						"glamorous": "4.9.7",
+						"prop-types": "15.6.0"
+					},
+					"dependencies": {
+						"glamorous": {
+							"version": "4.9.7",
+							"resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.9.7.tgz",
+							"integrity": "sha512-4Ts/k1fCvRez1k6xYIuXQqFmVG1RjbpQZOHNCWSteY1Tza4YeyExkj4SypAhCspcAzkjvqaUboaLmSfMmx9uLQ==",
+							"requires": {
+								"brcast": "3.0.1",
+								"fast-memoize": "2.2.8",
+								"html-tag-names": "1.1.2",
+								"is-function": "1.0.1",
+								"is-plain-object": "2.0.4",
+								"react-html-attributes": "1.4.1",
+								"svg-tag-names": "1.1.1"
+							}
+						}
+					}
+				},
+				"@storybook/react-fuzzy": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/@storybook/react-fuzzy/-/react-fuzzy-0.4.1.tgz",
+					"integrity": "sha512-UCV8HZ3rzEpn36Tn+Ip0ZqcwQjphIcxmnWDF7MgjBJkCPlSahSzALhS9EH6WLBeCDzajoDynAAUhwqC1EPkhkA==",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"classnames": "2.2.5",
+						"fuse.js": "3.2.0",
+						"prop-types": "15.6.0"
+					}
+				},
+				"@storybook/ui": {
+					"version": "3.2.12",
+					"resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.12.tgz",
+					"integrity": "sha512-g7O+YO92qJiWqgSp1U1q4sSgiobNxRBSWCrlYmRfHAUzEzD4cgYDnlldFWWUvR4zCEOCIG/MbJKtqG4727srNg==",
+					"requires": {
+						"@hypnosphi/fuse.js": "3.0.9",
+						"@storybook/components": "3.2.12",
+						"@storybook/react-fuzzy": "0.4.1",
+						"babel-runtime": "6.26.0",
+						"deep-equal": "1.0.1",
+						"events": "1.1.1",
+						"global": "4.3.2",
+						"json-stringify-safe": "5.0.1",
+						"keycode": "2.1.9",
+						"lodash.debounce": "4.0.8",
+						"lodash.pick": "4.4.0",
+						"lodash.sortby": "4.7.0",
+						"mantra-core": "1.7.0",
+						"podda": "1.2.2",
+						"prop-types": "15.6.0",
+						"qs": "6.5.1",
+						"react-icons": "2.2.7",
+						"react-inspector": "2.2.0",
+						"react-komposer": "2.0.0",
+						"react-modal": "2.4.1",
+						"react-split-pane": "0.1.66",
+						"react-treebeard": "2.0.3",
+						"redux": "3.7.2"
+					},
+					"dependencies": {
+						"react-modal": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-2.4.1.tgz",
+							"integrity": "sha512-3WQCn3xqkbEUvxRUO3nkeqxMNgt1F4CyEU3BiUIrg7C71tnqjQIuSE7+JXp85yFl8X1iRTJouySNpwNqv4kiWg==",
+							"requires": {
+								"exenv": "1.2.2",
+								"prop-types": "15.6.0"
+							}
+						}
+					}
+				},
+				"accepts": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+					"integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+					"requires": {
+						"mime-types": "2.1.17",
+						"negotiator": "0.6.1"
+					}
+				},
+				"acorn": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+					"integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+				},
+				"acorn-dynamic-import": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+					"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+					"requires": {
+						"acorn": "4.0.13"
+					},
+					"dependencies": {
+						"acorn": {
+							"version": "4.0.13",
+							"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+							"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+						}
+					}
+				},
+				"airbnb-js-shims": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-1.3.0.tgz",
+					"integrity": "sha512-Y/9jgf3uEdNyeWPUV1N49FowM/qMIiKSTkRUpYT4jpHkSADfTiRVwI8Mm6o4CIxhnBK1uMf4RIYNYKwwILMCAQ==",
+					"requires": {
+						"array-includes": "3.0.3",
+						"es5-shim": "4.5.9",
+						"es6-shim": "0.35.3",
+						"function.prototype.name": "1.0.3",
+						"object.entries": "1.0.4",
+						"object.getownpropertydescriptors": "2.0.3",
+						"object.values": "1.0.4",
+						"promise.prototype.finally": "3.0.1",
+						"string.prototype.padend": "3.0.0",
+						"string.prototype.padstart": "3.0.0"
+					}
+				},
+				"ajv": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+					"integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+					"requires": {
+						"co": "4.6.0",
+						"fast-deep-equal": "1.0.0",
+						"json-schema-traverse": "0.3.1",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ajv-keywords": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+				},
+				"align-text": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+					"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+					"requires": {
+						"kind-of": "3.2.2",
+						"longest": "1.0.1",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"alphanum-sort": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+					"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
+				},
+				"ansi-html": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+					"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"anymatch": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+					"requires": {
+						"micromatch": "2.3.11",
+						"normalize-path": "2.1.1"
+					}
+				},
+				"argparse": {
+					"version": "1.0.9",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+					"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+					"requires": {
+						"sprintf-js": "1.0.3"
+					}
+				},
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "1.1.0"
+					}
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+					"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+				},
+				"array-find": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+					"integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg="
+				},
+				"array-flatten": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+				},
+				"array-includes": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+					"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+					"requires": {
+						"define-properties": "1.1.2",
+						"es-abstract": "1.9.0"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
+				"asap": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+				},
+				"asn1.js": {
+					"version": "4.9.1",
+					"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+					"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+					"requires": {
+						"bn.js": "4.11.8",
+						"inherits": "2.0.3",
+						"minimalistic-assert": "1.0.0"
+					}
+				},
+				"assert": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+					"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+					"requires": {
+						"util": "0.10.3"
+					}
+				},
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				},
+				"ast-types": {
+					"version": "0.9.12",
+					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.12.tgz",
+					"integrity": "sha1-sTYwDWcCZiWuFTJpgsqZGOXbc8k="
+				},
+				"async": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+					"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+					"requires": {
+						"lodash": "4.17.4"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						}
+					}
+				},
+				"async-each": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+					"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+				},
+				"autoprefixer": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.5.tgz",
+					"integrity": "sha512-sMN453qIm8Z+tunzYWW+Y490wWkICHhCYm/VohLjjl+N7ARSFuF5au7E6tr7oEbeeXj8mNjpSw2kxjJaO6YCOw==",
+					"requires": {
+						"browserslist": "2.5.1",
+						"caniuse-lite": "1.0.30000748",
+						"normalize-range": "0.1.2",
+						"num2fraction": "1.2.2",
+						"postcss": "6.0.13",
+						"postcss-value-parser": "3.3.0"
+					}
+				},
+				"aws-sign2": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+				},
+				"babel-code-frame": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+					"requires": {
+						"chalk": "1.1.3",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"babel-core": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+					"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+					"requires": {
+						"babel-code-frame": "6.26.0",
+						"babel-generator": "6.26.0",
+						"babel-helpers": "6.24.1",
+						"babel-messages": "6.23.0",
+						"babel-register": "6.26.0",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"convert-source-map": "1.5.0",
+						"debug": "2.6.9",
+						"json5": "0.5.1",
+						"lodash": "4.17.4",
+						"minimatch": "3.0.4",
+						"path-is-absolute": "1.0.1",
+						"private": "0.1.8",
+						"slash": "1.0.0",
+						"source-map": "0.5.7"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						}
+					}
+				},
+				"babel-generator": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+					"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+					"requires": {
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"detect-indent": "4.0.0",
+						"jsesc": "1.3.0",
+						"lodash": "4.17.4",
+						"source-map": "0.5.7",
+						"trim-right": "1.0.1"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						}
+					}
+				},
+				"babel-helper-bindify-decorators": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
+					"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-helper-builder-binary-assignment-operator-visitor": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+					"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+					"requires": {
+						"babel-helper-explode-assignable-expression": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-helper-builder-react-jsx": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
+					"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"esutils": "2.0.2"
+					}
+				},
+				"babel-helper-call-delegate": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+					"requires": {
+						"babel-helper-hoist-variables": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-helper-define-map": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+					"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+					"requires": {
+						"babel-helper-function-name": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"lodash": "4.17.4"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						}
+					}
+				},
+				"babel-helper-explode-assignable-expression": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+					"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-helper-explode-class": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
+					"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+					"requires": {
+						"babel-helper-bindify-decorators": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-helper-function-name": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+					"requires": {
+						"babel-helper-get-function-arity": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-helper-get-function-arity": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-helper-hoist-variables": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-helper-optimise-call-expression": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-helper-regex": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+					"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"lodash": "4.17.4"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						}
+					}
+				},
+				"babel-helper-remap-async-to-generator": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+					"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+					"requires": {
+						"babel-helper-function-name": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-helper-replace-supers": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+					"requires": {
+						"babel-helper-optimise-call-expression": "6.24.1",
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-helpers": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0"
+					}
+				},
+				"babel-loader": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
+					"integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
+					"requires": {
+						"find-cache-dir": "1.0.0",
+						"loader-utils": "1.1.0",
+						"mkdirp": "0.5.1"
+					}
+				},
+				"babel-messages": {
+					"version": "6.23.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-check-es2015-constants": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-dynamic-import-node": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.0.2.tgz",
+					"integrity": "sha1-rbW8j0iokxFUA5WunwzD7UsQuy4=",
+					"requires": {
+						"babel-plugin-syntax-dynamic-import": "6.18.0",
+						"babel-template": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-plugin-react-docgen": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.8.1.tgz",
+					"integrity": "sha512-11Yxwk8/iEULr+n5DG0BxXD6j/9htpiiR0/hLfi/gtEAK/d6NCNkyKFrC8loQcyMvF3hehPo30SKXG/itSX+hw==",
+					"requires": {
+						"babel-types": "6.26.0",
+						"lodash": "4.17.4",
+						"react-docgen": "2.19.0"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						}
+					}
+				},
+				"babel-plugin-syntax-async-functions": {
+					"version": "6.13.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+					"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+				},
+				"babel-plugin-syntax-async-generators": {
+					"version": "6.13.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+					"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+				},
+				"babel-plugin-syntax-class-constructor-call": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+					"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
+				},
+				"babel-plugin-syntax-class-properties": {
+					"version": "6.13.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+					"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+				},
+				"babel-plugin-syntax-decorators": {
+					"version": "6.13.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+					"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
+				},
+				"babel-plugin-syntax-do-expressions": {
+					"version": "6.13.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
+					"integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0="
+				},
+				"babel-plugin-syntax-dynamic-import": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+					"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+				},
+				"babel-plugin-syntax-exponentiation-operator": {
+					"version": "6.13.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+					"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+				},
+				"babel-plugin-syntax-export-extensions": {
+					"version": "6.13.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+					"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
+				},
+				"babel-plugin-syntax-flow": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+					"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+				},
+				"babel-plugin-syntax-function-bind": {
+					"version": "6.13.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
+					"integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y="
+				},
+				"babel-plugin-syntax-jsx": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+					"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+				},
+				"babel-plugin-syntax-object-rest-spread": {
+					"version": "6.13.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+					"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+				},
+				"babel-plugin-syntax-trailing-function-commas": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+					"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+				},
+				"babel-plugin-transform-async-generator-functions": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+					"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+					"requires": {
+						"babel-helper-remap-async-to-generator": "6.24.1",
+						"babel-plugin-syntax-async-generators": "6.13.0",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-async-to-generator": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+					"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+					"requires": {
+						"babel-helper-remap-async-to-generator": "6.24.1",
+						"babel-plugin-syntax-async-functions": "6.13.0",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-class-constructor-call": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
+					"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+					"requires": {
+						"babel-plugin-syntax-class-constructor-call": "6.18.0",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-class-properties": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+					"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+					"requires": {
+						"babel-helper-function-name": "6.24.1",
+						"babel-plugin-syntax-class-properties": "6.13.0",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-decorators": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
+					"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+					"requires": {
+						"babel-helper-explode-class": "6.24.1",
+						"babel-plugin-syntax-decorators": "6.13.0",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-do-expressions": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
+					"integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
+					"requires": {
+						"babel-plugin-syntax-do-expressions": "6.13.0",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-arrow-functions": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-block-scoped-functions": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-block-scoping": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+					"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"lodash": "4.17.4"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						}
+					}
+				},
+				"babel-plugin-transform-es2015-classes": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+					"requires": {
+						"babel-helper-define-map": "6.26.0",
+						"babel-helper-function-name": "6.24.1",
+						"babel-helper-optimise-call-expression": "6.24.1",
+						"babel-helper-replace-supers": "6.24.1",
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-computed-properties": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-destructuring": {
+					"version": "6.23.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-duplicate-keys": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-for-of": {
+					"version": "6.23.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-function-name": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+					"requires": {
+						"babel-helper-function-name": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-literals": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-modules-amd": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+					"requires": {
+						"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-modules-commonjs": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+					"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+					"requires": {
+						"babel-plugin-transform-strict-mode": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-modules-systemjs": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+					"requires": {
+						"babel-helper-hoist-variables": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-modules-umd": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+					"requires": {
+						"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-object-super": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+					"requires": {
+						"babel-helper-replace-supers": "6.24.1",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-parameters": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+					"requires": {
+						"babel-helper-call-delegate": "6.24.1",
+						"babel-helper-get-function-arity": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-shorthand-properties": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-spread": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-sticky-regex": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+					"requires": {
+						"babel-helper-regex": "6.26.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-template-literals": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-typeof-symbol": {
+					"version": "6.23.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-es2015-unicode-regex": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+					"requires": {
+						"babel-helper-regex": "6.26.0",
+						"babel-runtime": "6.26.0",
+						"regexpu-core": "2.0.0"
+					}
+				},
+				"babel-plugin-transform-exponentiation-operator": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+					"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+					"requires": {
+						"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+						"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-export-extensions": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
+					"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+					"requires": {
+						"babel-plugin-syntax-export-extensions": "6.13.0",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-flow-strip-types": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+					"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+					"requires": {
+						"babel-plugin-syntax-flow": "6.18.0",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-function-bind": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
+					"integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
+					"requires": {
+						"babel-plugin-syntax-function-bind": "6.13.0",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-object-rest-spread": {
+					"version": "6.23.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
+					"integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+					"requires": {
+						"babel-plugin-syntax-object-rest-spread": "6.13.0",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-react-constant-elements": {
+					"version": "6.23.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.23.0.tgz",
+					"integrity": "sha1-LxGb9NLN1F65uqrldAU8YE9hR90=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-react-display-name": {
+					"version": "6.25.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+					"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-react-jsx": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
+					"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+					"requires": {
+						"babel-helper-builder-react-jsx": "6.26.0",
+						"babel-plugin-syntax-jsx": "6.18.0",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-react-jsx-self": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+					"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+					"requires": {
+						"babel-plugin-syntax-jsx": "6.18.0",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-react-jsx-source": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+					"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+					"requires": {
+						"babel-plugin-syntax-jsx": "6.18.0",
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-regenerator": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+					"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+					"requires": {
+						"regenerator-transform": "0.10.1"
+					}
+				},
+				"babel-plugin-transform-runtime": {
+					"version": "6.23.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+					"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-plugin-transform-strict-mode": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"babel-preset-env": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.5.2.tgz",
+					"integrity": "sha1-zUrpCm6Utwn5c3SzPl+LmDVWre8=",
+					"requires": {
+						"babel-plugin-check-es2015-constants": "6.22.0",
+						"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+						"babel-plugin-transform-async-to-generator": "6.24.1",
+						"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+						"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+						"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+						"babel-plugin-transform-es2015-classes": "6.24.1",
+						"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+						"babel-plugin-transform-es2015-destructuring": "6.23.0",
+						"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+						"babel-plugin-transform-es2015-for-of": "6.23.0",
+						"babel-plugin-transform-es2015-function-name": "6.24.1",
+						"babel-plugin-transform-es2015-literals": "6.22.0",
+						"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+						"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+						"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+						"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+						"babel-plugin-transform-es2015-object-super": "6.24.1",
+						"babel-plugin-transform-es2015-parameters": "6.24.1",
+						"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+						"babel-plugin-transform-es2015-spread": "6.22.0",
+						"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+						"babel-plugin-transform-es2015-template-literals": "6.22.0",
+						"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+						"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+						"babel-plugin-transform-exponentiation-operator": "6.24.1",
+						"babel-plugin-transform-regenerator": "6.26.0",
+						"browserslist": "2.5.1",
+						"invariant": "2.2.2",
+						"semver": "5.4.1"
+					}
+				},
+				"babel-preset-es2015": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+					"requires": {
+						"babel-plugin-check-es2015-constants": "6.22.0",
+						"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+						"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+						"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+						"babel-plugin-transform-es2015-classes": "6.24.1",
+						"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+						"babel-plugin-transform-es2015-destructuring": "6.23.0",
+						"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+						"babel-plugin-transform-es2015-for-of": "6.23.0",
+						"babel-plugin-transform-es2015-function-name": "6.24.1",
+						"babel-plugin-transform-es2015-literals": "6.22.0",
+						"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+						"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+						"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+						"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+						"babel-plugin-transform-es2015-object-super": "6.24.1",
+						"babel-plugin-transform-es2015-parameters": "6.24.1",
+						"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+						"babel-plugin-transform-es2015-spread": "6.22.0",
+						"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+						"babel-plugin-transform-es2015-template-literals": "6.22.0",
+						"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+						"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+						"babel-plugin-transform-regenerator": "6.26.0"
+					}
+				},
+				"babel-preset-es2016": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-preset-es2016/-/babel-preset-es2016-6.24.1.tgz",
+					"integrity": "sha1-+QC/k+LrwNJ235uKtZck6/2Vn4s=",
+					"requires": {
+						"babel-plugin-transform-exponentiation-operator": "6.24.1"
+					}
+				},
+				"babel-preset-flow": {
+					"version": "6.23.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
+					"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+					"requires": {
+						"babel-plugin-transform-flow-strip-types": "6.22.0"
+					}
+				},
+				"babel-preset-react": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
+					"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+					"requires": {
+						"babel-plugin-syntax-jsx": "6.18.0",
+						"babel-plugin-transform-react-display-name": "6.25.0",
+						"babel-plugin-transform-react-jsx": "6.24.1",
+						"babel-plugin-transform-react-jsx-self": "6.22.0",
+						"babel-plugin-transform-react-jsx-source": "6.22.0",
+						"babel-preset-flow": "6.23.0"
+					}
+				},
+				"babel-preset-react-app": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-3.0.3.tgz",
+					"integrity": "sha512-hK1hPq8xOFxmnNwpsOcQ2wSRAQwNBhDqsMV75gyKYQ7Z39KmTRpMN2Jx6Wp0Mberqd2QEWsUqd9ccP2jfd4z2Q==",
+					"requires": {
+						"babel-plugin-dynamic-import-node": "1.0.2",
+						"babel-plugin-syntax-dynamic-import": "6.18.0",
+						"babel-plugin-transform-class-properties": "6.24.1",
+						"babel-plugin-transform-object-rest-spread": "6.23.0",
+						"babel-plugin-transform-react-constant-elements": "6.23.0",
+						"babel-plugin-transform-react-jsx": "6.24.1",
+						"babel-plugin-transform-react-jsx-self": "6.22.0",
+						"babel-plugin-transform-react-jsx-source": "6.22.0",
+						"babel-plugin-transform-regenerator": "6.24.1",
+						"babel-plugin-transform-runtime": "6.23.0",
+						"babel-preset-env": "1.5.2",
+						"babel-preset-react": "6.24.1"
+					},
+					"dependencies": {
+						"babel-plugin-transform-regenerator": {
+							"version": "6.24.1",
+							"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+							"integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+							"requires": {
+								"regenerator-transform": "0.9.11"
+							}
+						},
+						"regenerator-transform": {
+							"version": "0.9.11",
+							"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+							"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+							"requires": {
+								"babel-runtime": "6.26.0",
+								"babel-types": "6.26.0",
+								"private": "0.1.8"
+							}
+						}
+					}
+				},
+				"babel-preset-stage-0": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
+					"integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
+					"requires": {
+						"babel-plugin-transform-do-expressions": "6.22.0",
+						"babel-plugin-transform-function-bind": "6.22.0",
+						"babel-preset-stage-1": "6.24.1"
+					}
+				},
+				"babel-preset-stage-1": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
+					"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+					"requires": {
+						"babel-plugin-transform-class-constructor-call": "6.24.1",
+						"babel-plugin-transform-export-extensions": "6.22.0",
+						"babel-preset-stage-2": "6.24.1"
+					}
+				},
+				"babel-preset-stage-2": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
+					"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+					"requires": {
+						"babel-plugin-syntax-dynamic-import": "6.18.0",
+						"babel-plugin-transform-class-properties": "6.24.1",
+						"babel-plugin-transform-decorators": "6.24.1",
+						"babel-preset-stage-3": "6.24.1"
+					}
+				},
+				"babel-preset-stage-3": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
+					"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+					"requires": {
+						"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+						"babel-plugin-transform-async-generator-functions": "6.24.1",
+						"babel-plugin-transform-async-to-generator": "6.24.1",
+						"babel-plugin-transform-exponentiation-operator": "6.24.1",
+						"babel-plugin-transform-object-rest-spread": "6.23.0"
+					}
+				},
+				"babel-register": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+					"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+					"requires": {
+						"babel-core": "6.26.0",
+						"babel-runtime": "6.26.0",
+						"core-js": "2.5.1",
+						"home-or-tmp": "2.0.0",
+						"lodash": "4.17.4",
+						"mkdirp": "0.5.1",
+						"source-map-support": "0.4.18"
+					},
+					"dependencies": {
+						"core-js": {
+							"version": "2.5.1",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+							"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+						},
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						}
+					}
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+					"requires": {
+						"core-js": "2.5.1",
+						"regenerator-runtime": "0.11.0"
+					},
+					"dependencies": {
+						"core-js": {
+							"version": "2.5.1",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+							"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+						}
+					}
+				},
+				"babel-template": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+					"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"lodash": "4.17.4"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						}
+					}
+				},
+				"babel-traverse": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+					"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+					"requires": {
+						"babel-code-frame": "6.26.0",
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"debug": "2.6.9",
+						"globals": "9.18.0",
+						"invariant": "2.2.2",
+						"lodash": "4.17.4"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						}
+					}
+				},
+				"babel-types": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "1.0.3"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						}
+					}
+				},
+				"babylon": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+				},
+				"base64-js": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+					"integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"big.js": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+					"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+				},
+				"binary-extensions": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+					"integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
+				},
+				"bn.js": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+				},
+				"body-parser": {
+					"version": "1.18.2",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+					"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+					"requires": {
+						"bytes": "3.0.0",
+						"content-type": "1.0.4",
+						"debug": "2.6.9",
+						"depd": "1.1.1",
+						"http-errors": "1.6.2",
+						"iconv-lite": "0.4.19",
+						"on-finished": "2.3.0",
+						"qs": "6.5.1",
+						"raw-body": "2.3.2",
+						"type-is": "1.6.15"
+					}
+				},
+				"boom": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+					"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+					"requires": {
+						"hoek": "4.2.0"
+					}
+				},
+				"bowser": {
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/bowser/-/bowser-1.8.0.tgz",
+					"integrity": "sha512-ARpB9VfvItCA47oBk9tVA/L93fU83Q2YwE1yTjhCyr1tu6Zw74mDHdpXNWutl5/tFGYhgCOfBH83WJY4RBGA3A=="
+				},
+				"brace-expansion": {
+					"version": "1.1.8",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+					"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+					"requires": {
+						"balanced-match": "1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
+					}
+				},
+				"brcast": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
+					"integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg=="
+				},
+				"brorand": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+					"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+				},
+				"browserify-aes": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+					"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+					"requires": {
+						"buffer-xor": "1.0.3",
+						"cipher-base": "1.0.4",
+						"create-hash": "1.1.3",
+						"evp_bytestokey": "1.0.3",
+						"inherits": "2.0.3",
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"browserify-cipher": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+					"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+					"requires": {
+						"browserify-aes": "1.1.1",
+						"browserify-des": "1.0.0",
+						"evp_bytestokey": "1.0.3"
+					}
+				},
+				"browserify-des": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+					"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+					"requires": {
+						"cipher-base": "1.0.4",
+						"des.js": "1.0.0",
+						"inherits": "2.0.3"
+					}
+				},
+				"browserify-rsa": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+					"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+					"requires": {
+						"bn.js": "4.11.8",
+						"randombytes": "2.0.5"
+					}
+				},
+				"browserify-sign": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+					"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+					"requires": {
+						"bn.js": "4.11.8",
+						"browserify-rsa": "4.0.1",
+						"create-hash": "1.1.3",
+						"create-hmac": "1.1.6",
+						"elliptic": "6.4.0",
+						"inherits": "2.0.3",
+						"parse-asn1": "5.1.0"
+					}
+				},
+				"browserify-zlib": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+					"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+					"requires": {
+						"pako": "0.2.9"
+					}
+				},
+				"browserslist": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.5.1.tgz",
+					"integrity": "sha512-jAvM2ku7YDJ+leAq3bFH1DE0Ylw+F+EQDq4GkqZfgPEqpWYw9ofQH85uKSB9r3Tv7XDbfqVtE+sdvKJW7IlPJA==",
+					"requires": {
+						"caniuse-lite": "1.0.30000748",
+						"electron-to-chromium": "1.3.26"
+					}
+				},
+				"buffer": {
+					"version": "4.9.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+					"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+					"requires": {
+						"base64-js": "1.2.1",
+						"ieee754": "1.1.8",
+						"isarray": "1.0.0"
+					}
+				},
+				"buffer-xor": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+					"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+				},
+				"builtin-status-codes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+					"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+				},
+				"bytes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+				},
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+				},
+				"caniuse-api": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+					"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+					"requires": {
+						"browserslist": "1.7.7",
+						"caniuse-db": "1.0.30000748",
+						"lodash.memoize": "4.1.2",
+						"lodash.uniq": "4.5.0"
+					},
+					"dependencies": {
+						"browserslist": {
+							"version": "1.7.7",
+							"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+							"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+							"requires": {
+								"caniuse-db": "1.0.30000748",
+								"electron-to-chromium": "1.3.26"
+							}
+						}
+					}
+				},
+				"caniuse-db": {
+					"version": "1.0.30000748",
+					"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000748.tgz",
+					"integrity": "sha1-eF2e381kW/eVxv887TPEXVgMSKA="
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000748",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000748.tgz",
+					"integrity": "sha1-RMjW2lKtZaXXudyk7+vQvdmCugk="
+				},
+				"case-sensitive-paths-webpack-plugin": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.1.tgz",
+					"integrity": "sha1-PSnO2MHxJL9vU4Rvs/WJRzH9yQk="
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+				},
+				"center-align": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+					"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+					"requires": {
+						"align-text": "0.1.4",
+						"lazy-cache": "1.0.4"
+					}
+				},
+				"chain-function": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
+					"integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "2.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+							"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+						},
+						"supports-color": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+						}
+					}
+				},
+				"chokidar": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+					"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+					"requires": {
+						"anymatch": "1.3.2",
+						"async-each": "1.0.1",
+						"glob-parent": "2.0.0",
+						"inherits": "2.0.3",
+						"is-binary-path": "1.0.1",
+						"is-glob": "2.0.1",
+						"path-is-absolute": "1.0.1",
+						"readdirp": "2.1.0"
+					}
+				},
+				"cipher-base": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+					"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+					"requires": {
+						"inherits": "2.0.3",
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"clap": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+					"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+					"requires": {
+						"chalk": "1.1.3"
+					}
+				},
+				"classnames": {
+					"version": "2.2.5",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+					"integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+					"requires": {
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
+						"wordwrap": "0.0.2"
+					}
+				},
+				"clone": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+					"integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+				},
+				"co": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+				},
+				"coa": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+					"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+					"requires": {
+						"q": "1.5.1"
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+				},
+				"color": {
+					"version": "0.11.4",
+					"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+					"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+					"requires": {
+						"clone": "1.0.2",
+						"color-convert": "1.9.0",
+						"color-string": "0.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+					"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				},
+				"color-string": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+					"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"colormin": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+					"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+					"requires": {
+						"color": "0.11.4",
+						"css-color-names": "0.0.4",
+						"has": "1.0.1"
+					}
+				},
+				"colors": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				},
+				"common-tags": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
+					"integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+					"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+				},
+				"configstore": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+					"integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+					"requires": {
+						"dot-prop": "4.2.0",
+						"graceful-fs": "4.1.11",
+						"make-dir": "1.0.0",
+						"unique-string": "1.0.0",
+						"write-file-atomic": "2.3.0",
+						"xdg-basedir": "3.0.0"
+					}
+				},
+				"console-browserify": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+					"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+					"requires": {
+						"date-now": "0.1.4"
+					}
+				},
+				"constants-browserify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+					"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+				},
+				"content-disposition": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+					"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+				},
+				"content-type": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+					"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+				},
+				"convert-source-map": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+				},
+				"cookie": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+					"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+				},
+				"cookie-signature": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+					"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+				},
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+				},
+				"cosmiconfig": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+					"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+					"requires": {
+						"is-directory": "0.3.1",
+						"js-yaml": "3.7.0",
+						"minimist": "1.2.0",
+						"object-assign": "4.1.1",
+						"os-homedir": "1.0.2",
+						"parse-json": "2.2.0",
+						"require-from-string": "1.2.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+						}
+					}
+				},
+				"create-ecdh": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+					"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+					"requires": {
+						"bn.js": "4.11.8",
+						"elliptic": "6.4.0"
+					}
+				},
+				"create-hash": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+					"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+					"requires": {
+						"cipher-base": "1.0.4",
+						"inherits": "2.0.3",
+						"ripemd160": "2.0.1",
+						"sha.js": "2.4.9"
+					}
+				},
+				"create-hmac": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+					"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+					"requires": {
+						"cipher-base": "1.0.4",
+						"create-hash": "1.1.3",
+						"inherits": "2.0.3",
+						"ripemd160": "2.0.1",
+						"safe-buffer": "5.1.1",
+						"sha.js": "2.4.9"
+					}
+				},
+				"create-react-class": {
+					"version": "15.6.2",
+					"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
+					"integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
+					"requires": {
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
+					}
+				},
+				"cryptiles": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+					"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+					"requires": {
+						"boom": "5.2.0"
+					},
+					"dependencies": {
+						"boom": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+							"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+							"requires": {
+								"hoek": "4.2.0"
+							}
+						}
+					}
+				},
+				"crypto-browserify": {
+					"version": "3.11.1",
+					"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+					"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+					"requires": {
+						"browserify-cipher": "1.0.0",
+						"browserify-sign": "4.0.4",
+						"create-ecdh": "4.0.0",
+						"create-hash": "1.1.3",
+						"create-hmac": "1.1.6",
+						"diffie-hellman": "5.0.2",
+						"inherits": "2.0.3",
+						"pbkdf2": "3.0.14",
+						"public-encrypt": "4.0.0",
+						"randombytes": "2.0.5"
+					}
+				},
+				"crypto-random-string": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+					"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+				},
+				"css-color-names": {
+					"version": "0.0.4",
+					"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+					"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
+				},
+				"css-in-js-utils": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz",
+					"integrity": "sha512-yuWmPMD9FLi50Xf3k8W8oO3WM1eVnxEGCldCLyfusQ+CgivFk0s23yst4ooW6tfxMuSa03S6uUEga9UhX6GRrA==",
+					"requires": {
+						"hyphenate-style-name": "1.0.2"
+					}
+				},
+				"css-loader": {
+					"version": "0.28.7",
+					"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
+					"integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
+					"requires": {
+						"babel-code-frame": "6.26.0",
+						"css-selector-tokenizer": "0.7.0",
+						"cssnano": "3.10.0",
+						"icss-utils": "2.1.0",
+						"loader-utils": "1.1.0",
+						"lodash.camelcase": "4.3.0",
+						"object-assign": "4.1.1",
+						"postcss": "5.2.18",
+						"postcss-modules-extract-imports": "1.1.0",
+						"postcss-modules-local-by-default": "1.2.0",
+						"postcss-modules-scope": "1.1.0",
+						"postcss-modules-values": "1.3.0",
+						"postcss-value-parser": "3.3.0",
+						"source-list-map": "2.0.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"css-selector-tokenizer": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+					"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+					"requires": {
+						"cssesc": "0.1.0",
+						"fastparse": "1.1.1",
+						"regexpu-core": "1.0.0"
+					},
+					"dependencies": {
+						"regexpu-core": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+							"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+							"requires": {
+								"regenerate": "1.3.3",
+								"regjsgen": "0.2.0",
+								"regjsparser": "0.1.5"
+							}
+						}
+					}
+				},
+				"cssesc": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+					"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
+				},
+				"cssnano": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+					"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+					"requires": {
+						"autoprefixer": "6.7.7",
+						"decamelize": "1.2.0",
+						"defined": "1.0.0",
+						"has": "1.0.1",
+						"object-assign": "4.1.1",
+						"postcss": "5.2.18",
+						"postcss-calc": "5.3.1",
+						"postcss-colormin": "2.2.2",
+						"postcss-convert-values": "2.6.1",
+						"postcss-discard-comments": "2.0.4",
+						"postcss-discard-duplicates": "2.1.0",
+						"postcss-discard-empty": "2.1.0",
+						"postcss-discard-overridden": "0.1.1",
+						"postcss-discard-unused": "2.2.3",
+						"postcss-filter-plugins": "2.0.2",
+						"postcss-merge-idents": "2.1.7",
+						"postcss-merge-longhand": "2.0.2",
+						"postcss-merge-rules": "2.1.2",
+						"postcss-minify-font-values": "1.0.5",
+						"postcss-minify-gradients": "1.0.5",
+						"postcss-minify-params": "1.2.2",
+						"postcss-minify-selectors": "2.1.1",
+						"postcss-normalize-charset": "1.1.1",
+						"postcss-normalize-url": "3.0.8",
+						"postcss-ordered-values": "2.2.3",
+						"postcss-reduce-idents": "2.4.0",
+						"postcss-reduce-initial": "1.0.1",
+						"postcss-reduce-transforms": "1.0.4",
+						"postcss-svgo": "2.1.6",
+						"postcss-unique-selectors": "2.0.2",
+						"postcss-value-parser": "3.3.0",
+						"postcss-zindex": "2.2.0"
+					},
+					"dependencies": {
+						"autoprefixer": {
+							"version": "6.7.7",
+							"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+							"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+							"requires": {
+								"browserslist": "1.7.7",
+								"caniuse-db": "1.0.30000748",
+								"normalize-range": "0.1.2",
+								"num2fraction": "1.2.2",
+								"postcss": "5.2.18",
+								"postcss-value-parser": "3.3.0"
+							}
+						},
+						"browserslist": {
+							"version": "1.7.7",
+							"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+							"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+							"requires": {
+								"caniuse-db": "1.0.30000748",
+								"electron-to-chromium": "1.3.26"
+							}
+						},
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"csso": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+					"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+					"requires": {
+						"clap": "1.2.3",
+						"source-map": "0.5.7"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						}
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+					"requires": {
+						"assert-plus": "1.0.0"
+					}
+				},
+				"date-now": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+					"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+				},
+				"deep-equal": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+					"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+				},
+				"define-properties": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+					"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+					"requires": {
+						"foreach": "2.0.5",
+						"object-keys": "1.0.11"
+					}
+				},
+				"defined": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+					"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+				},
+				"depd": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+				},
+				"des.js": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+					"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+					"requires": {
+						"inherits": "2.0.3",
+						"minimalistic-assert": "1.0.0"
+					}
+				},
+				"destroy": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+					"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+				},
+				"detect-indent": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+					"requires": {
+						"repeating": "2.0.1"
+					}
+				},
+				"diffie-hellman": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+					"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+					"requires": {
+						"bn.js": "4.11.8",
+						"miller-rabin": "4.0.1",
+						"randombytes": "2.0.5"
+					}
+				},
+				"doctrine": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+					"integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+					"requires": {
+						"esutils": "2.0.2",
+						"isarray": "1.0.0"
+					}
+				},
+				"dom-helpers": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
+					"integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
+				},
+				"dom-walk": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+					"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+				},
+				"domain-browser": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+					"integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+				},
+				"dot-prop": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+					"requires": {
+						"is-obj": "1.0.1"
+					}
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"ee-first": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+					"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+				},
+				"electron-to-chromium": {
+					"version": "1.3.26",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.26.tgz",
+					"integrity": "sha1-mWQnKUhhp02cfIK5Jg6jAejALWY="
+				},
+				"element-class": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/element-class/-/element-class-0.2.2.tgz",
+					"integrity": "sha1-nTu9B2f5AT744cjr5yLBQCpgBQ4="
+				},
+				"elliptic": {
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+					"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+					"requires": {
+						"bn.js": "4.11.8",
+						"brorand": "1.1.0",
+						"hash.js": "1.1.3",
+						"hmac-drbg": "1.0.1",
+						"inherits": "2.0.3",
+						"minimalistic-assert": "1.0.0",
+						"minimalistic-crypto-utils": "1.0.1"
+					}
+				},
+				"emojis-list": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+					"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+				},
+				"encodeurl": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+					"integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+				},
+				"encoding": {
+					"version": "0.1.12",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"requires": {
+						"iconv-lite": "0.4.19"
+					}
+				},
+				"enhanced-resolve": {
+					"version": "3.4.1",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+					"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"memory-fs": "0.4.1",
+						"object-assign": "4.1.1",
+						"tapable": "0.2.8"
+					}
+				},
+				"errno": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+					"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+					"requires": {
+						"prr": "0.0.0"
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+					"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+					"requires": {
+						"is-arrayish": "0.2.1"
+					}
+				},
+				"es-abstract": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+					"integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+					"requires": {
+						"es-to-primitive": "1.1.1",
+						"function-bind": "1.1.1",
+						"has": "1.0.1",
+						"is-callable": "1.1.3",
+						"is-regex": "1.0.4"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+					"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+					"requires": {
+						"is-callable": "1.1.3",
+						"is-date-object": "1.0.1",
+						"is-symbol": "1.0.1"
+					}
+				},
+				"es5-shim": {
+					"version": "4.5.9",
+					"resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.9.tgz",
+					"integrity": "sha1-Kh4rnlg/9f7Qwgo+4svz91IwpcA="
+				},
+				"es6-shim": {
+					"version": "0.35.3",
+					"resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.3.tgz",
+					"integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY="
+				},
+				"escape-html": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+					"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+				},
+				"esprima": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+				},
+				"etag": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+					"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+				},
+				"events": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+					"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+				},
+				"evp_bytestokey": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+					"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+					"requires": {
+						"md5.js": "1.3.4",
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"exenv": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+					"integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "0.1.1"
+					}
+				},
+				"expand-range": {
+					"version": "1.8.2",
+					"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+					"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+					"requires": {
+						"fill-range": "2.2.3"
+					}
+				},
+				"express": {
+					"version": "4.16.2",
+					"resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+					"integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+					"requires": {
+						"accepts": "1.3.4",
+						"array-flatten": "1.1.1",
+						"body-parser": "1.18.2",
+						"content-disposition": "0.5.2",
+						"content-type": "1.0.4",
+						"cookie": "0.3.1",
+						"cookie-signature": "1.0.6",
+						"debug": "2.6.9",
+						"depd": "1.1.1",
+						"encodeurl": "1.0.1",
+						"escape-html": "1.0.3",
+						"etag": "1.8.1",
+						"finalhandler": "1.1.0",
+						"fresh": "0.5.2",
+						"merge-descriptors": "1.0.1",
+						"methods": "1.1.2",
+						"on-finished": "2.3.0",
+						"parseurl": "1.3.2",
+						"path-to-regexp": "0.1.7",
+						"proxy-addr": "2.0.2",
+						"qs": "6.5.1",
+						"range-parser": "1.2.0",
+						"safe-buffer": "5.1.1",
+						"send": "0.16.1",
+						"serve-static": "1.13.1",
+						"setprototypeof": "1.1.0",
+						"statuses": "1.3.1",
+						"type-is": "1.6.15",
+						"utils-merge": "1.0.1",
+						"vary": "1.1.2"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"extsprintf": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+					"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+				},
+				"fast-deep-equal": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+					"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+				},
+				"fast-memoize": {
+					"version": "2.2.8",
+					"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.2.8.tgz",
+					"integrity": "sha512-3ppTC3fZ9Vwtjslx8DkhSIbI9PH1nM4pobuTHQINOxTxchG8n3SDGZ8L6jbatGJCGLKR+gbkNWKFN4E1iUROSA=="
+				},
+				"fastparse": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+					"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+				},
+				"fbjs": {
+					"version": "0.8.16",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+					"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+					"requires": {
+						"core-js": "1.2.7",
+						"isomorphic-fetch": "2.2.1",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1",
+						"promise": "7.3.1",
+						"setimmediate": "1.0.5",
+						"ua-parser-js": "0.7.17"
+					}
+				},
+				"file-loader": {
+					"version": "0.11.2",
+					"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.2.tgz",
+					"integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
+					"requires": {
+						"loader-utils": "1.1.0"
+					}
+				},
+				"filename-regex": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+					"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+				},
+				"fill-range": {
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+					"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+					"requires": {
+						"is-number": "2.1.0",
+						"isobject": "2.1.0",
+						"randomatic": "1.1.7",
+						"repeat-element": "1.1.2",
+						"repeat-string": "1.6.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"finalhandler": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+					"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+					"requires": {
+						"debug": "2.6.9",
+						"encodeurl": "1.0.1",
+						"escape-html": "1.0.3",
+						"on-finished": "2.3.0",
+						"parseurl": "1.3.2",
+						"statuses": "1.3.1",
+						"unpipe": "1.0.0"
+					}
+				},
+				"find-cache-dir": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+					"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+					"requires": {
+						"commondir": "1.0.1",
+						"make-dir": "1.0.0",
+						"pkg-dir": "2.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"flatten": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+					"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+				},
+				"for-own": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+					"requires": {
+						"for-in": "1.0.2"
+					}
+				},
+				"foreach": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+					"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+				},
+				"form-data": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+					"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.17"
+					}
+				},
+				"forwarded": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+					"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+				},
+				"fresh": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+					"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+				},
+				"fsevents": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+					"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"ajv": {
+							"version": "4.11.8",
+							"bundled": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true
+						},
+						"aproba": {
+							"version": "1.1.1",
+							"bundled": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.4",
+							"bundled": true
+						},
+						"asn1": {
+							"version": "0.2.3",
+							"bundled": true
+						},
+						"assert-plus": {
+							"version": "0.2.0",
+							"bundled": true
+						},
+						"asynckit": {
+							"version": "0.4.0",
+							"bundled": true
+						},
+						"aws-sign2": {
+							"version": "0.6.0",
+							"bundled": true
+						},
+						"aws4": {
+							"version": "1.6.0",
+							"bundled": true
+						},
+						"balanced-match": {
+							"version": "0.4.2",
+							"bundled": true
+						},
+						"bcrypt-pbkdf": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"block-stream": {
+							"version": "0.0.9",
+							"bundled": true
+						},
+						"boom": {
+							"version": "2.10.1",
+							"bundled": true
+						},
+						"brace-expansion": {
+							"version": "1.1.7",
+							"bundled": true
+						},
+						"buffer-shims": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"caseless": {
+							"version": "0.12.0",
+							"bundled": true
+						},
+						"co": {
+							"version": "4.6.0",
+							"bundled": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"combined-stream": {
+							"version": "1.0.5",
+							"bundled": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"cryptiles": {
+							"version": "2.0.5",
+							"bundled": true
+						},
+						"dashdash": {
+							"version": "1.14.1",
+							"bundled": true,
+							"dependencies": {
+								"assert-plus": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"debug": {
+							"version": "2.6.8",
+							"bundled": true
+						},
+						"deep-extend": {
+							"version": "0.4.2",
+							"bundled": true
+						},
+						"delayed-stream": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"ecc-jsbn": {
+							"version": "0.1.1",
+							"bundled": true
+						},
+						"extend": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"extsprintf": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"forever-agent": {
+							"version": "0.6.1",
+							"bundled": true
+						},
+						"form-data": {
+							"version": "2.1.4",
+							"bundled": true
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"fstream": {
+							"version": "1.0.11",
+							"bundled": true
+						},
+						"fstream-ignore": {
+							"version": "1.0.5",
+							"bundled": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true
+						},
+						"getpass": {
+							"version": "0.1.7",
+							"bundled": true,
+							"dependencies": {
+								"assert-plus": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"glob": {
+							"version": "7.1.2",
+							"bundled": true
+						},
+						"graceful-fs": {
+							"version": "4.1.11",
+							"bundled": true
+						},
+						"har-schema": {
+							"version": "1.0.5",
+							"bundled": true
+						},
+						"har-validator": {
+							"version": "4.2.1",
+							"bundled": true
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true
+						},
+						"hawk": {
+							"version": "3.1.3",
+							"bundled": true
+						},
+						"hoek": {
+							"version": "2.16.3",
+							"bundled": true
+						},
+						"http-signature": {
+							"version": "1.1.1",
+							"bundled": true
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true
+						},
+						"ini": {
+							"version": "1.3.4",
+							"bundled": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"is-typedarray": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"isstream": {
+							"version": "0.1.2",
+							"bundled": true
+						},
+						"jodid25519": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"jsbn": {
+							"version": "0.1.1",
+							"bundled": true
+						},
+						"json-schema": {
+							"version": "0.2.3",
+							"bundled": true
+						},
+						"json-stable-stringify": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"json-stringify-safe": {
+							"version": "5.0.1",
+							"bundled": true
+						},
+						"jsonify": {
+							"version": "0.0.0",
+							"bundled": true
+						},
+						"jsprim": {
+							"version": "1.4.0",
+							"bundled": true,
+							"dependencies": {
+								"assert-plus": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"mime-db": {
+							"version": "1.27.0",
+							"bundled": true
+						},
+						"mime-types": {
+							"version": "2.1.15",
+							"bundled": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true
+						},
+						"ms": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"node-pre-gyp": {
+							"version": "0.6.36",
+							"bundled": true
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true
+						},
+						"npmlog": {
+							"version": "4.1.0",
+							"bundled": true
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"oauth-sign": {
+							"version": "0.8.2",
+							"bundled": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"osenv": {
+							"version": "0.1.4",
+							"bundled": true
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"performance-now": {
+							"version": "0.2.0",
+							"bundled": true
+						},
+						"process-nextick-args": {
+							"version": "1.0.7",
+							"bundled": true
+						},
+						"punycode": {
+							"version": "1.4.1",
+							"bundled": true
+						},
+						"qs": {
+							"version": "6.4.0",
+							"bundled": true
+						},
+						"rc": {
+							"version": "1.2.1",
+							"bundled": true,
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.2.9",
+							"bundled": true
+						},
+						"request": {
+							"version": "2.81.0",
+							"bundled": true
+						},
+						"rimraf": {
+							"version": "2.6.1",
+							"bundled": true
+						},
+						"safe-buffer": {
+							"version": "5.0.1",
+							"bundled": true
+						},
+						"semver": {
+							"version": "5.3.0",
+							"bundled": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true
+						},
+						"sntp": {
+							"version": "1.0.9",
+							"bundled": true
+						},
+						"sshpk": {
+							"version": "1.13.0",
+							"bundled": true,
+							"dependencies": {
+								"assert-plus": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"string_decoder": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"stringstream": {
+							"version": "0.0.5",
+							"bundled": true
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true
+						},
+						"tar": {
+							"version": "2.2.1",
+							"bundled": true
+						},
+						"tar-pack": {
+							"version": "3.4.0",
+							"bundled": true
+						},
+						"tough-cookie": {
+							"version": "2.3.2",
+							"bundled": true
+						},
+						"tunnel-agent": {
+							"version": "0.6.0",
+							"bundled": true
+						},
+						"tweetnacl": {
+							"version": "0.14.5",
+							"bundled": true
+						},
+						"uid-number": {
+							"version": "0.0.6",
+							"bundled": true
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"uuid": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"verror": {
+							"version": "1.3.6",
+							"bundled": true
+						},
+						"wide-align": {
+							"version": "1.1.2",
+							"bundled": true
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"function-bind": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+					"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+				},
+				"function.prototype.name": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
+					"integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
+					"requires": {
+						"define-properties": "1.1.2",
+						"function-bind": "1.1.1",
+						"is-callable": "1.1.3"
+					}
+				},
+				"fuse.js": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.2.0.tgz",
+					"integrity": "sha1-8ESOgGmFW/Kj5oPNwdMg5+KgfvQ="
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+					"requires": {
+						"assert-plus": "1.0.0"
+					}
+				},
+				"glamor": {
+					"version": "2.20.40",
+					"resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
+					"integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
+					"requires": {
+						"fbjs": "0.8.16",
+						"inline-style-prefixer": "3.0.8",
+						"object-assign": "4.1.1",
+						"prop-types": "15.6.0",
+						"through": "2.3.8"
+					}
+				},
+				"glamorous": {
+					"version": "3.25.0",
+					"resolved": "https://registry.npmjs.org/glamorous/-/glamorous-3.25.0.tgz",
+					"integrity": "sha512-Y2ZykdbY+w1Bz97aUdOzmLr//vV6nQmBnnBfJfXG1AYi7zbp37m7X+giBGqZiyLCA65HgQ8yH89sZyD6sGMROg==",
+					"requires": {
+						"brcast": "2.0.2",
+						"fast-memoize": "2.2.8",
+						"html-tag-names": "1.1.2",
+						"react-html-attributes": "1.4.1",
+						"svg-tag-names": "1.1.1"
+					},
+					"dependencies": {
+						"brcast": {
+							"version": "2.0.2",
+							"resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
+							"integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg=="
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"glob-base": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+					"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+					"requires": {
+						"glob-parent": "2.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"global": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+					"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+					"requires": {
+						"min-document": "2.19.0",
+						"process": "0.5.2"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+				},
+				"har-schema": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+				},
+				"har-validator": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+					"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+					"requires": {
+						"ajv": "5.2.3",
+						"har-schema": "2.0.0"
+					}
+				},
+				"has": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+					"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+					"requires": {
+						"function-bind": "1.1.1"
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"hash-base": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+					"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"hash.js": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+					"requires": {
+						"inherits": "2.0.3",
+						"minimalistic-assert": "1.0.0"
+					}
+				},
+				"hawk": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+					"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+					"requires": {
+						"boom": "4.3.1",
+						"cryptiles": "3.1.2",
+						"hoek": "4.2.0",
+						"sntp": "2.0.2"
+					}
+				},
+				"hmac-drbg": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+					"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+					"requires": {
+						"hash.js": "1.1.3",
+						"minimalistic-assert": "1.0.0",
+						"minimalistic-crypto-utils": "1.0.1"
+					}
+				},
+				"hoek": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+					"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+				},
+				"hoist-non-react-statics": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+					"integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+				},
+				"home-or-tmp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+					"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+				},
+				"html-comment-regex": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+					"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4="
+				},
+				"html-element-attributes": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-1.3.0.tgz",
+					"integrity": "sha1-8G69/OIt6XnbggICZcrFQfsX1Pw="
+				},
+				"html-entities": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+					"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+				},
+				"html-tag-names": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.2.tgz",
+					"integrity": "sha1-9lFolkxanIJnXv2ogoddyyqHXCI="
+				},
+				"http-errors": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+					"requires": {
+						"depd": "1.1.1",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.0.3",
+						"statuses": "1.3.1"
+					},
+					"dependencies": {
+						"setprototypeof": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+							"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+						}
+					}
+				},
+				"http-signature": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+					"requires": {
+						"assert-plus": "1.0.0",
+						"jsprim": "1.4.1",
+						"sshpk": "1.13.1"
+					}
+				},
+				"https-browserify": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+					"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+				},
+				"hyphenate-style-name": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
+					"integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"icss-replace-symbols": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+					"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
+				},
+				"icss-utils": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+					"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+					"requires": {
+						"postcss": "6.0.13"
+					}
+				},
+				"ieee754": {
+					"version": "1.1.8",
+					"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+					"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+				},
+				"immutable": {
+					"version": "3.8.2",
+					"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+					"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+				},
+				"indexes-of": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+					"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+				},
+				"indexof": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+					"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				},
+				"inline-style-prefixer": {
+					"version": "3.0.8",
+					"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
+					"integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
+					"requires": {
+						"bowser": "1.8.0",
+						"css-in-js-utils": "2.0.0"
+					}
+				},
+				"interpret": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+					"integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA="
+				},
+				"invariant": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+					"requires": {
+						"loose-envify": "1.3.1"
+					}
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+				},
+				"ipaddr.js": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+					"integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
+				},
+				"is-absolute-url": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+					"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+				},
+				"is-binary-path": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+					"requires": {
+						"binary-extensions": "1.10.0"
+					}
+				},
+				"is-buffer": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+					"requires": {
+						"builtin-modules": "1.1.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+					"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+				},
+				"is-date-object": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+					"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+				},
+				"is-directory": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+					"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+				},
+				"is-dom": {
+					"version": "1.0.9",
+					"resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.0.9.tgz",
+					"integrity": "sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0="
+				},
+				"is-dotfile": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+					"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+				},
+				"is-equal-shallow": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+					"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+					"requires": {
+						"is-primitive": "2.0.0"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-finite": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-function": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+					"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+				},
+				"is-plain-obj": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+					"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"requires": {
+						"isobject": "3.0.1"
+					}
+				},
+				"is-posix-bracket": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+					"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+				},
+				"is-primitive": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+					"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+				},
+				"is-regex": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+					"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+					"requires": {
+						"has": "1.0.1"
+					}
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+				},
+				"is-svg": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+					"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+					"requires": {
+						"html-comment-regex": "1.1.1"
+					}
+				},
+				"is-symbol": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+					"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+					"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"isomorphic-fetch": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+					"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+					"requires": {
+						"node-fetch": "1.7.3",
+						"whatwg-fetch": "2.0.3"
+					}
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+				},
+				"js-base64": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
+					"integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw=="
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"js-yaml": {
+					"version": "3.7.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+					"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+					"requires": {
+						"argparse": "1.0.9",
+						"esprima": "2.7.3"
+					},
+					"dependencies": {
+						"esprima": {
+							"version": "2.7.3",
+							"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+							"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+						}
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+					"optional": true
+				},
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+				},
+				"json-loader": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+					"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+				},
+				"json-schema-traverse": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+				},
+				"json5": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+				},
+				"jsprim": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+					"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.3.0",
+						"json-schema": "0.2.3",
+						"verror": "1.10.0"
+					}
+				},
+				"keycode": {
+					"version": "2.1.9",
+					"resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz",
+					"integrity": "sha1-lkojxU5IiUBbSGGlyfBIDUUUHfo="
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "1.1.5"
+					}
+				},
+				"lazy-cache": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+					"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+					"requires": {
+						"invert-kv": "1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"loader-runner": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+					"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
+				},
+				"loader-utils": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+					"requires": {
+						"big.js": "3.2.0",
+						"emojis-list": "2.1.0",
+						"json5": "0.5.1"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
+					}
+				},
+				"lodash": {
+					"version": "3.10.1",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+				},
+				"lodash-es": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+					"integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+				},
+				"lodash._getnative": {
+					"version": "3.9.1",
+					"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+					"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+				},
+				"lodash.assign": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+					"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+				},
+				"lodash.camelcase": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+					"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+				},
+				"lodash.debounce": {
+					"version": "4.0.8",
+					"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+					"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+				},
+				"lodash.isarguments": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+					"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+				},
+				"lodash.isarray": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+					"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+				},
+				"lodash.keys": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+					"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+					"requires": {
+						"lodash._getnative": "3.9.1",
+						"lodash.isarguments": "3.1.0",
+						"lodash.isarray": "3.0.4"
+					}
+				},
+				"lodash.memoize": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+					"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+				},
+				"lodash.pick": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+					"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+				},
+				"lodash.sortby": {
+					"version": "4.7.0",
+					"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+					"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+				},
+				"lodash.uniq": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+					"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+				},
+				"longest": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+					"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"requires": {
+						"js-tokens": "3.0.2"
+					}
+				},
+				"macaddress": {
+					"version": "0.2.8",
+					"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+					"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
+				},
+				"make-dir": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+					"integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"mantra-core": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/mantra-core/-/mantra-core-1.7.0.tgz",
+					"integrity": "sha1-qMg+jO6D72pzgxMVGf6AMa1UY4Y=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"react-komposer": "1.13.1",
+						"react-simple-di": "1.2.0"
+					},
+					"dependencies": {
+						"react-komposer": {
+							"version": "1.13.1",
+							"resolved": "https://registry.npmjs.org/react-komposer/-/react-komposer-1.13.1.tgz",
+							"integrity": "sha1-S4rEvMcTI710E9yrlcgxGX9Q7tA=",
+							"requires": {
+								"babel-runtime": "6.26.0",
+								"hoist-non-react-statics": "1.2.0",
+								"invariant": "2.2.2",
+								"mobx": "2.7.0",
+								"shallowequal": "0.2.2"
+							}
+						}
+					}
+				},
+				"math-expression-evaluator": {
+					"version": "1.2.17",
+					"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+					"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
+				},
+				"md5.js": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+					"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+					"requires": {
+						"hash-base": "3.0.4",
+						"inherits": "2.0.3"
+					},
+					"dependencies": {
+						"hash-base": {
+							"version": "3.0.4",
+							"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+							"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+							"requires": {
+								"inherits": "2.0.3",
+								"safe-buffer": "5.1.1"
+							}
+						}
+					}
+				},
+				"media-typer": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+					"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+				},
+				"memory-fs": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+					"requires": {
+						"errno": "0.1.4",
+						"readable-stream": "2.3.3"
+					}
+				},
+				"merge-descriptors": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+					"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+				},
+				"methods": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+					"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
+					}
+				},
+				"miller-rabin": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+					"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+					"requires": {
+						"bn.js": "4.11.8",
+						"brorand": "1.1.0"
+					}
+				},
+				"mime": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+				},
+				"mime-db": {
+					"version": "1.30.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+					"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+				},
+				"mime-types": {
+					"version": "2.1.17",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+					"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+					"requires": {
+						"mime-db": "1.30.0"
+					}
+				},
+				"min-document": {
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+					"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+					"requires": {
+						"dom-walk": "0.1.1"
+					}
+				},
+				"minimalistic-assert": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+					"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+				},
+				"minimalistic-crypto-utils": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+					"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"mobx": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/mobx/-/mobx-2.7.0.tgz",
+					"integrity": "sha1-zz2C0YwMp/RY2PKiQIF7PcflSgE="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"nan": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+					"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+				},
+				"negotiator": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+					"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+				},
+				"node-dir": {
+					"version": "0.1.17",
+					"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+					"integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+					"requires": {
+						"minimatch": "3.0.4"
+					}
+				},
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "0.1.12",
+						"is-stream": "1.1.0"
+					}
+				},
+				"node-libs-browser": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
+					"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+					"requires": {
+						"assert": "1.4.1",
+						"browserify-zlib": "0.1.4",
+						"buffer": "4.9.1",
+						"console-browserify": "1.1.0",
+						"constants-browserify": "1.0.0",
+						"crypto-browserify": "3.11.1",
+						"domain-browser": "1.1.7",
+						"events": "1.1.1",
+						"https-browserify": "0.0.1",
+						"os-browserify": "0.2.1",
+						"path-browserify": "0.0.0",
+						"process": "0.11.10",
+						"punycode": "1.4.1",
+						"querystring-es3": "0.2.1",
+						"readable-stream": "2.3.3",
+						"stream-browserify": "2.0.1",
+						"stream-http": "2.7.2",
+						"string_decoder": "0.10.31",
+						"timers-browserify": "2.0.4",
+						"tty-browserify": "0.0.0",
+						"url": "0.11.0",
+						"util": "0.10.3",
+						"vm-browserify": "0.0.4"
+					},
+					"dependencies": {
+						"process": {
+							"version": "0.11.10",
+							"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+							"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+						},
+						"string_decoder": {
+							"version": "0.10.31",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+						}
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+					"requires": {
+						"hosted-git-info": "2.5.0",
+						"is-builtin-module": "1.0.0",
+						"semver": "5.4.1",
+						"validate-npm-package-license": "3.0.1"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"requires": {
+						"remove-trailing-separator": "1.1.0"
+					}
+				},
+				"normalize-range": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+					"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+				},
+				"normalize-url": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+					"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+					"requires": {
+						"object-assign": "4.1.1",
+						"prepend-http": "1.0.4",
+						"query-string": "4.3.4",
+						"sort-keys": "1.1.2"
+					}
+				},
+				"num2fraction": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+					"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"object-keys": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+					"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+				},
+				"object.entries": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+					"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+					"requires": {
+						"define-properties": "1.1.2",
+						"es-abstract": "1.9.0",
+						"function-bind": "1.1.1",
+						"has": "1.0.1"
+					}
+				},
+				"object.getownpropertydescriptors": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+					"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+					"requires": {
+						"define-properties": "1.1.2",
+						"es-abstract": "1.9.0"
+					}
+				},
+				"object.omit": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+					"requires": {
+						"for-own": "0.1.5",
+						"is-extendable": "0.1.1"
+					}
+				},
+				"object.values": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+					"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+					"requires": {
+						"define-properties": "1.1.2",
+						"es-abstract": "1.9.0",
+						"function-bind": "1.1.1",
+						"has": "1.0.1"
+					}
+				},
+				"on-finished": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+					"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+					"requires": {
+						"ee-first": "1.1.1"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-browserify": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+					"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+				},
+				"os-locale": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"requires": {
+						"lcid": "1.0.0"
+					}
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+				},
+				"p-limit": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+					"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "1.1.0"
+					}
+				},
+				"pako": {
+					"version": "0.2.9",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+					"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+				},
+				"parse-asn1": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+					"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+					"requires": {
+						"asn1.js": "4.9.1",
+						"browserify-aes": "1.1.1",
+						"create-hash": "1.1.3",
+						"evp_bytestokey": "1.0.3",
+						"pbkdf2": "3.0.14"
+					}
+				},
+				"parse-glob": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+					"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+					"requires": {
+						"glob-base": "0.3.0",
+						"is-dotfile": "1.0.3",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"requires": {
+						"error-ex": "1.3.1"
+					}
+				},
+				"parseurl": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+					"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+				},
+				"path-browserify": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+					"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+				},
+				"path-to-regexp": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pbkdf2": {
+					"version": "3.0.14",
+					"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+					"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+					"requires": {
+						"create-hash": "1.1.3",
+						"create-hmac": "1.1.6",
+						"ripemd160": "2.0.1",
+						"safe-buffer": "5.1.1",
+						"sha.js": "2.4.9"
+					}
+				},
+				"performance-now": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"requires": {
+						"find-up": "2.1.0"
+					}
+				},
+				"podda": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/podda/-/podda-1.2.2.tgz",
+					"integrity": "sha1-FbDtvTNK3hRYEzQ/Xs+cEKcc9QA=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"immutable": "3.8.2"
+					}
+				},
+				"postcss": {
+					"version": "6.0.13",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
+					"integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+					"requires": {
+						"chalk": "2.2.0",
+						"source-map": "0.6.1",
+						"supports-color": "4.5.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.2.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
+							"integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+							"requires": {
+								"ansi-styles": "3.2.0",
+								"escape-string-regexp": "1.0.5",
+								"supports-color": "4.5.0"
+							}
+						}
+					}
+				},
+				"postcss-calc": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+					"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+					"requires": {
+						"postcss": "5.2.18",
+						"postcss-message-helpers": "2.0.0",
+						"reduce-css-calc": "1.3.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-colormin": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+					"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+					"requires": {
+						"colormin": "1.1.2",
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-convert-values": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+					"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+					"requires": {
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-discard-comments": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+					"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+					"requires": {
+						"postcss": "5.2.18"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-discard-duplicates": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+					"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+					"requires": {
+						"postcss": "5.2.18"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-discard-empty": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+					"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+					"requires": {
+						"postcss": "5.2.18"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-discard-overridden": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+					"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+					"requires": {
+						"postcss": "5.2.18"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-discard-unused": {
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+					"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+					"requires": {
+						"postcss": "5.2.18",
+						"uniqs": "2.0.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-filter-plugins": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+					"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+					"requires": {
+						"postcss": "5.2.18",
+						"uniqid": "4.1.1"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-flexbugs-fixes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.2.0.tgz",
+					"integrity": "sha512-0AuD9HG1Ey3/3nqPWu9yqf7rL0KCPu5VgjDsjf5mzEcuo9H/z8nco/fljKgjsOUrZypa95MI0kS4xBZeBzz2lw==",
+					"requires": {
+						"postcss": "6.0.13"
+					}
+				},
+				"postcss-load-config": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+					"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
+					"requires": {
+						"cosmiconfig": "2.2.2",
+						"object-assign": "4.1.1",
+						"postcss-load-options": "1.2.0",
+						"postcss-load-plugins": "2.3.0"
+					}
+				},
+				"postcss-load-options": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+					"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
+					"requires": {
+						"cosmiconfig": "2.2.2",
+						"object-assign": "4.1.1"
+					}
+				},
+				"postcss-load-plugins": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
+					"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
+					"requires": {
+						"cosmiconfig": "2.2.2",
+						"object-assign": "4.1.1"
+					}
+				},
+				"postcss-loader": {
+					"version": "2.0.8",
+					"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.8.tgz",
+					"integrity": "sha512-KtXBiQ/r/WYW8LxTSJK7h8wLqvCMSub/BqmRnud/Mu8RzwflW9cmXxwsMwbn15TNv287Hcufdb3ZSs7xHKnG8Q==",
+					"requires": {
+						"loader-utils": "1.1.0",
+						"postcss": "6.0.13",
+						"postcss-load-config": "1.2.0",
+						"schema-utils": "0.3.0"
+					}
+				},
+				"postcss-merge-idents": {
+					"version": "2.1.7",
+					"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+					"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+					"requires": {
+						"has": "1.0.1",
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-merge-longhand": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+					"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+					"requires": {
+						"postcss": "5.2.18"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-merge-rules": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+					"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+					"requires": {
+						"browserslist": "1.7.7",
+						"caniuse-api": "1.6.1",
+						"postcss": "5.2.18",
+						"postcss-selector-parser": "2.2.3",
+						"vendors": "1.0.1"
+					},
+					"dependencies": {
+						"browserslist": {
+							"version": "1.7.7",
+							"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+							"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+							"requires": {
+								"caniuse-db": "1.0.30000748",
+								"electron-to-chromium": "1.3.26"
+							}
+						},
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-message-helpers": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+					"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
+				},
+				"postcss-minify-font-values": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+					"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+					"requires": {
+						"object-assign": "4.1.1",
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-minify-gradients": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+					"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+					"requires": {
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-minify-params": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+					"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+					"requires": {
+						"alphanum-sort": "1.0.2",
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0",
+						"uniqs": "2.0.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-minify-selectors": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+					"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+					"requires": {
+						"alphanum-sort": "1.0.2",
+						"has": "1.0.1",
+						"postcss": "5.2.18",
+						"postcss-selector-parser": "2.2.3"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-modules-extract-imports": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+					"integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
+					"requires": {
+						"postcss": "6.0.13"
+					}
+				},
+				"postcss-modules-local-by-default": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+					"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+					"requires": {
+						"css-selector-tokenizer": "0.7.0",
+						"postcss": "6.0.13"
+					}
+				},
+				"postcss-modules-scope": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+					"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+					"requires": {
+						"css-selector-tokenizer": "0.7.0",
+						"postcss": "6.0.13"
+					}
+				},
+				"postcss-modules-values": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+					"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+					"requires": {
+						"icss-replace-symbols": "1.1.0",
+						"postcss": "6.0.13"
+					}
+				},
+				"postcss-normalize-charset": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+					"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+					"requires": {
+						"postcss": "5.2.18"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-normalize-url": {
+					"version": "3.0.8",
+					"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+					"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+					"requires": {
+						"is-absolute-url": "2.1.0",
+						"normalize-url": "1.9.1",
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-ordered-values": {
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+					"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+					"requires": {
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-reduce-idents": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+					"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+					"requires": {
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-reduce-initial": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+					"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+					"requires": {
+						"postcss": "5.2.18"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-reduce-transforms": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+					"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+					"requires": {
+						"has": "1.0.1",
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-selector-parser": {
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+					"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+					"requires": {
+						"flatten": "1.0.2",
+						"indexes-of": "1.0.1",
+						"uniq": "1.0.1"
+					}
+				},
+				"postcss-svgo": {
+					"version": "2.1.6",
+					"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+					"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+					"requires": {
+						"is-svg": "2.1.0",
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0",
+						"svgo": "0.7.2"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-unique-selectors": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+					"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+					"requires": {
+						"alphanum-sort": "1.0.2",
+						"postcss": "5.2.18",
+						"uniqs": "2.0.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"postcss-value-parser": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+					"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+				},
+				"postcss-zindex": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+					"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+					"requires": {
+						"has": "1.0.1",
+						"postcss": "5.2.18",
+						"uniqs": "2.0.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"postcss": {
+							"version": "5.2.18",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+							"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+							"requires": {
+								"chalk": "1.1.3",
+								"js-base64": "2.3.2",
+								"source-map": "0.5.7",
+								"supports-color": "3.2.3"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"prepend-http": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+				},
+				"preserve": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+					"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+				},
+				"private": {
+					"version": "0.1.8",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+					"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+				},
+				"process": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+				},
+				"promise": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+					"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+					"requires": {
+						"asap": "2.0.6"
+					}
+				},
+				"promise.prototype.finally": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.0.1.tgz",
+					"integrity": "sha512-5o2ue0smn+Wn6tdkqN4wxB27lCu84UrladpMRQ3fm1tEkewOrhAGSOHwj15SRU+oE/ParFTou6XG3Jhgyb9sjw==",
+					"requires": {
+						"define-properties": "1.1.2",
+						"es-abstract": "1.9.0",
+						"function-bind": "1.1.1"
+					}
+				},
+				"prop-types": {
+					"version": "15.6.0",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+					"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+					"requires": {
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
+					}
+				},
+				"proxy-addr": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+					"integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+					"requires": {
+						"forwarded": "0.1.2",
+						"ipaddr.js": "1.5.2"
+					}
+				},
+				"prr": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+					"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+				},
+				"public-encrypt": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+					"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+					"requires": {
+						"bn.js": "4.11.8",
+						"browserify-rsa": "4.0.1",
+						"create-hash": "1.1.3",
+						"parse-asn1": "5.1.0",
+						"randombytes": "2.0.5"
+					}
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				},
+				"q": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+					"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				},
+				"query-string": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+					"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+					"requires": {
+						"object-assign": "4.1.1",
+						"strict-uri-encode": "1.1.0"
+					}
+				},
+				"querystring": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+					"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+				},
+				"querystring-es3": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+					"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+				},
+				"radium": {
+					"version": "0.19.5",
+					"resolved": "https://registry.npmjs.org/radium/-/radium-0.19.5.tgz",
+					"integrity": "sha512-W2vu68wvq6AcUb81PNaBkVqO7O0HksURQeY5KzoCR/k9hxLqglYvkiXMKeLqxNDr47mDj1W5Zbm3e8Xi9kBIFA==",
+					"requires": {
+						"array-find": "1.0.0",
+						"exenv": "1.2.2",
+						"inline-style-prefixer": "2.0.5",
+						"prop-types": "15.6.0"
+					},
+					"dependencies": {
+						"inline-style-prefixer": {
+							"version": "2.0.5",
+							"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
+							"integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
+							"requires": {
+								"bowser": "1.8.0",
+								"hyphenate-style-name": "1.0.2"
+							}
+						}
+					}
+				},
+				"randomatic": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+					"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+					"requires": {
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+							"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "1.1.5"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+							"requires": {
+								"is-buffer": "1.1.5"
+							}
+						}
+					}
+				},
+				"randombytes": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+					"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"range-parser": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+					"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+				},
+				"raw-body": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+					"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+					"requires": {
+						"bytes": "3.0.0",
+						"http-errors": "1.6.2",
+						"iconv-lite": "0.4.19",
+						"unpipe": "1.0.0"
+					}
+				},
+				"react-docgen": {
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.19.0.tgz",
+					"integrity": "sha1-qeNWJ3qjH0LfFj8LSRfTsHeYX50=",
+					"requires": {
+						"async": "2.5.0",
+						"babel-runtime": "6.26.0",
+						"babylon": "5.8.38",
+						"commander": "2.11.0",
+						"doctrine": "2.0.0",
+						"node-dir": "0.1.17",
+						"recast": "0.12.7"
+					},
+					"dependencies": {
+						"babylon": {
+							"version": "5.8.38",
+							"resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+							"integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
+						}
+					}
+				},
+				"react-dom-factories": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/react-dom-factories/-/react-dom-factories-1.0.2.tgz",
+					"integrity": "sha1-63cFxNs2+1AbOqOP91lhaqD/luA="
+				},
+				"react-html-attributes": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.4.1.tgz",
+					"integrity": "sha1-l7XscQ2miDNZjIvm+JrENiFoQKU=",
+					"requires": {
+						"html-element-attributes": "1.3.0"
+					}
+				},
+				"react-icon-base": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.1.0.tgz",
+					"integrity": "sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50="
+				},
+				"react-icons": {
+					"version": "2.2.7",
+					"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-2.2.7.tgz",
+					"integrity": "sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==",
+					"requires": {
+						"react-icon-base": "2.1.0"
+					}
+				},
+				"react-inspector": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.2.0.tgz",
+					"integrity": "sha512-G5qXffxY5U1XhleV/YxHfJvjAiHHPDhYItygvz0FGdEuFVop0FTHNlHbUYRn7XOtARiMBekaBinq8PkA+ylrEg==",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"is-dom": "1.0.9"
+					}
+				},
+				"react-komposer": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/react-komposer/-/react-komposer-2.0.0.tgz",
+					"integrity": "sha1-uWRzgBSptK7klKg8C1uDPWYHKpA=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"hoist-non-react-statics": "1.2.0",
+						"lodash.pick": "4.4.0",
+						"react-stubber": "1.0.0",
+						"shallowequal": "0.2.2"
+					}
+				},
+				"react-modal": {
+					"version": "1.9.7",
+					"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-1.9.7.tgz",
+					"integrity": "sha512-oZNqI0ZnPD7NnfObrCMz2hxHTAw5oEuhZJ+gnyFNIQB2rR8h1YbLQTfhms1mtSJigb0J23OOWElHjXYYaKO+wg==",
+					"requires": {
+						"create-react-class": "15.6.2",
+						"element-class": "0.2.2",
+						"exenv": "1.2.0",
+						"lodash.assign": "4.2.0",
+						"prop-types": "15.6.0",
+						"react-dom-factories": "1.0.2"
+					},
+					"dependencies": {
+						"exenv": {
+							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.0.tgz",
+							"integrity": "sha1-ODXxJ6vwdb/ggtCu1EhAV8eOPIk="
+						}
+					}
+				},
+				"react-simple-di": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/react-simple-di/-/react-simple-di-1.2.0.tgz",
+					"integrity": "sha1-3eDlv2ifOR7yqwLJBDshP+I5xtA=",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"hoist-non-react-statics": "1.2.0"
+					}
+				},
+				"react-split-pane": {
+					"version": "0.1.66",
+					"resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.66.tgz",
+					"integrity": "sha512-k4F0+BaHkPn0WclipkxEDL18Td2Ocgu+XzhOZznGngWk2l3mB5ujX7jxd5DSa8spHIuCGKQXzgjrk7rc2Y5BUQ==",
+					"requires": {
+						"inline-style-prefixer": "3.0.8",
+						"prop-types": "15.6.0",
+						"react-style-proptype": "3.0.0"
+					}
+				},
+				"react-stubber": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/react-stubber/-/react-stubber-1.0.0.tgz",
+					"integrity": "sha1-Qe4srHLU1P1wpjiW2pjhNzm4Rig=",
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"react-style-proptype": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.0.0.tgz",
+					"integrity": "sha1-ieC2RvJmxlarsPDdggLb1QNsMeY=",
+					"requires": {
+						"prop-types": "15.6.0"
+					}
+				},
+				"react-transition-group": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
+					"integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+					"requires": {
+						"chain-function": "1.0.0",
+						"dom-helpers": "3.2.1",
+						"loose-envify": "1.3.1",
+						"prop-types": "15.6.0",
+						"warning": "3.0.0"
+					}
+				},
+				"react-treebeard": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/react-treebeard/-/react-treebeard-2.0.3.tgz",
+					"integrity": "sha512-fqSmx0RPuUxvG5kQantyW89HnOCjz6e53o3AajuaXSVWL8O8tXNUCoSdxaO6xScXpujIV+iVaYUGBpOm5Pdhiw==",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"deep-equal": "1.0.1",
+						"prop-types": "15.6.0",
+						"radium": "0.19.5",
+						"shallowequal": "0.2.2",
+						"velocity-react": "1.3.3"
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+							"requires": {
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
+							}
+						},
+						"path-exists": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+							"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+							"requires": {
+								"pinkie-promise": "2.0.1"
+							}
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"readdirp": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+					"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"minimatch": "3.0.4",
+						"readable-stream": "2.3.3",
+						"set-immediate-shim": "1.0.1"
+					}
+				},
+				"recast": {
+					"version": "0.12.7",
+					"resolved": "https://registry.npmjs.org/recast/-/recast-0.12.7.tgz",
+					"integrity": "sha512-UgJBjELa0DaLUbblnIOPUj0UgdbetzYzrvWtHCXX8N5aCTHoMSx6ATkA2JH0hS7tP6dMJ5/CtVZEC4yW7V/8Dw==",
+					"requires": {
+						"ast-types": "0.9.12",
+						"core-js": "2.5.1",
+						"esprima": "4.0.0",
+						"private": "0.1.8",
+						"source-map": "0.6.1"
+					},
+					"dependencies": {
+						"core-js": {
+							"version": "2.5.1",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+							"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+						}
+					}
+				},
+				"rechoir": {
+					"version": "0.6.2",
+					"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+					"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+					"requires": {
+						"resolve": "1.4.0"
+					}
+				},
+				"reduce-css-calc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+					"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+					"requires": {
+						"balanced-match": "0.4.2",
+						"math-expression-evaluator": "1.2.17",
+						"reduce-function-call": "1.0.2"
+					},
+					"dependencies": {
+						"balanced-match": {
+							"version": "0.4.2",
+							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+							"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+						}
+					}
+				},
+				"reduce-function-call": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+					"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+					"requires": {
+						"balanced-match": "0.4.2"
+					},
+					"dependencies": {
+						"balanced-match": {
+							"version": "0.4.2",
+							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+							"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+						}
+					}
+				},
+				"redux": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+					"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+					"requires": {
+						"lodash": "4.17.4",
+						"lodash-es": "4.17.4",
+						"loose-envify": "1.3.1",
+						"symbol-observable": "1.0.4"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.4",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+						}
+					}
+				},
+				"regenerate": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+					"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+				},
+				"regenerator-runtime": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+					"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+				},
+				"regenerator-transform": {
+					"version": "0.10.1",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+					"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"private": "0.1.8"
+					}
+				},
+				"regex-cache": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+					"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+					"requires": {
+						"is-equal-shallow": "0.1.3"
+					}
+				},
+				"regexpu-core": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+					"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+					"requires": {
+						"regenerate": "1.3.3",
+						"regjsgen": "0.2.0",
+						"regjsparser": "0.1.5"
+					}
+				},
+				"regjsgen": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+				},
+				"regjsparser": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+					"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+					"requires": {
+						"jsesc": "0.5.0"
+					},
+					"dependencies": {
+						"jsesc": {
+							"version": "0.5.0",
+							"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+							"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+						}
+					}
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+					"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+					"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+				},
+				"repeating": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+					"requires": {
+						"is-finite": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.83.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+					"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+					"requires": {
+						"aws-sign2": "0.7.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.3.1",
+						"har-validator": "5.0.3",
+						"hawk": "6.0.2",
+						"http-signature": "1.2.0",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.17",
+						"oauth-sign": "0.8.2",
+						"performance-now": "2.1.0",
+						"qs": "6.5.1",
+						"safe-buffer": "5.1.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.3",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.1.0"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+				},
+				"require-from-string": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+					"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+				},
+				"resolve": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+					"requires": {
+						"path-parse": "1.0.5"
+					}
+				},
+				"right-align": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+					"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+					"requires": {
+						"align-text": "0.1.4"
+					}
+				},
+				"ripemd160": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+					"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+					"requires": {
+						"hash-base": "2.0.2",
+						"inherits": "2.0.3"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+				},
+				"sax": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+				},
+				"schema-utils": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+					"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+					"requires": {
+						"ajv": "5.2.3"
+					}
+				},
+				"semver": {
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+				},
+				"send": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+					"integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+					"requires": {
+						"debug": "2.6.9",
+						"depd": "1.1.1",
+						"destroy": "1.0.4",
+						"encodeurl": "1.0.1",
+						"escape-html": "1.0.3",
+						"etag": "1.8.1",
+						"fresh": "0.5.2",
+						"http-errors": "1.6.2",
+						"mime": "1.4.1",
+						"ms": "2.0.0",
+						"on-finished": "2.3.0",
+						"range-parser": "1.2.0",
+						"statuses": "1.3.1"
+					}
+				},
+				"serve-favicon": {
+					"version": "2.4.5",
+					"resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.5.tgz",
+					"integrity": "sha512-s7F8h2NrslMkG50KxvlGdj+ApSwaLex0vexuJ9iFf3GLTIp1ph/l1qZvRe9T9TJEYZgmq72ZwJ2VYiAEtChknw==",
+					"requires": {
+						"etag": "1.8.1",
+						"fresh": "0.5.2",
+						"ms": "2.0.0",
+						"parseurl": "1.3.2",
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"serve-static": {
+					"version": "1.13.1",
+					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+					"integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+					"requires": {
+						"encodeurl": "1.0.1",
+						"escape-html": "1.0.3",
+						"parseurl": "1.3.2",
+						"send": "0.16.1"
+					}
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+				},
+				"set-immediate-shim": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+					"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+				},
+				"setimmediate": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+				},
+				"sha.js": {
+					"version": "2.4.9",
+					"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
+					"integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+					"requires": {
+						"inherits": "2.0.3",
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"shallowequal": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
+					"integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
+					"requires": {
+						"lodash.keys": "3.1.2"
+					}
+				},
+				"shelljs": {
+					"version": "0.7.8",
+					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+					"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+					"requires": {
+						"glob": "7.1.2",
+						"interpret": "1.0.4",
+						"rechoir": "0.6.2"
+					}
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				},
+				"sntp": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+					"integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+					"requires": {
+						"hoek": "4.2.0"
+					}
+				},
+				"sort-keys": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+					"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+					"requires": {
+						"is-plain-obj": "1.1.0"
+					}
+				},
+				"source-list-map": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+					"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"source-map-support": {
+					"version": "0.4.18",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+					"requires": {
+						"source-map": "0.5.7"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						}
+					}
+				},
+				"spdx-correct": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+					"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+					"requires": {
+						"spdx-license-ids": "1.2.2"
+					}
+				},
+				"spdx-expression-parse": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+					"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+				},
+				"spdx-license-ids": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+					"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+				},
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+				},
+				"sshpk": {
+					"version": "1.13.1",
+					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+					"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"statuses": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+					"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+				},
+				"stream-browserify": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+					"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+					"requires": {
+						"inherits": "2.0.3",
+						"readable-stream": "2.3.3"
+					}
+				},
+				"stream-http": {
+					"version": "2.7.2",
+					"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+					"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+					"requires": {
+						"builtin-status-codes": "3.0.0",
+						"inherits": "2.0.3",
+						"readable-stream": "2.3.3",
+						"to-arraybuffer": "1.0.1",
+						"xtend": "4.0.1"
+					}
+				},
+				"strict-uri-encode": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+					"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"string.prototype.padend": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+					"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+					"requires": {
+						"define-properties": "1.1.2",
+						"es-abstract": "1.9.0",
+						"function-bind": "1.1.1"
+					}
+				},
+				"string.prototype.padstart": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.0.0.tgz",
+					"integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
+					"requires": {
+						"define-properties": "1.1.2",
+						"es-abstract": "1.9.0",
+						"function-bind": "1.1.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"style-loader": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.17.0.tgz",
+					"integrity": "sha1-6CVLzNt690vVgnTjYQe01atN8xA=",
+					"requires": {
+						"loader-utils": "1.1.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				},
+				"svg-tag-names": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/svg-tag-names/-/svg-tag-names-1.1.1.tgz",
+					"integrity": "sha1-lkGynvcQJe4JTHBD983efZn71Qo="
+				},
+				"svgo": {
+					"version": "0.7.2",
+					"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+					"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+					"requires": {
+						"coa": "1.0.4",
+						"colors": "1.1.2",
+						"csso": "2.3.2",
+						"js-yaml": "3.7.0",
+						"mkdirp": "0.5.1",
+						"sax": "1.2.4",
+						"whet.extend": "0.9.9"
+					}
+				},
+				"symbol-observable": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+					"integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
+				},
+				"tapable": {
+					"version": "0.2.8",
+					"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+					"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+				},
+				"through": {
+					"version": "2.3.8",
+					"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+				},
+				"time-stamp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+					"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
+				},
+				"timers-browserify": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
+					"integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+					"requires": {
+						"setimmediate": "1.0.5"
+					}
+				},
+				"to-arraybuffer": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+					"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+				},
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+				},
+				"tough-cookie": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+					"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"trim-right": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+				},
+				"tty-browserify": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+					"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+					"optional": true
+				},
+				"type-is": {
+					"version": "1.6.15",
+					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+					"integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+					"requires": {
+						"media-typer": "0.3.0",
+						"mime-types": "2.1.17"
+					}
+				},
+				"ua-parser-js": {
+					"version": "0.7.17",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+					"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+					"requires": {
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"yargs": {
+							"version": "3.10.0",
+							"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+							"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+							"requires": {
+								"camelcase": "1.2.1",
+								"cliui": "2.1.0",
+								"decamelize": "1.2.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglify-to-browserify": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+					"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+					"optional": true
+				},
+				"uniq": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+					"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+				},
+				"uniqid": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+					"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+					"requires": {
+						"macaddress": "0.2.8"
+					}
+				},
+				"uniqs": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+					"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
+				},
+				"unique-string": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+					"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+					"requires": {
+						"crypto-random-string": "1.0.0"
+					}
+				},
+				"unpipe": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+					"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+				},
+				"url": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+					"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+					"requires": {
+						"punycode": "1.3.2",
+						"querystring": "0.2.0"
+					},
+					"dependencies": {
+						"punycode": {
+							"version": "1.3.2",
+							"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+							"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+						}
+					}
+				},
+				"url-loader": {
+					"version": "0.5.9",
+					"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
+					"integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
+					"requires": {
+						"loader-utils": "1.1.0",
+						"mime": "1.3.6"
+					},
+					"dependencies": {
+						"mime": {
+							"version": "1.3.6",
+							"resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+							"integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
+						}
+					}
+				},
+				"util": {
+					"version": "0.10.3",
+					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+					"requires": {
+						"inherits": "2.0.1"
+					},
+					"dependencies": {
+						"inherits": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+							"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+						}
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+				},
+				"utils-merge": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+					"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+				},
+				"uuid": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+					"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+					"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+					"requires": {
+						"spdx-correct": "1.0.2",
+						"spdx-expression-parse": "1.0.4"
+					}
+				},
+				"vary": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+					"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+				},
+				"velocity-animate": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/velocity-animate/-/velocity-animate-1.5.0.tgz",
+					"integrity": "sha1-/Idx2N/hE2/wKnB+EPuwlXxLAw8="
+				},
+				"velocity-react": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/velocity-react/-/velocity-react-1.3.3.tgz",
+					"integrity": "sha1-1tRyds/Ivip1Yjh5sgFArFjBuCs=",
+					"requires": {
+						"lodash": "3.10.1",
+						"prop-types": "15.6.0",
+						"react-transition-group": "1.2.1",
+						"velocity-animate": "1.5.0"
+					}
+				},
+				"vendors": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+					"integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI="
+				},
+				"verror": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+					"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+					"requires": {
+						"assert-plus": "1.0.0",
+						"core-util-is": "1.0.2",
+						"extsprintf": "1.3.0"
+					}
+				},
+				"vm-browserify": {
+					"version": "0.0.4",
+					"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+					"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+					"requires": {
+						"indexof": "0.0.1"
+					}
+				},
+				"warning": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+					"requires": {
+						"loose-envify": "1.3.1"
+					}
+				},
+				"watchpack": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
+					"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+					"requires": {
+						"async": "2.5.0",
+						"chokidar": "1.7.0",
+						"graceful-fs": "4.1.11"
+					}
+				},
+				"webpack": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
+					"integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
+					"requires": {
+						"acorn": "5.1.2",
+						"acorn-dynamic-import": "2.0.2",
+						"ajv": "4.11.8",
+						"ajv-keywords": "1.5.1",
+						"async": "2.5.0",
+						"enhanced-resolve": "3.4.1",
+						"interpret": "1.0.4",
+						"json-loader": "0.5.7",
+						"json5": "0.5.1",
+						"loader-runner": "2.3.0",
+						"loader-utils": "0.2.17",
+						"memory-fs": "0.4.1",
+						"mkdirp": "0.5.1",
+						"node-libs-browser": "2.0.0",
+						"source-map": "0.5.7",
+						"supports-color": "3.2.3",
+						"tapable": "0.2.8",
+						"uglify-js": "2.8.29",
+						"watchpack": "1.4.0",
+						"webpack-sources": "1.0.1",
+						"yargs": "6.6.0"
+					},
+					"dependencies": {
+						"ajv": {
+							"version": "4.11.8",
+							"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+							"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+							"requires": {
+								"co": "4.6.0",
+								"json-stable-stringify": "1.0.1"
+							}
+						},
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+						},
+						"loader-utils": {
+							"version": "0.2.17",
+							"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+							"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+							"requires": {
+								"big.js": "3.2.0",
+								"emojis-list": "2.1.0",
+								"json5": "0.5.1",
+								"object-assign": "4.1.1"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"webpack-dev-middleware": {
+					"version": "1.12.0",
+					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
+					"integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
+					"requires": {
+						"memory-fs": "0.4.1",
+						"mime": "1.4.1",
+						"path-is-absolute": "1.0.1",
+						"range-parser": "1.2.0",
+						"time-stamp": "2.0.0"
+					}
+				},
+				"webpack-hot-middleware": {
+					"version": "2.20.0",
+					"resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.20.0.tgz",
+					"integrity": "sha512-AYwVG9DCvMoXbwx8eK16CbJY3Ltwap44lW3T7hFsE0U3zRwtViHMw1DFpY5hMwXNqKsUk3HtNcf3PoV+gIxJeg==",
+					"requires": {
+						"ansi-html": "0.0.7",
+						"html-entities": "1.2.1",
+						"querystring": "0.2.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"webpack-sources": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
+					"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+					"requires": {
+						"source-list-map": "2.0.0",
+						"source-map": "0.5.7"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						}
+					}
+				},
+				"whatwg-fetch": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+					"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+				},
+				"whet.extend": {
+					"version": "0.9.9",
+					"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+					"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
+				},
+				"which-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+				},
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+				},
+				"write-file-atomic": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"signal-exit": "3.0.2"
+					}
+				},
+				"xdg-basedir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+					"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+				},
+				"xtend": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+					"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				},
+				"yargs": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+					"requires": {
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "4.2.1"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+						},
+						"cliui": {
+							"version": "3.2.0",
+							"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+							"requires": {
+								"string-width": "1.0.2",
+								"strip-ansi": "3.0.1",
+								"wrap-ansi": "2.1.0"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+					"requires": {
+						"camelcase": "3.0.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+						}
+					}
+				}
+			}
+		},
+		"fetch-jsonp": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/fetch-jsonp/-/fetch-jsonp-1.0.3.tgz",
+			"integrity": "sha1-ckRY8cb8j/9UYv0LWwH1Fpuu7Js="
+		},
+		"flux": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/flux/-/flux-2.1.1.tgz",
+			"integrity": "sha1-LGrGUtQzdIiWhInGWG86/yajjqQ=",
+			"requires": {
+				"fbemitter": "2.1.1",
+				"fbjs": "0.1.0-alpha.7",
+				"immutable": "3.7.6"
+			},
+			"dependencies": {
+				"asap": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+				},
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				},
+				"encoding": {
+					"version": "0.1.12",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"requires": {
+						"iconv-lite": "0.4.19"
+					}
+				},
+				"fbemitter": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
+					"integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
+					"requires": {
+						"fbjs": "0.8.16"
+					},
+					"dependencies": {
+						"fbjs": {
+							"version": "0.8.16",
+							"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+							"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+							"requires": {
+								"core-js": "1.2.7",
+								"isomorphic-fetch": "2.2.1",
+								"loose-envify": "1.3.1",
+								"object-assign": "4.1.1",
+								"promise": "7.3.1",
+								"setimmediate": "1.0.5",
+								"ua-parser-js": "0.7.17"
+							}
+						}
+					}
+				},
+				"fbjs": {
+					"version": "0.1.0-alpha.7",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz",
+					"integrity": "sha1-rUMIuPIy+zxzYDNJ6nJdHpw5Mjw=",
+					"requires": {
+						"core-js": "1.2.7",
+						"promise": "7.3.1",
+						"whatwg-fetch": "0.9.0"
+					},
+					"dependencies": {
+						"whatwg-fetch": {
+							"version": "0.9.0",
+							"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
+							"integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA="
+						}
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+				},
+				"isomorphic-fetch": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+					"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+					"requires": {
+						"node-fetch": "1.7.3",
+						"whatwg-fetch": "2.0.3"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"requires": {
+						"js-tokens": "3.0.2"
+					}
+				},
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "0.1.12",
+						"is-stream": "1.1.0"
+					}
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"promise": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+					"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+					"requires": {
+						"asap": "2.0.6"
+					}
+				},
+				"setimmediate": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+				},
+				"ua-parser-js": {
+					"version": "0.7.17",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+					"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+				},
+				"whatwg-fetch": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+					"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+				}
+			}
+		},
+		"immutable": {
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+			"integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
+		},
+		"lodash.clonedeep": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.3.2.tgz",
+			"integrity": "sha1-0BEsAsdrUiODOuvGpLbjNPDQV94=",
+			"requires": {
+				"lodash._baseclone": "4.5.7"
+			},
+			"dependencies": {
+				"lodash._baseclone": {
+					"version": "4.5.7",
+					"resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.7.tgz",
+					"integrity": "sha1-zkKt4IOE711i+nfDD2GkbmhvhDQ="
+				}
+			}
+		},
+		"lru-cache": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+			"integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			},
+			"dependencies": {
+				"pseudomap": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+				}
+			}
+		},
+		"moment": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.16.0.tgz",
+			"integrity": "sha1-848sl8mImw7hj8bMOS4eRDrS2o4="
+		},
+		"moment-timezone": {
+			"version": "0.5.12",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.12.tgz",
+			"integrity": "sha1-2Nb6UbNlBQ3hrHzFxuP6lpRE7eo=",
+			"requires": {
+				"moment": "2.16.0"
+			}
+		},
+		"react-day-picker": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-6.1.1.tgz",
+			"integrity": "sha512-QZKp9QzPPGAPW1jsUV1LYhRwnE//bdUL4boq0A+VTPLOsrnJ4E5oJmla5mcYxya/lljdZdWquRn2VWo7+rimtg==",
+			"requires": {
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.0"
+			},
+			"dependencies": {
+				"asap": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+				},
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				},
+				"encoding": {
+					"version": "0.1.12",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"requires": {
+						"iconv-lite": "0.4.19"
+					}
+				},
+				"fbjs": {
+					"version": "0.8.16",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+					"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+					"requires": {
+						"core-js": "1.2.7",
+						"isomorphic-fetch": "2.2.1",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1",
+						"promise": "7.3.1",
+						"setimmediate": "1.0.5",
+						"ua-parser-js": "0.7.17"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+				},
+				"isomorphic-fetch": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+					"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+					"requires": {
+						"node-fetch": "1.7.3",
+						"whatwg-fetch": "2.0.3"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"requires": {
+						"js-tokens": "3.0.2"
+					}
+				},
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "0.1.12",
+						"is-stream": "1.1.0"
+					}
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"promise": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+					"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+					"requires": {
+						"asap": "2.0.6"
+					}
+				},
+				"prop-types": {
+					"version": "15.6.0",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+					"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+					"requires": {
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
+					}
+				},
+				"setimmediate": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+				},
+				"ua-parser-js": {
+					"version": "0.7.17",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+					"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+				},
+				"whatwg-fetch": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+					"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+				}
+			}
+		},
+		"react-test-renderer": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.0.0.tgz",
+			"integrity": "sha1-n+e4MI8vcfKfw1bUECCG8THJyxU=",
+			"requires": {
+				"fbjs": "0.8.16",
+				"object-assign": "4.1.1"
+			},
+			"dependencies": {
+				"asap": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+				},
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				},
+				"encoding": {
+					"version": "0.1.12",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"requires": {
+						"iconv-lite": "0.4.19"
+					}
+				},
+				"fbjs": {
+					"version": "0.8.16",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+					"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+					"requires": {
+						"core-js": "1.2.7",
+						"isomorphic-fetch": "2.2.1",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1",
+						"promise": "7.3.1",
+						"setimmediate": "1.0.5",
+						"ua-parser-js": "0.7.17"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+				},
+				"isomorphic-fetch": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+					"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+					"requires": {
+						"node-fetch": "1.7.3",
+						"whatwg-fetch": "2.0.3"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"requires": {
+						"js-tokens": "3.0.2"
+					}
+				},
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "0.1.12",
+						"is-stream": "1.1.0"
+					}
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"promise": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+					"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+					"requires": {
+						"asap": "2.0.6"
+					}
+				},
+				"setimmediate": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+				},
+				"ua-parser-js": {
+					"version": "0.7.17",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+					"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+				},
+				"whatwg-fetch": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+					"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+				}
+			}
+		}
+	}
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,6 +18,7 @@
     "body-parser": "1.17.2",
     "bugsnag": "1.11.0",
     "cookie-parser": "1.4.3",
+    "node-dogstatsd": "0.0.6",
     "express": "4.15.3",
     "jsonwebtoken": "7.4.1",
     "micro": "7.3.3",

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -19,6 +19,7 @@ const requeuePost = require('./requeuePost');
 const updatePausedSchedules = require('./updatePausedSchedules');
 const sendFeedback = require('./sendFeedback');
 const savePublishBetaRedirect = require('./savePublishBetaRedirect');
+const performanceTrackingMethod = require('./performanceTracking');
 
 module.exports = checkToken(rpc(
   profilesMethod,
@@ -40,4 +41,5 @@ module.exports = checkToken(rpc(
   updatePausedSchedules,
   sendFeedback,
   savePublishBetaRedirect,
+  performanceTrackingMethod,
 ));

--- a/packages/server/rpc/performanceTracking/index.js
+++ b/packages/server/rpc/performanceTracking/index.js
@@ -6,18 +6,21 @@ const dogstatsd = new StatsD('dd-agent.default');
 module.exports = method(
   'performance',
   'track performance',
-  ({ data }) => {
-    if (!data.tags) data.tags = [];
-    if (!data.name) throw createError({ message: 'can\'t save a measure without a valid data.name' });
-    if (!data.duration) throw createError({ message: 'can\'t save a measure without a valid data.duration' });
-    data.tags.push('app:publish');
-    data.name = `buffer.perf.${data.name}`;
+  ({ measures }) => {
+    const processedMeasures = measures.map((data) => {
+      if (!data.tags) data.tags = [];
+      if (!data.name) throw createError({ message: 'can\'t save a measure without a valid data.name' });
+      if (!data.duration) throw createError({ message: 'can\'t save a measure without a valid data.duration' });
+      data.tags.push('app:publish');
+      data.name = `buffer.perf.${data.name}`;
 
-    dogstatsd.histogram(
-      data.name,
-      data.duration,
-      1,
-      data.tags,
-    );
-    return data;
+      dogstatsd.histogram(
+        data.name,
+        data.duration,
+        1,
+        data.tags,
+      );
+      return data;
+    });
+    return processedMeasures;
   });

--- a/packages/server/rpc/performanceTracking/index.js
+++ b/packages/server/rpc/performanceTracking/index.js
@@ -1,4 +1,4 @@
-const { method } = require('@bufferapp/micro-rpc');
+const { method, createError } = require('@bufferapp/micro-rpc');
 const StatsD = require('node-dogstatsd').StatsD;
 
 const dogstatsd = new StatsD('dd-agent.default');
@@ -8,6 +8,8 @@ module.exports = method(
   'track performance',
   ({ data }) => {
     if (!data.tags) data.tags = [];
+    if (!data.name) throw createError({ message: 'can\'t save a measure without a valid data.name' });
+    if (!data.duration) throw createError({ message: 'can\'t save a measure without a valid data.duration' });
     data.tags.push('app:publish');
     data.name = `buffer.perf.${data.name}`;
 

--- a/packages/server/rpc/performanceTracking/index.js
+++ b/packages/server/rpc/performanceTracking/index.js
@@ -1,0 +1,21 @@
+const { method } = require('@bufferapp/micro-rpc');
+const StatsD = require('node-dogstatsd').StatsD;
+
+const dogstatsd = new StatsD('dd-agent.default');
+
+module.exports = method(
+  'performance',
+  'track performance',
+  ({ data }) => {
+    if (!data.tags) data.tags = [];
+    data.tags.push('app:publish');
+    data.name = `buffer.perf.${data.name}`;
+
+    dogstatsd.histogram(
+      data.name,
+      data.duration,
+      1,
+      data.tags,
+    );
+    return data;
+  });

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = {
       },
       {
         test: /\.jsx?$/,
-        exclude: /node_modules(?!\/@bufferapp\/components)(?!\/@bufferapp\/web-components)(?!\/@bufferapp\/composer)/,
+        exclude: /node_modules(?!\/@bufferapp\/performance-tracking)(?!\/@bufferapp\/async-data-fetch)(?!\/@bufferapp\/components)(?!\/@bufferapp\/web-components)(?!\/@bufferapp\/composer)/,
         loader: 'babel-loader',
         query: {
           presets: ['es2015', 'stage-0', 'react'],

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -18,6 +18,7 @@ import { middleware as environmentMiddleware } from '@bufferapp/environment';
 import { middleware as unauthorizedRedirectMiddleware } from '@bufferapp/unauthorized-redirect';
 import { middleware as appSwitcherMiddleware } from '@bufferapp/publish-app-switcher';
 import { middleware as betaRedirectMiddleware } from '@bufferapp/publish-beta-redirect';
+import performanceMiddleware from '@bufferapp/performance-tracking/middleware';
 import reducers from './reducers';
 
 export const history = createHistory();
@@ -37,6 +38,7 @@ const configureStore = (initialstate) => {
         asyncDataFetchMiddleware,
         i18nMiddleware,
         profileSidebarMiddleware,
+        performanceMiddleware,
         appSidebarMiddleware,
         queueMiddleware,
         sentMiddleware,

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -14,6 +14,7 @@
     "@bufferapp/async-data-fetch": "1.2.7",
     "@bufferapp/environment": "1.2.7",
     "@bufferapp/notifications": "1.2.7",
+    "@bufferapp/performance-tracking": "^0.1.0",
     "@bufferapp/publish-app-switcher": "1.2.7",
     "@bufferapp/publish-beta-redirect": "1.2.9",
     "@bufferapp/publish-example": "1.2.7",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -14,7 +14,7 @@
     "@bufferapp/async-data-fetch": "1.2.7",
     "@bufferapp/environment": "1.2.7",
     "@bufferapp/notifications": "1.2.7",
-    "@bufferapp/performance-tracking": "^0.1.0",
+    "@bufferapp/performance-tracking": "0.43.5",
     "@bufferapp/publish-app-switcher": "1.2.7",
     "@bufferapp/publish-beta-redirect": "1.2.9",
     "@bufferapp/publish-example": "1.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@bufferapp/async-data-fetch@0.5.36-beta01":
+  version "0.5.36-beta01"
+  resolved "https://registry.yarnpkg.com/@bufferapp/async-data-fetch/-/async-data-fetch-0.5.36-beta01.tgz#684504ddc303577c42b0ba350d854990d6bd1ad1"
+
 "@bufferapp/buffer-js-api@0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@bufferapp/buffer-js-api/-/buffer-js-api-0.3.0.tgz#7bb43ef9c3a5d3ce6cdc93674dd89ba81a8d0121"
@@ -19,6 +23,10 @@
   resolved "https://registry.yarnpkg.com/@bufferapp/buffer-js-request/-/buffer-js-request-0.2.0.tgz#b7492f538da364a664e46e6d49c679dfa37dbe3e"
   dependencies:
     whatwg-fetch "0.11.1"
+
+"@bufferapp/chronos@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@bufferapp/chronos/-/chronos-0.6.1.tgz#0213dff339459ca510103e5a72f558682a2675dd"
 
 "@bufferapp/components@1.1.0-beta.6":
   version "1.1.0-beta.6"
@@ -119,6 +127,13 @@
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@bufferapp/micro-rpc/-/micro-rpc-0.1.6.tgz#104417af8c4940c92d45164cc097d5d38fd7d957"
 
+"@bufferapp/performance-tracking@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@bufferapp/performance-tracking/-/performance-tracking-0.1.0.tgz#b64c3a17f58eebeeeaa86dba93255d8b2b6e27e5"
+  dependencies:
+    "@bufferapp/async-data-fetch" "0.5.36-beta01"
+    "@bufferapp/chronos" "0.6.1"
+
 "@bufferapp/react-images-loaded@^1.1.0-fork.0":
   version "1.1.0-fork.0"
   resolved "https://registry.yarnpkg.com/@bufferapp/react-images-loaded/-/react-images-loaded-1.1.0-fork.0.tgz#fb3e2e13df30c806cf17ebf11b19a20d32c02e46"
@@ -143,24 +158,26 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@bufferapp/shutdown-helper/-/shutdown-helper-0.2.0.tgz#d43bbba845e30e411dda76a7b7629e11160e5395"
 
-"@storybook/addon-actions@^3.1.2", "@storybook/addon-actions@^3.3.9":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.3.9.tgz#2b191548928467fe1dd26dcba606feafbf182d36"
+"@hypnosphi/fuse.js@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz#ea99f6121b4a8f065b4c71f85595db2714498807"
+
+"@storybook/addon-actions@^3.1.2", "@storybook/addon-actions@^3.2.17":
+  version "3.2.17"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.2.17.tgz#e85d38f743125157fdaf6669708e089bc2008e50"
   dependencies:
+    "@storybook/addons" "^3.2.17"
     deep-equal "^1.0.1"
-    global "^4.3.2"
-    make-error "^1.3.2"
+    json-stringify-safe "^5.0.1"
     prop-types "^15.6.0"
-    react-inspector "^2.2.2"
+    react-inspector "^2.2.1"
     uuid "^3.1.0"
 
-"@storybook/addon-links@^3.1.2", "@storybook/addon-links@^3.3.9":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.3.9.tgz#13781ac1c21ddfe347ece6ceab8518c8d1f98a0f"
+"@storybook/addon-links@^3.1.2", "@storybook/addon-links@^3.2.17":
+  version "3.2.17"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.2.17.tgz#fb1d5f5f16575e56d560955d70c2a756c9f5b612"
   dependencies:
-    "@storybook/components" "^3.3.9"
-    global "^4.3.2"
-    prop-types "^15.5.10"
+    "@storybook/addons" "^3.2.17"
 
 "@storybook/addon-storyshots@3.1.4":
   version "3.1.4"
@@ -171,35 +188,31 @@
     prop-types "^15.5.8"
     read-pkg-up "^2.0.0"
 
-"@storybook/addons@^3.1.2", "@storybook/addons@^3.3.9":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.3.9.tgz#356ce7f1de892d88ca4bc5f686d06e07dd8c2108"
+"@storybook/addons@^3.1.2", "@storybook/addons@^3.2.17":
+  version "3.2.17"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.2.17.tgz#5c2ece24c5f7fbf7cedf4cfe503c5e356543e62d"
 
-"@storybook/channel-postmessage@^3.1.2", "@storybook/channel-postmessage@^3.3.9":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-3.3.9.tgz#a59220f9ecbdbe05deac6ac4339715aa587d41dd"
+"@storybook/channel-postmessage@^3.1.2", "@storybook/channel-postmessage@^3.2.17":
+  version "3.2.17"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-3.2.17.tgz#530c1d6852b2c77df08490988fa943ba1373b1ec"
   dependencies:
-    "@storybook/channels" "^3.3.9"
+    "@storybook/channels" "^3.2.17"
     global "^4.3.2"
     json-stringify-safe "^5.0.1"
 
-"@storybook/channels@^3.3.9":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.3.9.tgz#3116a6c5e441fd057558870b254c34fe3a9fbfb0"
+"@storybook/channels@^3.2.17":
+  version "3.2.17"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.2.17.tgz#09219a512564d1aa2292419d8d6064dbf7f5a5b3"
 
-"@storybook/client-logger@^3.3.9":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-3.3.9.tgz#a73e382c383c1bfa6d2ff7fa5cae77cd09efa524"
-
-"@storybook/components@^3.3.9":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.3.9.tgz#1f7ced8b10a0e405c1d3fd6fe7ef7b8957ddf89f"
+"@storybook/components@^3.2.17":
+  version "3.2.17"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.2.17.tgz#318c6e6a1d3ffb469523b5dcfee775639ccc500b"
   dependencies:
     glamor "^2.20.40"
-    glamorous "^4.11.2"
+    glamorous "^4.11.0"
     prop-types "^15.6.0"
 
-"@storybook/mantra-core@^1.7.2":
+"@storybook/mantra-core@^1.7.0":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@storybook/mantra-core/-/mantra-core-1.7.2.tgz#e10c7faca29769e97131e0e0308ef7cfb655b70c"
   dependencies:
@@ -207,14 +220,16 @@
     "@storybook/react-simple-di" "^1.2.1"
     babel-runtime "6.x.x"
 
-"@storybook/node-logger@^3.3.9":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-3.3.9.tgz#c070ef5ced91b1b1aa7bb3e402855db277ed426b"
+"@storybook/react-fuzzy@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/react-fuzzy/-/react-fuzzy-0.4.3.tgz#36f7536ba97bf08b03cb57f47c58ae2cca330aec"
   dependencies:
-    chalk "^2.3.0"
-    npmlog "^4.1.2"
+    babel-runtime "^6.23.0"
+    classnames "^2.2.5"
+    fuse.js "^3.0.1"
+    prop-types "^15.5.9"
 
-"@storybook/react-komposer@^2.0.1", "@storybook/react-komposer@^2.0.3":
+"@storybook/react-komposer@^2.0.0", "@storybook/react-komposer@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@storybook/react-komposer/-/react-komposer-2.0.3.tgz#f9e12a9586b2ce95c24c137eabb8b71527ddb369"
   dependencies:
@@ -291,18 +306,17 @@
     webpack-hot-middleware "^2.18.0"
 
 "@storybook/react@^3.0.0":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-3.3.9.tgz#2bd203a5b3c5e5fad4a756ca41d78e62cd49b160"
+  version "3.2.17"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-3.2.17.tgz#c7b0595efef049d4dae89202994c17f332ee4662"
   dependencies:
-    "@storybook/addon-actions" "^3.3.9"
-    "@storybook/addon-links" "^3.3.9"
-    "@storybook/addons" "^3.3.9"
-    "@storybook/channel-postmessage" "^3.3.9"
-    "@storybook/client-logger" "^3.3.9"
-    "@storybook/node-logger" "^3.3.9"
-    "@storybook/ui" "^3.3.9"
-    airbnb-js-shims "^1.4.0"
-    autoprefixer "^7.2.3"
+    "@storybook/addon-actions" "^3.2.17"
+    "@storybook/addon-links" "^3.2.17"
+    "@storybook/addons" "^3.2.17"
+    "@storybook/channel-postmessage" "^3.2.17"
+    "@storybook/ui" "^3.2.17"
+    airbnb-js-shims "^1.3.0"
+    autoprefixer "^7.1.6"
+    babel-core "^6.26.0"
     babel-loader "^7.1.2"
     babel-plugin-react-docgen "^1.8.0"
     babel-plugin-transform-regenerator "^6.26.0"
@@ -315,26 +329,23 @@
     babel-runtime "^6.26.0"
     case-sensitive-paths-webpack-plugin "^2.1.1"
     chalk "^2.3.0"
-    commander "^2.12.2"
-    common-tags "^1.6.0"
+    commander "^2.12.1"
+    common-tags "^1.5.1"
     configstore "^3.1.1"
-    core-js "^2.5.3"
-    css-loader "^0.28.8"
+    core-js "^2.5.1"
+    css-loader "^0.28.7"
     dotenv-webpack "^1.5.4"
     express "^4.16.2"
-    file-loader "^1.1.6"
+    file-loader "^1.1.5"
     find-cache-dir "^1.0.0"
     glamor "^2.20.40"
-    glamorous "^4.11.2"
+    glamorous "^4.11.0"
     global "^4.3.2"
-    html-loader "^0.5.4"
-    html-webpack-plugin "^2.30.1"
     json-loader "^0.5.7"
     json-stringify-safe "^5.0.1"
     json5 "^0.5.1"
     lodash.flattendeep "^4.4.0"
-    markdown-loader "^2.0.1"
-    npmlog "^4.1.2"
+    lodash.pick "^4.4.0"
     postcss-flexbugs-fixes "^3.2.0"
     postcss-loader "^2.0.9"
     prop-types "^15.6.0"
@@ -343,41 +354,40 @@
     request "^2.83.0"
     serve-favicon "^2.4.5"
     shelljs "^0.7.8"
-    style-loader "^0.19.1"
-    uglifyjs-webpack-plugin "^1.1.6"
+    style-loader "^0.18.2"
     url-loader "^0.6.2"
     util-deprecate "^1.0.2"
     uuid "^3.1.0"
-    webpack "^3.10.0"
+    webpack "^3.8.1"
     webpack-dev-middleware "^1.12.2"
     webpack-hot-middleware "^2.21.0"
 
-"@storybook/ui@^3.1.3", "@storybook/ui@^3.3.9":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.3.9.tgz#abb1df557131b174bf3c0879863a309ee85de8e3"
+"@storybook/ui@^3.1.3", "@storybook/ui@^3.2.17":
+  version "3.2.17"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.2.17.tgz#8838fc5bbe21cedfafc65ee90fe525499370118a"
   dependencies:
-    "@storybook/components" "^3.3.9"
-    "@storybook/mantra-core" "^1.7.2"
-    "@storybook/react-komposer" "^2.0.3"
+    "@hypnosphi/fuse.js" "^3.0.9"
+    "@storybook/components" "^3.2.17"
+    "@storybook/mantra-core" "^1.7.0"
+    "@storybook/react-fuzzy" "^0.4.3"
+    "@storybook/react-komposer" "^2.0.0"
     babel-runtime "^6.26.0"
     deep-equal "^1.0.1"
     events "^1.1.1"
-    fuse.js "^3.2.0"
     global "^4.3.2"
     json-stringify-safe "^5.0.1"
-    keycode "^2.1.9"
+    keycode "^2.1.8"
     lodash.debounce "^4.0.8"
     lodash.pick "^4.4.0"
     lodash.sortby "^4.7.0"
     podda "^1.2.2"
     prop-types "^15.6.0"
     qs "^6.5.1"
-    react-fuzzy "^0.5.1"
     react-icons "^2.2.7"
-    react-inspector "^2.2.2"
-    react-modal "^3.1.10"
-    react-split-pane "^0.1.74"
-    react-treebeard "^2.1.0"
+    react-inspector "^2.2.1"
+    react-modal "^3.1.4"
+    react-split-pane "^0.1.71"
+    react-treebeard "^2.0.3"
     redux "^3.7.2"
 
 "@types/inline-style-prefixer@^3.0.0":
@@ -389,8 +399,8 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
 
 "@types/react@^16.0.18":
-  version "16.0.34"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.34.tgz#7a8f795afd8a404a9c4af9539b24c75d3996914e"
+  version "16.0.28"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.28.tgz#eb0b31272528da8f20477ec27569c4f767315b33"
 
 JSONStream@^1.0.4:
   version "1.3.1"
@@ -452,7 +462,7 @@ add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
 
-airbnb-js-shims@^1.1.1, airbnb-js-shims@^1.4.0:
+airbnb-js-shims@^1.1.1, airbnb-js-shims@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/airbnb-js-shims/-/airbnb-js-shims-1.4.0.tgz#b920b0bc9fafe8b8ae2a073f29fb10303b1b2b18"
   dependencies:
@@ -473,7 +483,7 @@ ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
-ajv-keywords@^2.0.0, ajv-keywords@^2.1.0:
+ajv-keywords@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
@@ -484,18 +494,9 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0:
+ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.1.tgz#b38bb8876d9e86bee994956a04e721e88b248eb2"
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-
-ajv@^5.1.0, ajv@^5.1.5:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -577,10 +578,6 @@ append-transform@^0.4.0:
 aproba@^1.0.3:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
-
-aproba@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
 
 are-we-there-yet@~1.1.2:
   version "1.1.4"
@@ -731,10 +728,6 @@ ast-types@0.10.1:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.10.1.tgz#f52fca9715579a14f841d67d7f8d25432ab6a3dd"
 
-ast-types@0.9.6:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
-
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -790,15 +783,15 @@ autoprefixer@^6.0.2, autoprefixer@^6.3.1:
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
 
-autoprefixer@^7.1.1, autoprefixer@^7.2.3:
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.5.tgz#04ccbd0c6a61131b6d13f53d371926092952d192"
+autoprefixer@^7.1.1, autoprefixer@^7.1.6:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.2.tgz#082293b964be00602efacc59aa4aa7df5158bb6e"
   dependencies:
-    browserslist "^2.11.1"
-    caniuse-lite "^1.0.30000791"
+    browserslist "^2.10.0"
+    caniuse-lite "^1.0.30000780"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^6.0.16"
+    postcss "^6.0.14"
     postcss-value-parser "^3.2.3"
 
 aws-sign2@~0.6.0:
@@ -1223,12 +1216,12 @@ babel-plugin-minify-type-constructors@^0.2.0:
     babel-helper-is-void-0 "^0.2.0"
 
 babel-plugin-react-docgen@^1.5.0, babel-plugin-react-docgen@^1.8.0:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.8.2.tgz#4615da43588c8cf5bdcae028f217954c70e6770b"
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.8.1.tgz#6e08e057f5dcd46b434e7553e971baa604dae377"
   dependencies:
     babel-types "^6.24.1"
-    lodash "^4.17.0"
-    react-docgen "^2.20.0"
+    lodash "4.x.x"
+    react-docgen "^2.15.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -1389,7 +1382,7 @@ babel-plugin-transform-es2015-computed-properties@^6.22.0, babel-plugin-transfor
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-destructuring@6.23.0, babel-plugin-transform-es2015-destructuring@^6.22.0, babel-plugin-transform-es2015-destructuring@^6.23.0:
+babel-plugin-transform-es2015-destructuring@^6.22.0, babel-plugin-transform-es2015-destructuring@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:
@@ -1828,13 +1821,12 @@ babel-preset-minify@^0.2.0:
     lodash.isplainobject "^4.0.6"
 
 babel-preset-react-app@^3.0.0, babel-preset-react-app@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-3.1.1.tgz#d3f06a79742f0e89d7afcb72e282d9809c850920"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-3.1.0.tgz#d77f6061ab9d7bf4b3cdc86b7cde9ded0df03e48"
   dependencies:
     babel-plugin-dynamic-import-node "1.1.0"
     babel-plugin-syntax-dynamic-import "6.18.0"
     babel-plugin-transform-class-properties "6.24.1"
-    babel-plugin-transform-es2015-destructuring "6.23.0"
     babel-plugin-transform-object-rest-spread "6.26.0"
     babel-plugin-transform-react-constant-elements "6.23.0"
     babel-plugin-transform-react-jsx "6.24.1"
@@ -2065,10 +2057,6 @@ bluebird@3.5.0, bluebird@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
-bluebird@^3.4.7:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -2251,12 +2239,12 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
-browserslist@^2.1.2, browserslist@^2.11.1:
-  version "2.11.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
+browserslist@^2.1.2, browserslist@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.10.0.tgz#bac5ee1cc69ca9d96403ffb8a3abdc5b6aed6346"
   dependencies:
-    caniuse-lite "^1.0.30000792"
-    electron-to-chromium "^1.3.30"
+    caniuse-lite "^1.0.30000780"
+    electron-to-chromium "^1.3.28"
 
 bser@1.0.2:
   version "1.0.2"
@@ -2327,24 +2315,6 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
-cacache@^10.0.1:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-10.0.2.tgz#105a93a162bbedf3a25da42e1939ed99ffb145f8"
-  dependencies:
-    bluebird "^3.5.0"
-    chownr "^1.0.1"
-    glob "^7.1.2"
-    graceful-fs "^4.1.11"
-    lru-cache "^4.1.1"
-    mississippi "^1.3.0"
-    mkdirp "^0.5.1"
-    move-concurrently "^1.0.1"
-    promise-inflight "^1.0.1"
-    rimraf "^2.6.1"
-    ssri "^5.0.0"
-    unique-filename "^1.1.0"
-    y18n "^3.2.1"
-
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -2358,13 +2328,6 @@ callsites@^0.2.0:
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
-
-camel-case@3.0.x:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
-  dependencies:
-    no-case "^2.2.0"
-    upper-case "^1.1.1"
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
@@ -2402,9 +2365,9 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000712"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000712.tgz#89748396f9d7419d5fa27df3b48872dadbf8318a"
 
-caniuse-lite@^1.0.30000791, caniuse-lite@^1.0.30000792:
-  version "1.0.30000792"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz#d0cea981f8118f3961471afbb43c9a1e5bbf0332"
+caniuse-lite@^1.0.30000780:
+  version "1.0.30000780"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000780.tgz#1f9095f2efd4940e0ba6c5992ab7a9b64cc35ba4"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -2485,10 +2448,6 @@ chokidar@^1.6.0, chokidar@^1.6.1, chokidar@^1.7.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chownr@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
-
 ci-info@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
@@ -2513,12 +2472,6 @@ clap@^1.0.9:
 classnames@^2.1.2, classnames@^2.2.0, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
-
-clean-css@4.1.x:
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
-  dependencies:
-    source-map "0.5.x"
 
 cli-boxes@^1.0.0:
   version "1.0.0"
@@ -2644,17 +2597,17 @@ command-join@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"
 
-commander@2.12.x:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
-
-commander@^2.11.0, commander@^2.12.2, commander@^2.9.0, commander@~2.13.0:
+commander@^2.11.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
-common-tags@^1.4.0, common-tags@^1.6.0:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.7.2.tgz#24d9768c63d253a56ecff93845b44b4df1d52771"
+commander@^2.12.1, commander@^2.9.0:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
+common-tags@^1.4.0, common-tags@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.5.1.tgz#e2e39931a013cd02253defeed89a1ad615a27f07"
   dependencies:
     babel-runtime "^6.26.0"
 
@@ -2691,7 +2644,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.10, concat-stream@^1.5.0, concat-stream@^1.5.2:
+concat-stream@^1.4.10, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -2889,9 +2842,13 @@ conventional-recommended-bump@^1.0.1:
     meow "^3.3.0"
     object-assign "^4.0.1"
 
-convert-source-map@^1.1.0, convert-source-map@^1.5.0:
+convert-source-map@^1.1.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
+
+convert-source-map@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
 cookie-parser@1.4.3:
   version "1.4.3"
@@ -2908,28 +2865,17 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
-copy-concurrently@^1.0.0:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
-  dependencies:
-    aproba "^1.1.1"
-    fs-write-stream-atomic "^1.0.8"
-    iferr "^0.1.5"
-    mkdirp "^0.5.1"
-    rimraf "^2.5.4"
-    run-queue "^1.0.0"
-
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.0.tgz#569c050918be6486b3837552028ae0466b717086"
 
-core-js@^2.4.1, core-js@^2.5.3:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
+core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -3078,9 +3024,28 @@ css-loader@0.27.3:
     postcss-modules-values "^1.1.0"
     source-list-map "^0.1.7"
 
-css-loader@^0.28.1, css-loader@^0.28.8:
-  version "0.28.8"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.8.tgz#ff36381464dea18fe60f2601a060ba6445886bd5"
+css-loader@^0.28.1:
+  version "0.28.7"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.7.tgz#5f2ee989dd32edd907717f953317656160999c1b"
+  dependencies:
+    babel-code-frame "^6.11.0"
+    css-selector-tokenizer "^0.7.0"
+    cssnano ">=2.6.1 <4"
+    icss-utils "^2.1.0"
+    loader-utils "^1.0.2"
+    lodash.camelcase "^4.3.0"
+    object-assign "^4.0.1"
+    postcss "^5.0.6"
+    postcss-modules-extract-imports "^1.0.0"
+    postcss-modules-local-by-default "^1.0.1"
+    postcss-modules-scope "^1.0.0"
+    postcss-modules-values "^1.1.0"
+    postcss-value-parser "^3.3.0"
+    source-list-map "^2.0.0"
+
+css-loader@^0.28.7:
+  version "0.28.9"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.9.tgz#68064b85f4e271d7ce4c48a58300928e535d1c95"
   dependencies:
     babel-code-frame "^6.26.0"
     css-selector-tokenizer "^0.7.0"
@@ -3090,14 +3055,14 @@ css-loader@^0.28.1, css-loader@^0.28.8:
     lodash.camelcase "^4.3.0"
     object-assign "^4.1.1"
     postcss "^5.0.6"
-    postcss-modules-extract-imports "^1.1.0"
+    postcss-modules-extract-imports "^1.2.0"
     postcss-modules-local-by-default "^1.2.0"
     postcss-modules-scope "^1.1.0"
     postcss-modules-values "^1.3.0"
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
-css-select@^1.1.0, css-select@~1.2.0:
+css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   dependencies:
@@ -3185,10 +3150,6 @@ currently-unhandled@^0.4.1:
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
   dependencies:
     array-find-index "^1.0.1"
-
-cyclist@~0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
 d@1:
   version "1.0.0"
@@ -3420,16 +3381,10 @@ doctrine@1.5.0, doctrine@^1.2.2:
     isarray "^1.0.0"
 
 doctrine@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
   dependencies:
     esutils "^2.0.2"
-
-dom-converter@~0.1:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
-  dependencies:
-    utila "~0.3"
 
 dom-helpers@^3.2.0:
   version "3.3.1"
@@ -3462,21 +3417,9 @@ domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
 
-domhandler@2.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.1.0.tgz#d2646f5e57f6c3bab11cf6cb05d3c0acf7412594"
-  dependencies:
-    domelementtype "1"
-
 domhandler@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
-  dependencies:
-    domelementtype "1"
-
-domutils@1.1:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
   dependencies:
     domelementtype "1"
 
@@ -3523,15 +3466,6 @@ duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
-duplexify@^3.4.2, duplexify@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.3.tgz#8b5818800df92fd0125b27ab896491912858243e"
-  dependencies:
-    end-of-stream "^1.0.0"
-    inherits "^2.0.1"
-    readable-stream "^2.0.0"
-    stream-shift "^1.0.0"
-
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -3549,19 +3483,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-releases@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/electron-releases/-/electron-releases-2.1.0.tgz#c5614bf811f176ce3c836e368a0625782341fd4e"
-
-electron-to-chromium@^1.2.7:
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.28:
   version "1.3.28"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz#8dd4e6458086644e9f9f0a1cf32e2a1f9dffd9ee"
-
-electron-to-chromium@^1.3.30:
-  version "1.3.30"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz#9666f532a64586651fc56a72513692e820d06a80"
-  dependencies:
-    electron-releases "^2.1.0"
 
 element-class@^0.2.0:
   version "0.2.2"
@@ -3596,12 +3520,6 @@ encoding@^0.1.11:
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
     iconv-lite "~0.4.13"
-
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
-  dependencies:
-    once "^1.4.0"
 
 enhanced-resolve@^3.3.0, enhanced-resolve@^3.4.0:
   version "3.4.1"
@@ -3755,13 +3673,6 @@ es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
-
-es6-templates@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/es6-templates/-/es6-templates-0.2.3.tgz#5cb9ac9fb1ded6eb1239342b81d792bbb4078ee4"
-  dependencies:
-    recast "~0.11.12"
-    through "~2.3.6"
 
 es6-weak-map@^2.0.1:
   version "2.0.2"
@@ -3918,7 +3829,7 @@ esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
-esprima@^3.1.3, esprima@~3.1.0:
+esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
@@ -4288,9 +4199,9 @@ file-loader@^0.11.1:
   dependencies:
     loader-utils "^1.0.2"
 
-file-loader@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.6.tgz#7b9a8f2c58f00a77fddf49e940f7ac978a3ea0e8"
+file-loader@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.5.tgz#91c25b6b6fbe56dae99f10a425fd64933b5c9daa"
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
@@ -4392,13 +4303,6 @@ fluent-logger@2.2.0:
   dependencies:
     msgpack-lite "*"
 
-flush-write-stream@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.2.tgz#c81b90d8746766f1a609a46809946c45dd8ae417"
-  dependencies:
-    inherits "^2.0.1"
-    readable-stream "^2.0.4"
-
 flux@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/flux/-/flux-2.1.1.tgz#2c6ac652d4337488968489c6586f3aff26a38ea4"
@@ -4468,13 +4372,6 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
-from2@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
-  dependencies:
-    inherits "^2.0.1"
-    readable-stream "^2.0.0"
-
 fs-extra@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
@@ -4486,15 +4383,6 @@ fs-extra@^4.0.1:
 fs-readdir-recursive@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
-
-fs-write-stream-atomic@^1.0.8:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
-  dependencies:
-    graceful-fs "^4.1.2"
-    iferr "^0.1.5"
-    imurmurhash "^0.1.4"
-    readable-stream "1 || 2"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -4540,7 +4428,7 @@ function.prototype.name@^1.0.3:
     function-bind "^1.1.0"
     is-callable "^1.1.3"
 
-fuse.js@^3.0.1, fuse.js@^3.2.0:
+fuse.js@^3.0.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.2.0.tgz#f0448e8069855bf2a3e683cdc1d320e7e2a07ef4"
 
@@ -4643,9 +4531,9 @@ glamor@^2.20.40:
     prop-types "^15.5.10"
     through "^2.3.8"
 
-glamorous@^4.11.2:
-  version "4.11.2"
-  resolved "https://registry.yarnpkg.com/glamorous/-/glamorous-4.11.2.tgz#ce144c6a53e247ddf0896ad6faddebf78c49d864"
+glamorous@^4.11.0:
+  version "4.11.4"
+  resolved "https://registry.yarnpkg.com/glamorous/-/glamorous-4.11.4.tgz#61b333e1ec552abbe48e2fea48fea89fc0026149"
   dependencies:
     brcast "^3.0.0"
     fast-memoize "^2.2.7"
@@ -4856,10 +4744,6 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
-he@1.1.x:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
-
 history@^4.5.1, history@^4.7.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
@@ -4932,43 +4816,9 @@ html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 
-html-loader@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-0.5.4.tgz#70f36e30a923cc52536fdc812cec6f556aeb47a4"
-  dependencies:
-    es6-templates "^0.2.3"
-    fastparse "^1.1.1"
-    html-minifier "^3.5.8"
-    loader-utils "^1.1.0"
-    object-assign "^4.1.1"
-
-html-minifier@^3.2.3, html-minifier@^3.5.8:
-  version "3.5.8"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.8.tgz#5ccdb1f73a0d654e6090147511f6e6b2ee312700"
-  dependencies:
-    camel-case "3.0.x"
-    clean-css "4.1.x"
-    commander "2.12.x"
-    he "1.1.x"
-    ncname "1.0.x"
-    param-case "2.1.x"
-    relateurl "0.2.x"
-    uglify-js "3.3.x"
-
 html-tag-names@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/html-tag-names/-/html-tag-names-1.1.2.tgz#f65168964c5a9c82675efda882875dcb2a875c22"
-
-html-webpack-plugin@^2.30.1:
-  version "2.30.1"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz#7f9c421b7ea91ec460f56527d78df484ee7537d5"
-  dependencies:
-    bluebird "^3.4.7"
-    html-minifier "^3.2.3"
-    loader-utils "^0.2.16"
-    lodash "^4.17.3"
-    pretty-error "^2.0.2"
-    toposort "^1.0.0"
 
 htmlparser2@^3.9.1:
   version "3.9.2"
@@ -4980,15 +4830,6 @@ htmlparser2@^3.9.1:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^2.0.2"
-
-htmlparser2@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.3.0.tgz#cc70d05a59f6542e43f0e685c982e14c924a9efe"
-  dependencies:
-    domelementtype "1"
-    domhandler "2.1"
-    domutils "1.1"
-    readable-stream "1.0"
 
 http-deceiver@^1.2.7:
   version "1.2.7"
@@ -5078,10 +4919,6 @@ identity-obj-proxy@3.0.0:
 ieee754@^1.1.4, ieee754@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
-
-iferr@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
 ignore@^3.2.0:
   version "3.3.7"
@@ -5386,8 +5223,8 @@ is-path-in-cwd@^1.0.0:
     is-path-inside "^1.0.0"
 
 is-path-inside@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
   dependencies:
     path-is-inside "^1.0.1"
 
@@ -5955,7 +5792,7 @@ jws@^3.1.4:
     jwa "^1.1.4"
     safe-buffer "^5.0.1"
 
-keycode@^2.1.9:
+keycode@^2.1.8:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.1.9.tgz#964a23c54e4889405b4861a5c9f0480d45141dfa"
 
@@ -6268,13 +6105,13 @@ lodash.uniqby@4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
 
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 loglevel@^1.4.1:
   version "1.6.0"
@@ -6297,10 +6134,6 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lower-case@^1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
-
 lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
@@ -6312,7 +6145,7 @@ lru-cache@4.0.2:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-lru-cache@4.1.1, lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.1.1:
+lru-cache@4.1.1, lru-cache@^4.0.0, lru-cache@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
   dependencies:
@@ -6335,10 +6168,6 @@ make-dir@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
-make-error@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.2.tgz#8762ffad2444dd8ff1f7c819629fa28e24fea1c4"
-
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -6348,17 +6177,6 @@ makeerror@1.0.x:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
-
-markdown-loader@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/markdown-loader/-/markdown-loader-2.0.2.tgz#1cdcf11307658cd611046d7db34c2fe80542af7c"
-  dependencies:
-    loader-utils "^1.1.0"
-    marked "^0.3.9"
-
-marked@^0.3.9:
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.12.tgz#7cf25ff2252632f3fe2406bde258e94eee927519"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -6540,21 +6358,6 @@ minimist@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
 
-mississippi@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-1.3.0.tgz#d201583eb12327e3c5c1642a404a9cacf94e34f5"
-  dependencies:
-    concat-stream "^1.5.0"
-    duplexify "^3.4.2"
-    end-of-stream "^1.1.0"
-    flush-write-stream "^1.0.0"
-    from2 "^2.1.0"
-    parallel-transform "^1.1.0"
-    pump "^1.0.0"
-    pumpify "^1.3.3"
-    stream-each "^1.1.0"
-    through2 "^2.0.0"
-
 mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -6586,19 +6389,8 @@ moment@2.18.1, "moment@>= 2.9.0", moment@^2.6.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
 moment@2.x.x, moment@^2.10.6:
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
-
-move-concurrently@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
-  dependencies:
-    aproba "^1.1.1"
-    copy-concurrently "^1.0.0"
-    fs-write-stream-atomic "^1.0.8"
-    mkdirp "^0.5.1"
-    rimraf "^2.5.4"
-    run-queue "^1.0.3"
+  version "2.19.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"
 
 ms@2.0.0:
   version "2.0.0"
@@ -6656,12 +6448,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-ncname@1.0.x:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"
-  dependencies:
-    xml-char-classes "^1.0.0"
-
 ncp@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
@@ -6678,17 +6464,15 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-no-case@^2.2.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
-  dependencies:
-    lower-case "^1.1.1"
-
 node-dir@^0.1.10:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
   dependencies:
     minimatch "^3.0.2"
+
+node-dogstatsd@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/node-dogstatsd/-/node-dogstatsd-0.0.6.tgz#d697e4d1903a7ff0c16479cd5d1cde043737e047"
 
 node-fetch@^1.0.1:
   version "1.7.2"
@@ -6919,7 +6703,7 @@ on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
-once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
+once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -7043,20 +6827,6 @@ package-json@^4.0.0, package-json@^4.0.1:
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
-
-parallel-transform@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.1.0.tgz#d410f065b05da23081fcd10f28854c29bda33b06"
-  dependencies:
-    cyclist "~0.2.2"
-    inherits "^2.0.3"
-    readable-stream "^2.1.5"
-
-param-case@2.1.x:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
-  dependencies:
-    no-case "^2.2.0"
 
 parse-asn1@^5.0.0:
   version "5.1.0"
@@ -7384,8 +7154,8 @@ postcss-loader@0.8.2:
     postcss "^5.0.19"
 
 postcss-loader@^2.0.5, postcss-loader@^2.0.9:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-2.0.10.tgz#090db0540140bd56a7a7f717c41bc29aeef4c674"
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-2.0.9.tgz#001fdf7bfeeb159405ee61d1bb8e59b528dbd309"
   dependencies:
     loader-utils "^1.1.0"
     postcss "^6.0.0"
@@ -7453,15 +7223,9 @@ postcss-minify-selectors@^2.0.4:
     postcss "^5.0.14"
     postcss-selector-parser "^2.0.0"
 
-postcss-modules-extract-imports@^1.0.0:
+postcss-modules-extract-imports@^1.0.0, postcss-modules-extract-imports@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz#66140ecece38ef06bf0d3e355d69bf59d141ea85"
-  dependencies:
-    postcss "^6.0.1"
-
-postcss-modules-extract-imports@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz#b614c9720be6816eaee35fb3a5faa1dba6a05ddb"
   dependencies:
     postcss "^6.0.1"
 
@@ -7590,15 +7354,7 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.16:
-  version "6.0.16"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.16.tgz#112e2fe2a6d2109be0957687243170ea5589e146"
-  dependencies:
-    chalk "^2.3.0"
-    source-map "^0.6.1"
-    supports-color "^5.1.0"
-
-postcss@^6.0.1:
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.14:
   version "6.0.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.14.tgz#5534c72114739e75d0afcf017db853099f562885"
   dependencies:
@@ -7617,13 +7373,6 @@ prepend-http@^1.0.0, prepend-http@^1.0.1:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
-
-pretty-error@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
-  dependencies:
-    renderkid "^2.0.1"
-    utila "~0.4"
 
 pretty-format@^19.0.0:
   version "19.0.0"
@@ -7654,10 +7403,6 @@ process@~0.5.1:
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
-
-promise-inflight@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
 
 promise.prototype.finally@^3.1.0:
   version "3.1.0"
@@ -7723,28 +7468,6 @@ public-encrypt@^4.0.0:
     create-hash "^1.1.0"
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
-
-pump@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
-
-pump@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.0.tgz#7946da1c8d622b098e2ceb2d3476582470829c9d"
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
-
-pumpify@^1.3.3:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.3.6.tgz#00d40e5ded0a3bf1e0788b1c0cf426a42882ab64"
-  dependencies:
-    duplexify "^3.5.3"
-    inherits "^2.0.3"
-    pump "^2.0.0"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -7946,7 +7669,7 @@ react-dnd@2.5.1:
     lodash "^4.2.0"
     prop-types "^15.5.10"
 
-react-docgen@^2.20.0:
+react-docgen@^2.15.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.20.0.tgz#41a6da483a34a4aaed041a9909f5e61864d681cb"
   dependencies:
@@ -7985,15 +7708,6 @@ react-dropzone@4.2.3:
     attr-accept "^1.0.3"
     prop-types "^15.5.7"
 
-react-fuzzy@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/react-fuzzy/-/react-fuzzy-0.5.1.tgz#295c2a4079ad39402e05605d9d7accd2db8527b6"
-  dependencies:
-    babel-runtime "^6.23.0"
-    classnames "^2.2.5"
-    fuse.js "^3.0.1"
-    prop-types "^15.5.9"
-
 react-hot-loader@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.1.2.tgz#3d4a0f7fdeb5dce085767d751a683f979345557d"
@@ -8029,7 +7743,7 @@ react-images@0.5.5:
     react-scrolllock "^1.0.5"
     react-transition-group "^1.1.3"
 
-react-inspector@^2.2.2:
+react-inspector@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.2.tgz#c04f5248fa92ab6c23e37960e725fb7f48c34d05"
   dependencies:
@@ -8047,9 +7761,9 @@ react-modal@^1.7.7:
     prop-types "^15.5.7"
     react-dom-factories "^1.0.0"
 
-react-modal@^3.1.10:
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.1.10.tgz#8898b5cc4ebba78adbb8dea4c55a69818aa682cc"
+react-modal@^3.1.4:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.1.7.tgz#21feb937c95cd722bf2d375cada751fdc8189c0e"
   dependencies:
     exenv "^1.2.0"
     prop-types "^15.5.10"
@@ -8116,7 +7830,7 @@ react-simple-dropdown@3.2.0:
     classnames "^2.1.2"
     prop-types "^15.5.8"
 
-react-split-pane@^0.1.74:
+react-split-pane@^0.1.71:
   version "0.1.74"
   resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.74.tgz#cf79fc98b51ab0763fdc778749b810a102b036ca"
   dependencies:
@@ -8162,7 +7876,7 @@ react-transition-group@^1.1.2, react-transition-group@^1.1.3:
     prop-types "^15.5.6"
     warning "^3.0.0"
 
-react-treebeard@^2.1.0:
+react-treebeard@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/react-treebeard/-/react-treebeard-2.1.0.tgz#fbd5cf51089b6f09a9b18350ab3bddf736e57800"
   dependencies:
@@ -8232,7 +7946,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -8243,15 +7957,6 @@ read-pkg@^3.0.0:
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
-
-readable-stream@1.0:
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
 
 readable-stream@~2.0.5:
   version "2.0.6"
@@ -8290,15 +7995,6 @@ recast@^0.12.6:
     esprima "~4.0.0"
     private "~0.1.5"
     source-map "~0.6.1"
-
-recast@~0.11.12:
-  version "0.11.23"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
-  dependencies:
-    ast-types "0.9.6"
-    esprima "~3.1.0"
-    private "~0.1.5"
-    source-map "~0.5.0"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -8441,23 +8137,9 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
-relateurl@0.2.x:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
-
 remove-trailing-separator@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
-
-renderkid@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.1.tgz#898cabfc8bede4b7b91135a3ffd323e58c0db319"
-  dependencies:
-    css-select "^1.1.0"
-    dom-converter "~0.1"
-    htmlparser2 "~3.3.0"
-    strip-ansi "^3.0.0"
-    utila "~0.3"
 
 repeat-element@^1.1.2:
   version "1.1.2"
@@ -8653,7 +8335,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -8690,12 +8372,6 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
-
-run-queue@^1.0.0, run-queue@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
-  dependencies:
-    aproba "^1.1.1"
 
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
@@ -8740,13 +8416,6 @@ schema-utils@^0.3.0:
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.3.0.tgz#f5877222ce3e931edae039f17eb3716e7137f8cf"
   dependencies:
     ajv "^5.0.0"
-
-schema-utils@^0.4.2:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.3.tgz#e2a594d3395834d5e15da22b48be13517859458e"
-  dependencies:
-    ajv "^5.0.0"
-    ajv-keywords "^2.1.0"
 
 select-hose@^2.0.0:
   version "2.0.0"
@@ -8803,10 +8472,6 @@ send@0.16.1:
     on-finished "~2.3.0"
     range-parser "~1.2.0"
     statuses "~1.3.1"
-
-serialize-javascript@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.4.0.tgz#7c958514db6ac2443a8abc062dc9f7886a7f6005"
 
 serve-favicon@^2.4.3, serve-favicon@^2.4.5:
   version "2.4.5"
@@ -8978,10 +8643,6 @@ source-map@0.5.6, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, sourc
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@0.5.x, source-map@~0.5.0, source-map@~0.5.6:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -8991,6 +8652,10 @@ source-map@^0.4.4:
 source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+source-map@~0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
 sourcemapped-stacktrace@^1.1.6:
   version "1.1.7"
@@ -9065,12 +8730,6 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-ssri@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-5.0.0.tgz#13c19390b606c821f2a10d02b351c1729b94d8cf"
-  dependencies:
-    safe-buffer "^5.1.0"
-
 stack-trace@0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
@@ -9102,13 +8761,6 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-each@^1.1.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.2.tgz#8e8c463f91da8991778765873fe4d960d8f616bd"
-  dependencies:
-    end-of-stream "^1.1.0"
-    stream-shift "^1.0.0"
-
 stream-http@^2.3.1:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.2.tgz#40a050ec8dc3b53b33d9909415c02c0bf1abfbad"
@@ -9118,10 +8770,6 @@ stream-http@^2.3.1:
     readable-stream "^2.2.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
-
-stream-shift@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -9243,9 +8891,9 @@ style-loader@^0.17.0:
   dependencies:
     loader-utils "^1.0.2"
 
-style-loader@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.19.1.tgz#591ffc80bcefe268b77c5d9ebc0505d772619f85"
+style-loader@^0.18.2:
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.18.2.tgz#cc31459afbcd6d80b7220ee54b291a9fd66ff5eb"
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
@@ -9263,12 +8911,6 @@ supports-color@^3.1.0, supports-color@^3.1.2, supports-color@^3.2.3:
 supports-color@^4.0.0, supports-color@^4.2.1, supports-color@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
-  dependencies:
-    has-flag "^2.0.0"
-
-supports-color@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.1.0.tgz#058a021d1b619f7ddf3980d712ea3590ce7de3d5"
   dependencies:
     has-flag "^2.0.0"
 
@@ -9405,7 +9047,7 @@ through2@^2.0.0, through2@^2.0.2:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8, through@~2.3.6:
+through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -9451,10 +9093,6 @@ topo@1.x.x:
   resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
   dependencies:
     hoek "2.x.x"
-
-toposort@^1.0.0:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.6.tgz#c31748e55d210effc00fdcdc7d6e68d7d7bb9cec"
 
 tough-cookie@>=2.3.0, tough-cookie@~2.3.0:
   version "2.3.2"
@@ -9527,20 +9165,6 @@ ua-parser-js@^0.7.9:
   version "0.7.14"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
 
-uglify-es@^3.3.4:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.7.tgz#d1249af668666aba7cb1163e277455be9eb393cf"
-  dependencies:
-    commander "~2.13.0"
-    source-map "~0.6.1"
-
-uglify-js@3.3.x:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.7.tgz#28463e7c7451f89061d2b235e30925bf5625e14d"
-  dependencies:
-    commander "~2.13.0"
-    source-map "~0.6.1"
-
 uglify-js@^2.6, uglify-js@^2.8.27, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -9561,19 +9185,6 @@ uglifyjs-webpack-plugin@^0.4.6:
     source-map "^0.5.6"
     uglify-js "^2.8.29"
     webpack-sources "^1.0.1"
-
-uglifyjs-webpack-plugin@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.6.tgz#f4ba8449edcf17835c18ba6ae99b9d610857fb19"
-  dependencies:
-    cacache "^10.0.1"
-    find-cache-dir "^1.0.0"
-    schema-utils "^0.4.2"
-    serialize-javascript "^1.4.0"
-    source-map "^0.6.1"
-    uglify-es "^3.3.4"
-    webpack-sources "^1.1.0"
-    worker-farm "^1.5.2"
 
 uid-number@^0.0.6:
   version "0.0.6"
@@ -9600,18 +9211,6 @@ uniqid@^4.0.0:
 uniqs@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
-
-unique-filename@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.0.tgz#d05f2fe4032560871f30e93cbe735eea201514f3"
-  dependencies:
-    unique-slug "^2.0.0"
-
-unique-slug@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.0.tgz#db6676e7c7cc0629878ff196097c78855ae9f4ab"
-  dependencies:
-    imurmurhash "^0.1.4"
 
 unique-string@^1.0.0:
   version "1.0.0"
@@ -9643,10 +9242,6 @@ update-notifier@2.1.0:
     lazy-req "^2.0.0"
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
-
-upper-case@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
 url-loader@^0.5.8:
   version "0.5.9"
@@ -9713,14 +9308,6 @@ util@0.10.3, util@^0.10.3:
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
     inherits "2.0.1"
-
-utila@~0.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/utila/-/utila-0.3.3.tgz#d7e8e7d7e309107092b05f8d9688824d633a4226"
-
-utila@~0.4:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
 
 utils-merge@1.0.0:
   version "1.0.0"
@@ -9911,14 +9498,14 @@ webpack-hot-middleware@^2.18.0, webpack-hot-middleware@^2.21.0:
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
 
-webpack-sources@^1.0.1, webpack-sources@^1.1.0:
+webpack-sources@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@3.10.0, webpack@^3.10.0:
+webpack@3.10.0, webpack@^3.8.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.10.0.tgz#5291b875078cf2abf42bdd23afe3f8f96c17d725"
   dependencies:
@@ -10051,7 +9638,7 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
-worker-farm@^1.3.1, worker-farm@^1.5.2:
+worker-farm@^1.3.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.5.2.tgz#32b312e5dc3d5d45d79ef44acc2587491cd729ae"
   dependencies:
@@ -10112,10 +9699,6 @@ write@^0.2.1:
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
-
-xml-char-classes@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
 
 xml-name-validator@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,9 +127,9 @@
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@bufferapp/micro-rpc/-/micro-rpc-0.1.6.tgz#104417af8c4940c92d45164cc097d5d38fd7d957"
 
-"@bufferapp/performance-tracking@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@bufferapp/performance-tracking/-/performance-tracking-0.1.0.tgz#b64c3a17f58eebeeeaa86dba93255d8b2b6e27e5"
+"@bufferapp/performance-tracking@0.43.5":
+  version "0.43.5"
+  resolved "https://registry.yarnpkg.com/@bufferapp/performance-tracking/-/performance-tracking-0.43.5.tgz#20d4f4813e898e2fe0484522d67b4536177e05fd"
   dependencies:
     "@bufferapp/async-data-fetch" "0.5.36-beta01"
     "@bufferapp/chronos" "0.6.1"


### PR DESCRIPTION
### Purpose
To add front-end performance tracking on Datadog.
I hope this is useful :smile:.


### Notes
The middleware is just a wrapper around @bufferapp/chronos APIs and exposes Chronos methods via action creators.

The basic functionality is to automatically track all async data fetch requests. 

Also you can easily use it to track any kind of events you are interested in with:
```
store.dispatch(performanceActions.startMeasure({ name: 'foo' }));
store.dispatch(performanceActions.stopMeasure({ name: 'foo' }));
```
or measuring any event from navigation start  with:
```
dispatch(performanceActions.measureFromNavigationStart({ name: 'foo' }));
```

The data sent to Datadog has the following structure:
```
{
    "duration":745.6550000000007,
    "name":"buffer.perf.queuedPostsFetch",
    "navigationStart":1512788235288,
    "start_time":15677.205,
    "tags":["app:publish"]
}
```

_duration is in floating ms_.

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
