### PR TITLE
Add back code coverage

### DIFF
--- a/.jestrc.json
+++ b/.jestrc.json
@@ -3,6 +3,7 @@
     "node_modules/(?!@bufferapp/*)"
   ],
   "verbose": true,
+  "collectCoverage": true,
   "moduleNameMapper": {
     "\\.(css|less)$": "identity-obj-proxy"
   }


### PR DESCRIPTION
### Purpose

To add back code coverage when using Jest and allow the codecov integration to run back again.