### PR TITLE
[PUB-632] Adding condition in new Publish for new feature flip

### DIFF
--- a/packages/beta-redirect/middleware.js
+++ b/packages/beta-redirect/middleware.js
@@ -14,9 +14,15 @@ export default ({ getState, dispatch }) => next => (action) => {
   next(action);
   switch (action.type) {
     case `user_${dataFetchActionTypes.FETCH_SUCCESS}`: {
-      const { hasPublishBeta, hasPublishBetaRedirect } = getState().betaRedirect;
+      const {
+        hasPublishBeta,
+        hasPublishBetaRedirect,
+        hasNewPublishNewFreeUser,
+      } = getState().betaRedirect;
       if (!hasPublishBeta) {
-        window.location = getClassicBufferURL();
+        if (!hasNewPublishNewFreeUser) {
+          window.location = getClassicBufferURL();
+        }
       } else if (!hasPublishBetaRedirect) {
         dispatch(dataFetchActions.fetch({ name: 'savePublishBetaRedirect' }));
       }

--- a/packages/beta-redirect/middleware.test.js
+++ b/packages/beta-redirect/middleware.test.js
@@ -4,7 +4,7 @@ import middleware from './middleware';
 
 describe('middleware', () => {
   const next = jest.fn();
-  it('if has feature flips it redirects to classic Buffer', () => {
+  it('if user has publishBeta feature it should dispatch savePublishBetaRedirect', () => {
     const dispatch = jest.fn();
     const betaRedirect = {
       hasPublishBeta: true,
@@ -27,5 +27,26 @@ describe('middleware', () => {
       .toBeCalledWith(asyncDataFetchActions.fetch({
         name: 'savePublishBetaRedirect',
       }));
+  });
+
+  it('if user doesn\'t have hasNewPublishNewFreeUser feature should redirect to classic Buffer', () => {
+    const dispatch = jest.fn();
+    const betaRedirect = {
+      hasPublishBeta: false,
+      hasPublishBetaRedirect: false,
+      hasNewPublishNewFreeUser: true,
+    };
+    const store = {
+      dispatch,
+      getState: () => ({
+        betaRedirect,
+      }),
+    };
+    const action = {
+      type: `user_${asyncDataFetchActionTypes.FETCH_SUCCESS}`,
+    };
+    middleware(store)(next)(action);
+    expect(next)
+      .toBeCalledWith(action);
   });
 });

--- a/packages/beta-redirect/middleware.test.js
+++ b/packages/beta-redirect/middleware.test.js
@@ -1,0 +1,31 @@
+import { actions as asyncDataFetchActions, actionTypes as asyncDataFetchActionTypes } from '@bufferapp/async-data-fetch';
+
+import middleware from './middleware';
+
+describe('middleware', () => {
+  const next = jest.fn();
+  it('if has feature flips it redirects to classic Buffer', () => {
+    const dispatch = jest.fn();
+    const betaRedirect = {
+      hasPublishBeta: true,
+      hasPublishBetaRedirect: false,
+      hasNewPublishNewFreeUser: false,
+    };
+    const store = {
+      dispatch,
+      getState: () => ({
+        betaRedirect,
+      }),
+    };
+    const action = {
+      type: `user_${asyncDataFetchActionTypes.FETCH_SUCCESS}`,
+    };
+    middleware(store)(next)(action);
+    expect(next)
+      .toBeCalledWith(action);
+    expect(store.dispatch)
+      .toBeCalledWith(asyncDataFetchActions.fetch({
+        name: 'savePublishBetaRedirect',
+      }));
+  });
+});

--- a/packages/beta-redirect/reducer.js
+++ b/packages/beta-redirect/reducer.js
@@ -18,6 +18,7 @@ export default (state = initialState, action) => {
         loading: false,
         hasPublishBeta: features.includes('new_publish_beta'),
         hasPublishBetaRedirect: features.includes('new_publish_beta_redirect'),
+        hasNewPublishNewFreeUser: features.includes('new_publish_new_buffer_free_users'),
       };
     }
     default:


### PR DESCRIPTION
…Buffer Free Users” to Buffer Classic if they have the “new_publish_new_buffer_free_users” feature flip.

### Purpose
Adding a condition in new Publish, so that it doesn’t redirect “New to Buffer Free Users” to Buffer Classic if they have the “new_publish_new_buffer_free_users” feature flip.

### Notes

### Review
Verify that the condition is placed correctly.

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
