### PR TITLE
Extract retweet comment links from retweet comment - not from retweet

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@bufferapp/logger": "0.7.0",
     "@bufferapp/micro-rpc": "0.1.6",
-    "@bufferapp/publish-utils": "1.4.0",
+    "@bufferapp/publish-utils": "1.4.0-beta.1",
     "@bufferapp/session-manager": "0.6.2",
     "@bufferapp/shutdown-helper": "0.2.0",
     "body-parser": "1.17.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/publish-utils",
-  "version": "1.4.0",
+  "version": "1.4.0-beta.1",
   "description": "Misc. utils for dates, parsing, etc.",
   "main": "index.js",
   "scripts": {

--- a/packages/utils/postParser.js
+++ b/packages/utils/postParser.js
@@ -84,6 +84,8 @@ module.exports = (post) => {
         .concat(post.profile_service === 'facebook' ? parseFacebookEntities(text, post.entities) : [])
         .sort(({ indices: [startIdxA] }, { indices: [startIdxB] }) => startIdxA - startIdxB);
 
+  const retweetCommentLinks = canHaveLinks ? parseTwitterLinks(retweetComment) : [];
+
   const isFixed = (
     post.pinned ||
     post.scheduled_at ||
@@ -119,7 +121,7 @@ module.exports = (post) => {
     profile_service: post.profile_service,
     retweet: post.retweet,
     retweetComment,
-    retweetCommentLinks: canHaveLinks ? links : [],
+    retweetCommentLinks,
     retweetProfile: getRetweetProfileInfo(post),
     sent: post.status === 'sent',
     source_url: post.source_url,

--- a/packages/utils/postParser.test.js
+++ b/packages/utils/postParser.test.js
@@ -1,6 +1,11 @@
 import postParser from './postParser';
 
-const post = {
+const tweet = {
+  profile_service: 'twitter',
+  text: 'What Do the New Twitter Rules Mean for Social Media Managers (and Buffer Customers) https://buff.ly/2JNS3tL',
+  type: 'text',
+};
+const retweet = {
   profile_service: 'twitter',
   retweet: {
     user_id: 19475858,
@@ -15,8 +20,8 @@ const post = {
       http: 'http://pbs.twimg.com/profile_images/867425050043052033/Ci4OgTlV_normal.jpg',
       https: 'https://pbs.twimg.com/profile_images/867425050043052033/Ci4OgTlV_normal.jpg',
     },
-    comment: 'Fascinating',
-    comment_formatted: 'Fascinating',
+    comment: 'Fascinating #Really',
+    comment_formatted: 'Fascinating <a href="https://twitter.com/#!/search?q=%23Really" title="#Really" class="hashtag" rel="external nofollow" target="_blank">#Really</a>',
   },
   retweeted_tweet_id: '990952846110658560',
   text: 'Fascinating',
@@ -26,12 +31,17 @@ const post = {
 
 describe('post parser', () => {
   it('extracts links from retweet', () => {
-    const parsedPost = postParser(post);
+    const parsedPost = postParser(retweet);
     expect(parsedPost.links).toHaveLength(2);
   });
 
   it('stores links from retweet comment in retweetCommentLinks', () => {
-    const parsedPost = postParser(post);
+    const parsedPost = postParser(retweet);
+    expect(parsedPost.retweetCommentLinks).toHaveLength(1);
+  });
+
+  it('does not extract retweetCommentLinks if there is no retweetComment', () => {
+    const parsedPost = postParser(tweet);
     expect(parsedPost.retweetCommentLinks).toHaveLength(0);
   });
 });

--- a/packages/utils/postParser.test.js
+++ b/packages/utils/postParser.test.js
@@ -1,0 +1,37 @@
+import postParser from './postParser';
+
+const post = {
+  profile_service: 'twitter',
+  retweet: {
+    user_id: 19475858,
+    tweet_id: '990952846110658560',
+    username: 'LouPas',
+    url: 'https://twitter.com/LouPas/status/990952846110658560',
+    created_at: 1525096544,
+    created_at_string: 'Mon Apr 30 13:55:44 +0000 2018',
+    profile_name: 'Lou Paskalis',
+    text: '“The Daily has more listeners that the New York Times has readers. We are the new front page and reporters want to be on our show because of the power of that megaphone. You don’t skim a podcast” Michael Barbaro, TheDaily, #NewFronts https://t.co/zJR5wjR6e5',
+    avatars: {
+      http: 'http://pbs.twimg.com/profile_images/867425050043052033/Ci4OgTlV_normal.jpg',
+      https: 'https://pbs.twimg.com/profile_images/867425050043052033/Ci4OgTlV_normal.jpg',
+    },
+    comment: 'Fascinating',
+    comment_formatted: 'Fascinating',
+  },
+  retweeted_tweet_id: '990952846110658560',
+  text: 'Fascinating',
+  text_formatted: '“The Daily has more listeners that the New York Times has readers. We are the new front page and reporters want to be on our show because of the power of that megaphone. You don’t skim a podcast” Michael Barbaro, TheDaily, <a href="https://twitter.com/#!/search?q=%23NewFronts" title="#NewFronts" class="hashtag" rel="external nofollow" target="_blank">#NewFronts</a> <a class="url" href="https://t.co/zJR5wjR6e5" rel="external nofollow" target="_blank">https://t.co/zJR5wjR6e5</a>',
+  type: 'retweet',
+};
+
+describe('post parser', () => {
+  it('extracts links from retweet', () => {
+    const parsedPost = postParser(post);
+    expect(parsedPost.links).toHaveLength(2);
+  });
+
+  it('stores links from retweet comment in retweetCommentLinks', () => {
+    const parsedPost = postParser(post);
+    expect(parsedPost.retweetCommentLinks).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### Purpose

To fix cases where `LinkifiedText` would go into an endless loop because for retweets with comments we would pass the retweet's links as the retweet comments' links when in reality they're two different entities.