### PR TITLE
Use new Account Management upgrade endpoint

### DIFF
--- a/packages/app-switcher/middleware.js
+++ b/packages/app-switcher/middleware.js
@@ -1,12 +1,6 @@
 import { actionTypes } from '@bufferapp/async-data-fetch';
 import { actions as notificationActions } from '@bufferapp/notifications';
-
-const getClassicBufferURL = () => {
-  if (window.location.hostname === 'publish.local.buffer.com') {
-    return 'https://local.buffer.com/classic';
-  }
-  return 'https://buffer.com/classic';
-};
+import { getClassicBufferURL } from '@bufferapp/publish-utils';
 
 export default ({ dispatch }) => next => (action) => {
   next(action);

--- a/packages/app-switcher/package.json
+++ b/packages/app-switcher/package.json
@@ -11,7 +11,8 @@
   "author": "hamstu@gmail.com",
   "dependencies": {
     "@bufferapp/async-data-fetch": "1.6.2",
-    "@bufferapp/notifications": "1.8.0"
+    "@bufferapp/notifications": "1.8.0",
+    "@bufferapp/publish-utils": "1.6.2"
   },
   "devDependencies": {
     "eslint": "3.19.0",

--- a/packages/server/rpc/upgradeToPro/index.js
+++ b/packages/server/rpc/upgradeToPro/index.js
@@ -12,7 +12,7 @@ module.exports = method(
         method: 'POST',
         strictSSL: process.env.NODE_ENV !== 'development',
         json: true,
-        body: {
+        form: {
           cycle,
           stripeToken: token,
           access_token: session.publish.accessToken,

--- a/packages/server/rpc/upgradeToPro/index.js
+++ b/packages/server/rpc/upgradeToPro/index.js
@@ -6,16 +6,18 @@ module.exports = method(
   'upgrade user to the pro plan',
   ({ cycle, token }, { session }) =>
     rp({
-      uri: `${process.env.API_ADDR}/1/upgrade_to_pro.json`,
+      uri: `${process.env.API_ADDR}/1/billing/start-or-upgrade-subscription.json`,
       method: 'POST',
       strictSSL: process.env.NODE_ENV !== 'development',
       body: {
         cycle,
         stripeToken: token,
         access_token: session.publish.accessToken,
+        product: 'publish',
+        plan: 'pro',
       },
     })
     .then(result => JSON.parse(result))
-    .catch(e => console.log(e)),
+    .catch(e => console.log(e)), // eslint-disable-line no-console
 );
 

--- a/packages/server/rpc/upgradeToPro/index.js
+++ b/packages/server/rpc/upgradeToPro/index.js
@@ -1,23 +1,30 @@
-const { method } = require('@bufferapp/micro-rpc');
+const { method, createError } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
 
 module.exports = method(
   'upgradeToPro',
   'upgrade user to the pro plan',
-  ({ cycle, token }, { session }) =>
-    rp({
-      uri: `${process.env.API_ADDR}/1/billing/start-or-upgrade-subscription.json`,
-      method: 'POST',
-      strictSSL: process.env.NODE_ENV !== 'development',
-      body: {
-        cycle,
-        stripeToken: token,
-        access_token: session.publish.accessToken,
-        product: 'publish',
-        plan: 'pro',
-      },
-    })
-    .then(result => JSON.parse(result))
-    .catch(e => console.log(e)), // eslint-disable-line no-console
+  async ({ cycle, token }, { session }) => {
+    let result;
+    try {
+      result = await rp({
+        uri: `${process.env.API_ADDR}/1/billing/start-or-upgrade-subscription.json`,
+        method: 'POST',
+        strictSSL: process.env.NODE_ENV !== 'development',
+        json: true,
+        body: {
+          cycle,
+          stripeToken: token,
+          access_token: session.publish.accessToken,
+          product: 'publish',
+          plan: 'pro',
+        },
+      });
+    } catch (response) {
+      throw createError({
+        message: response.error,
+      });
+    }
+    return result;
+  },
 );
-

--- a/packages/server/rpc/upgradeToPro/index.js
+++ b/packages/server/rpc/upgradeToPro/index.js
@@ -8,7 +8,7 @@ module.exports = method(
     let result;
     try {
       result = await rp({
-        uri: `${process.env.API_ADDR}/1/billing/start-or-upgrade-subscription.json`,
+        uri: `${process.env.API_ADDR}/1/billing/start-or-update-subscription.json`,
         method: 'POST',
         strictSSL: process.env.NODE_ENV !== 'development',
         json: true,

--- a/packages/server/rpc/upgradeToPro/test.js
+++ b/packages/server/rpc/upgradeToPro/test.js
@@ -28,4 +28,9 @@ describe('rpc/upgradeToPro', () => {
     expect(rp.mock.calls[0][0].body.cycle).toBe('year');
     expect(rp.mock.calls[0][0].body.stripeToken).toBe('stripe token');
   });
+
+  it('sets up product/plan to identify it is an upgrade to the Pro plan in Publish', () => {
+    expect(rp.mock.calls[0][0].body.plan).toBe('pro');
+    expect(rp.mock.calls[0][0].body.product).toBe('publish');
+  });
 });

--- a/packages/server/rpc/upgradeToPro/test.js
+++ b/packages/server/rpc/upgradeToPro/test.js
@@ -23,21 +23,21 @@ describe('rpc/upgradeToPro', () => {
   it('sends over a request to Buffer\'s API with Publish\'s access token', () => {
     rp.mockReturnValueOnce(Promise.resolve({}));
     upgradeToPro();
-    expect(rp.mock.calls[0][0].body.access_token).toBe(accessToken);
+    expect(rp.mock.calls[0][0].form.access_token).toBe(accessToken);
   });
 
   it('sends over the selected cycle and current stripe token', () => {
     rp.mockReturnValueOnce(Promise.resolve({}));
     upgradeToPro();
-    expect(rp.mock.calls[0][0].body.cycle).toBe('year');
-    expect(rp.mock.calls[0][0].body.stripeToken).toBe('stripe token');
+    expect(rp.mock.calls[0][0].form.cycle).toBe('year');
+    expect(rp.mock.calls[0][0].form.stripeToken).toBe('stripe token');
   });
 
   it('sets up product/plan to identify it is an upgrade to the Pro plan in Publish', () => {
     rp.mockReturnValueOnce(Promise.resolve({}));
     upgradeToPro();
-    expect(rp.mock.calls[0][0].body.plan).toBe('pro');
-    expect(rp.mock.calls[0][0].body.product).toBe('publish');
+    expect(rp.mock.calls[0][0].form.plan).toBe('pro');
+    expect(rp.mock.calls[0][0].form.product).toBe('publish');
   });
 
   it('an error response gets returned too', () => {

--- a/packages/server/rpc/upgradeToPro/test.js
+++ b/packages/server/rpc/upgradeToPro/test.js
@@ -2,7 +2,7 @@
 jest.mock('micro-rpc-client');
 jest.mock('request-promise');
 import rp from 'request-promise';
-import upgradeToPro from './';
+import RPCEndpoint from './';
 
 const accessToken = 'AN ACCESS TOKEN';
 const session = {
@@ -10,27 +10,41 @@ const session = {
     accessToken,
   },
 };
-describe('rpc/upgradeToPro', () => {
-  beforeEach(async () => {
-    rp.mockReturnValueOnce(Promise.resolve('{}'));
-    await upgradeToPro.fn({
-      cycle: 'year',
-      token: 'stripe token',
-    }, {
-      session,
-    });
+
+const upgradeToPro = () =>
+  RPCEndpoint.fn({
+    cycle: 'year',
+    token: 'stripe token',
+  }, {
+    session,
   });
+
+describe('rpc/upgradeToPro', () => {
   it('sends over a request to Buffer\'s API with Publish\'s access token', () => {
+    rp.mockReturnValueOnce(Promise.resolve({}));
+    upgradeToPro();
     expect(rp.mock.calls[0][0].body.access_token).toBe(accessToken);
   });
 
   it('sends over the selected cycle and current stripe token', () => {
+    rp.mockReturnValueOnce(Promise.resolve({}));
+    upgradeToPro();
     expect(rp.mock.calls[0][0].body.cycle).toBe('year');
     expect(rp.mock.calls[0][0].body.stripeToken).toBe('stripe token');
   });
 
   it('sets up product/plan to identify it is an upgrade to the Pro plan in Publish', () => {
+    rp.mockReturnValueOnce(Promise.resolve({}));
+    upgradeToPro();
     expect(rp.mock.calls[0][0].body.plan).toBe('pro');
     expect(rp.mock.calls[0][0].body.product).toBe('publish');
+  });
+
+  it('an error response gets returned too', () => {
+    rp.mockReturnValueOnce(Promise.reject({
+      error: 'Something went wrong!',
+    }));
+
+    return upgradeToPro().catch(result => expect(result.message).toBe('Something went wrong!'));
   });
 });

--- a/packages/stripe/middleware.js
+++ b/packages/stripe/middleware.js
@@ -1,7 +1,8 @@
 /* global Stripe */
 
+import { getClassicBufferURL } from '@bufferapp/publish-utils';
 import { actions as notification } from '@bufferapp/notifications';
-import { actions as asyncDataFetchActions } from '@bufferapp/async-data-fetch';
+import { actions as asyncDataFetchActions, actionTypes as asyncDataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import { actions, actionTypes } from './reducer';
 
 const getErrorMessage = (response, errorMessages) => {
@@ -43,6 +44,9 @@ export default ({ dispatch, getState }) => next => (action) => {
           }));
         }
       });
+      break;
+    case `upgradeToPro_${asyncDataFetchActionTypes.FETCH_SUCCESS}`:
+      window.location.assign(getClassicBufferURL());
       break;
     default:
       break;

--- a/packages/stripe/middleware.test.js
+++ b/packages/stripe/middleware.test.js
@@ -1,6 +1,6 @@
 /* global Stripe */
 
-import { actions as asyncDataFetchActions } from '@bufferapp/async-data-fetch';
+import { actions as asyncDataFetchActions, actionTypes as asyncDataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import middleware from './middleware';
 import { actions, actionTypes } from './reducer';
 import { CREDIT_CARD, SUCCESS_RESPONSE, ERROR_RESPONSE, CARD_WITHOUT_NAME_RESPONSE, CARD_WITHOUT_ZIP_RESPONSE, CARD_WITH_WRONG_ZIP_RESPONSE } from './test/constants';
@@ -8,6 +8,10 @@ import { CREDIT_CARD, SUCCESS_RESPONSE, ERROR_RESPONSE, CARD_WITHOUT_NAME_RESPON
 global.Stripe = {
   createToken: jest.fn(),
 };
+
+Object.defineProperty(window.location, 'hostname', {
+  value: 'publish.local.buffer.com',
+});
 
 const i18n = {
   translations: {
@@ -65,6 +69,15 @@ describe('middleware', () => {
       done();
     };
     validateCreditCard();
+  });
+
+  it('if upgraded to pro, it redirects to classic Buffer', () => {
+    window.location.assign = jest.fn();
+    const action = {
+      type: `upgradeToPro_${asyncDataFetchActionTypes.FETCH_SUCCESS}`,
+    };
+    middleware(store)(next)(action);
+    expect(window.location.assign).toHaveBeenCalledWith('https://local.buffer.com/classic');
   });
 
   describe('error handling', () => {

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -21,6 +21,7 @@
   },
   "author": "mike@msanroman.io",
   "dependencies": {
+    "@bufferapp/publish-utils": "1.8.0",
     "@bufferapp/keywrapper": "0.2.0"
   },
   "devDependencies": {

--- a/packages/utils/getClassicBufferURL/index.js
+++ b/packages/utils/getClassicBufferURL/index.js
@@ -1,0 +1,6 @@
+module.exports = () => {
+  if (window.location.hostname === 'publish.local.buffer.com') {
+    return 'https://local.buffer.com/classic';
+  }
+  return 'https://buffer.com/classic';
+};

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -5,6 +5,7 @@ const userParser = require('./userParser');
 const linkParsing = require('./linkParsing');
 const buildPostMap = require('./buildPostMap');
 const constants = require('./constants');
+const getClassicBufferURL = require('./getClassicBufferURL');
 
 module.exports = {
   date,
@@ -14,4 +15,5 @@ module.exports = {
   linkParsing,
   buildPostMap,
   constants,
+  getClassicBufferURL,
 };


### PR DESCRIPTION
### Purpose

Uses the new Account Management upgrade endpoint specified on
https://github.com/bufferapp/README/blob/master/billing/api-endpoints.md
and released on https://github.com/bufferapp/buffer-web/pull/15173.

The RPC endpoint encapsulates the config details that the user can't
choose (product is "publish" and the plan is "pro").