### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To get started on local development and testing:
 5. **Start up the publish docker containers**
     ```bash
     $ cd ../buffer-dev
-    $ ./dev up session-service login account publish
+    $ ./dev up session-service login publish
    ```
 
    Publish relies on both the **session** and **account** services, so it's important to include them in our _up_ command. The order is important, since this relates to the way docker-compose starts up containers.


### PR DESCRIPTION
Updated ./dev up command

### Purpose
Update the documentation because it wasn't up to date.

### Notes
The account isn't necessary to start the publish server.

### Review
Could you try to check if the command works the same way without the account param?

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
