### PR TITLE
Use new URL to go to own org

### DIFF
--- a/packages/profile-sidebar/middleware.js
+++ b/packages/profile-sidebar/middleware.js
@@ -16,9 +16,9 @@ import {
 
 const getConnectAccountURL = () => {
   if (window.location.hostname === 'publish.local.buffer.com') {
-    return 'https://local.buffer.com/manage';
+    return 'https://local.buffer.com/manage/own';
   }
-  return 'https://buffer.com/manage';
+  return 'https://buffer.com/manage/own';
 };
 
 export default ({ dispatch, getState }) => next => (action) => {


### PR DESCRIPTION
Use new URL for going directly to own org. (https://github.com/bufferapp/buffer-web/pull/15221)