### PR TITLE
[PUB-623] Don't show app switcher for NTB-F Users

### DIFF
--- a/packages/app-switcher/package.json
+++ b/packages/app-switcher/package.json
@@ -4,7 +4,8 @@
   "description": "Displays a popup and modal for beta publish users to switch to classic Buffer",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint . --ignore-pattern coverage node_modules"
+    "lint": "eslint . --ignore-pattern coverage node_modules",
+    "test-watch": "jest --watch"
   },
   "author": "hamstu@gmail.com",
   "dependencies": {

--- a/packages/app-switcher/reducer.js
+++ b/packages/app-switcher/reducer.js
@@ -19,9 +19,7 @@ export default (state = initialState, action) => {
     case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
       return {
         ...state,
-        // TODO: uncomment this back in when we can roll out to free users
-        // showGoBackToClassic: !action.result.is_free_user,
-        showGoBackToClassic: true,
+        showGoBackToClassic: !action.result.features.includes('new_publish_new_buffer_free_users'),
         user: {
           ...action.result,
           loading: false,

--- a/packages/app-switcher/reducer.js
+++ b/packages/app-switcher/reducer.js
@@ -5,7 +5,7 @@ import {
 
 export const actionTypes = {};
 
-const initialState = {
+export const initialState = {
   redirecting: false,
   showGoBackToClassic: false,
   submittingFeedback: false,

--- a/packages/app-switcher/reducer.test.js
+++ b/packages/app-switcher/reducer.test.js
@@ -1,0 +1,72 @@
+import {
+  actionTypes as dataFetchActionTypes,
+  actions as dataFetchActions,
+} from '@bufferapp/async-data-fetch';
+
+import reducer from './reducer';
+
+describe('reducer', () => {
+  describe('actions', () => {
+    it('user_fetchSuccess triggers a FETCH_SUCCESS action', () => {
+      const id = 1;
+      const name = 'sendFeedback';
+      const result = 'result';
+      const args = {
+        body: 'test',
+      };
+      expect(dataFetchActions.fetchSuccess({ name, args, id, result })).toEqual({
+        type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
+        name,
+        args,
+        id,
+        result,
+      });
+    });
+
+    it('sendFeedback_fetchStart triggers a FETCH_START action', () => {
+      const id = 1;
+      const name = 'sendFeedback';
+      const args = {
+        body: 'test',
+      };
+      expect(dataFetchActions.fetchStart({ name, args, id })).toEqual({
+        type: `sendFeedback_${dataFetchActionTypes.FETCH_START}`,
+        name,
+        args,
+        id,
+      });
+    });
+
+    it('sendFeedback_fetchSuccess triggers a FETCH_SUCCESS action', () => {
+      const id = 1;
+      const name = 'sendFeedback';
+      const result = 'result';
+      const args = {
+        body: 'test',
+      };
+      expect(dataFetchActions.fetchSuccess({ name, args, id, result })).toEqual({
+        type: `sendFeedback_${dataFetchActionTypes.FETCH_SUCCESS}`,
+        name,
+        args,
+        id,
+        result,
+      });
+    });
+
+    it('sendFeedback_fetchFail triggers a FETCH_FAIL action', () => {
+      const id = 1;
+      const name = 'sendFeedback';
+      const error = 'error';
+      const args = {
+        body: 'test',
+      };
+      expect(dataFetchActions.fetchFail({ name, args, id, error })).toEqual({
+        type: `sendFeedback_${dataFetchActionTypes.FETCH_FAIL}`,
+        name,
+        args,
+        id,
+        error,
+      });
+    });
+  });
+});

--- a/packages/app-switcher/reducer.test.js
+++ b/packages/app-switcher/reducer.test.js
@@ -9,7 +9,7 @@ describe('reducer', () => {
   describe('actions', () => {
     it('user_fetchSuccess triggers a FETCH_SUCCESS action', () => {
       const id = 1;
-      const name = 'sendFeedback';
+      const name = 'user';
       const result = 'result';
       const args = {
         body: 'test',

--- a/packages/app-switcher/reducer.test.js
+++ b/packages/app-switcher/reducer.test.js
@@ -38,66 +38,47 @@ describe('reducer', () => {
         .toEqual(stateAfter);
     });
 
-    it('sendFeedback_fetchStart triggers a FETCH_START action', () => {
-      const submittingFeedback = true;
-      const redirecting = false;
-      const showGoBackToClassic = false;
-      const loading = true;
-      const result = { features: ['...'] };
+    it('sets submittingFeedback to true on FETCH_START', () => {
+      const stateAfter = {
+        ...initialState,
+        submittingFeedback: true,
+      };
 
       const action = {
         type: `sendFeedback_${dataFetchActionTypes.FETCH_START}`,
-        redirecting,
-        showGoBackToClassic,
-        submittingFeedback,
-        user: { loading },
-        result,
       };
-      const stateAfter = { redirecting, showGoBackToClassic, submittingFeedback, user: { loading } };
+
       deepFreeze(action);
       expect(reducer(undefined, action))
         .toEqual(stateAfter);
     });
 
-    it('sendFeedback_fetchSuccess triggers a FETCH_SUCCESS action', () => {
-      const submittingFeedback = false;
-      const redirecting = true;
-      const showGoBackToClassic = false;
-      const loading = true;
-      const result = { features: ['...'] };
+    it('sets submittingFeedback to false and redirecting to true on FETCH_SUCCESS', () => {
+      const stateAfter = {
+        ...initialState,
+        submittingFeedback: false,
+        redirecting: true,
+      };
 
       const action = {
         type: `sendFeedback_${dataFetchActionTypes.FETCH_SUCCESS}`,
-        redirecting,
-        showGoBackToClassic,
-        submittingFeedback,
-        user: { loading },
-        result,
       };
 
-      const stateAfter = { redirecting, showGoBackToClassic, submittingFeedback, user: { loading } };
       deepFreeze(action);
       expect(reducer(undefined, action))
         .toEqual(stateAfter);
     });
 
-    it('sendFeedback_fetchFail triggers a FETCH_FAIL action', () => {
-      const submittingFeedback = false;
-      const redirecting = false;
-      const showGoBackToClassic = false;
-      const loading = true;
-      const result = { features: ['...'] };
+    it('sets submittingFeedback to false on FETCH_FAIL', () => {
+      const stateAfter = {
+        ...initialState,
+        submittingFeedback: false,
+      };
 
       const action = {
         type: `sendFeedback_${dataFetchActionTypes.FETCH_FAIL}`,
-        redirecting,
-        showGoBackToClassic,
-        submittingFeedback,
-        user: { loading },
-        result,
       };
 
-      const stateAfter = { redirecting, showGoBackToClassic, submittingFeedback, user: { loading } };
       deepFreeze(action);
       expect(reducer(undefined, action))
         .toEqual(stateAfter);

--- a/packages/app-switcher/reducer.test.js
+++ b/packages/app-switcher/reducer.test.js
@@ -2,43 +2,37 @@ import {
   actionTypes as dataFetchActionTypes,
 } from '@bufferapp/async-data-fetch';
 import deepFreeze from 'deep-freeze';
-import reducer from './reducer';
+import reducer, { initialState } from './reducer';
 
 describe('reducer', () => {
   describe('actions', () => {
     it('should initialize default state', () => {
-      const stateAfter = {
-        redirecting: false,
-        showGoBackToClassic: false,
-        submittingFeedback: false,
-        user: {
-          loading: true,
-        },
-      };
       const action = {
         type: 'INIT',
       };
       deepFreeze(action);
       expect(reducer(undefined, action))
-        .toEqual(stateAfter);
+        .toEqual(initialState);
     });
 
-    it('user_fetchSuccess triggers a FETCH_SUCCESS action', () => {
-      const redirecting = false;
-      const showGoBackToClassic = true;
-      const submittingFeedback = false;
-      const loading = false;
-      const result = { features: ['...'] };
+    it('sets showGoBackToClassic to true when the user is on new publish beta', () => {
+      const features = ['new_publish_beta', 'new_publish_beta_redirect'];
+      const stateAfter = {
+        ...initialState,
+        showGoBackToClassic: true,
+        user: {
+          loading: false,
+          features,
+        },
+      };
 
       const action = {
         type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
-        redirecting,
-        showGoBackToClassic,
-        submittingFeedback,
-        user: { loading },
-        result,
+        result: {
+          features,
+        },
       };
-      const stateAfter = { redirecting, showGoBackToClassic, submittingFeedback, user: { loading, features: ['...'] } };
+
       deepFreeze(action);
       expect(reducer(undefined, action))
         .toEqual(stateAfter);

--- a/packages/app-switcher/reducer.test.js
+++ b/packages/app-switcher/reducer.test.js
@@ -1,72 +1,112 @@
 import {
   actionTypes as dataFetchActionTypes,
-  actions as dataFetchActions,
 } from '@bufferapp/async-data-fetch';
-
+import deepFreeze from 'deep-freeze';
 import reducer from './reducer';
 
 describe('reducer', () => {
   describe('actions', () => {
-    it('user_fetchSuccess triggers a FETCH_SUCCESS action', () => {
-      const id = 1;
-      const name = 'user';
-      const result = 'result';
-      const args = {
-        body: 'test',
+    it('should initialize default state', () => {
+      const stateAfter = {
+        redirecting: false,
+        showGoBackToClassic: false,
+        submittingFeedback: false,
+        user: {
+          loading: true,
+        },
       };
-      expect(dataFetchActions.fetchSuccess({ name, args, id, result })).toEqual({
+      const action = {
+        type: 'INIT',
+      };
+      deepFreeze(action);
+      expect(reducer(undefined, action))
+        .toEqual(stateAfter);
+    });
+
+    it('user_fetchSuccess triggers a FETCH_SUCCESS action', () => {
+      const redirecting = false;
+      const showGoBackToClassic = true;
+      const submittingFeedback = false;
+      const loading = false;
+      const result = { features: ['...'] };
+
+      const action = {
         type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
-        name,
-        args,
-        id,
+        redirecting,
+        showGoBackToClassic,
+        submittingFeedback,
+        user: { loading },
         result,
-      });
+      };
+      const stateAfter = { redirecting, showGoBackToClassic, submittingFeedback, user: { loading, features: ['...'] } };
+      deepFreeze(action);
+      expect(reducer(undefined, action))
+        .toEqual(stateAfter);
     });
 
     it('sendFeedback_fetchStart triggers a FETCH_START action', () => {
-      const id = 1;
-      const name = 'sendFeedback';
-      const args = {
-        body: 'test',
-      };
-      expect(dataFetchActions.fetchStart({ name, args, id })).toEqual({
+      const submittingFeedback = true;
+      const redirecting = false;
+      const showGoBackToClassic = false;
+      const loading = true;
+      const result = { features: ['...'] };
+
+      const action = {
         type: `sendFeedback_${dataFetchActionTypes.FETCH_START}`,
-        name,
-        args,
-        id,
-      });
+        redirecting,
+        showGoBackToClassic,
+        submittingFeedback,
+        user: { loading },
+        result,
+      };
+      const stateAfter = { redirecting, showGoBackToClassic, submittingFeedback, user: { loading } };
+      deepFreeze(action);
+      expect(reducer(undefined, action))
+        .toEqual(stateAfter);
     });
 
     it('sendFeedback_fetchSuccess triggers a FETCH_SUCCESS action', () => {
-      const id = 1;
-      const name = 'sendFeedback';
-      const result = 'result';
-      const args = {
-        body: 'test',
-      };
-      expect(dataFetchActions.fetchSuccess({ name, args, id, result })).toEqual({
+      const submittingFeedback = false;
+      const redirecting = true;
+      const showGoBackToClassic = false;
+      const loading = true;
+      const result = { features: ['...'] };
+
+      const action = {
         type: `sendFeedback_${dataFetchActionTypes.FETCH_SUCCESS}`,
-        name,
-        args,
-        id,
+        redirecting,
+        showGoBackToClassic,
+        submittingFeedback,
+        user: { loading },
         result,
-      });
+      };
+
+      const stateAfter = { redirecting, showGoBackToClassic, submittingFeedback, user: { loading } };
+      deepFreeze(action);
+      expect(reducer(undefined, action))
+        .toEqual(stateAfter);
     });
 
     it('sendFeedback_fetchFail triggers a FETCH_FAIL action', () => {
-      const id = 1;
-      const name = 'sendFeedback';
-      const error = 'error';
-      const args = {
-        body: 'test',
-      };
-      expect(dataFetchActions.fetchFail({ name, args, id, error })).toEqual({
+      const submittingFeedback = false;
+      const redirecting = false;
+      const showGoBackToClassic = false;
+      const loading = true;
+      const result = { features: ['...'] };
+
+      const action = {
         type: `sendFeedback_${dataFetchActionTypes.FETCH_FAIL}`,
-        name,
-        args,
-        id,
-        error,
-      });
+        redirecting,
+        showGoBackToClassic,
+        submittingFeedback,
+        user: { loading },
+        result,
+      };
+
+      const stateAfter = { redirecting, showGoBackToClassic, submittingFeedback, user: { loading } };
+      deepFreeze(action);
+      expect(reducer(undefined, action))
+        .toEqual(stateAfter);
     });
   });
 });


### PR DESCRIPTION
### Purpose
When feature ‘new_publish_new_buffer_free_users’ is present prevent showing the app switcher in New Publish.

### Notes

### Review
Verify that the app switcher doesn't display for New Buffer Free Users.

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
