### PR TITLE
Use legacy watch mode with nodemon

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -8,5 +8,5 @@ RUN npm install -g nodemon
 
 EXPOSE 80
 
-CMD nodemon --ignore 'index.html' --watch ./packages/server -e html,js,json packages/server/index.js
+CMD nodemon -V -L --ignore 'index.html' --watch ./packages/server -e html,js,json packages/server/index.js
 # add '--inspect=0.0.0.0:5858' to debug the server


### PR DESCRIPTION
### Purpose

Recently `nodemon` has stopped restarting the server when things change. I suspect this is due to changes in Docker. As such I've switched nodemon to use the 'legacy' watching mode. This mode is slower as it uses polling, but that should make little to no difference in our case as we're only watching ~30 files in the server package.

### Notes

Hey @emily-plummer, sounds like this was happening to you too. Would love for you to test this out. I'll merge it into master and you'll just have to run `./dev rebuild publish`.

cc @alvarezmelissa87 as well.

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
