### PR TITLE
Adding conditions to redirect New to Buffer Free Users to New Publish…

### DIFF
--- a/packages/beta-redirect/components/EnsurePublishBetaUser/index.jsx
+++ b/packages/beta-redirect/components/EnsurePublishBetaUser/index.jsx
@@ -4,13 +4,13 @@ import PropTypes from 'prop-types';
 
 import { BufferLoading } from '@bufferapp/publish-shared-components';
 
-const EnsurePublishBetaUser = ({ children, loading, hasPublishBeta }) => {
-  if (loading || !hasPublishBeta) {
+const EnsurePublishBetaUser = ({ children, loading, hasPublishBeta, hasNewPublishNewFreeUser }) => {
+  if (loading || (!hasPublishBeta && !hasNewPublishNewFreeUser)) {
     return (
       <BufferLoading fullscreen />
     );
   }
-  if (hasPublishBeta) {
+  if (hasPublishBeta || hasNewPublishNewFreeUser) {
     return children;
   }
 };
@@ -19,6 +19,7 @@ EnsurePublishBetaUser.propTypes = {
   children: PropTypes.node.isRequired,
   loading: PropTypes.bool.isRequired,
   hasPublishBeta: PropTypes.bool.isRequired,
+  hasNewPublishNewFreeUser: PropTypes.bool.isRequired,
 };
 
 export default EnsurePublishBetaUser;

--- a/packages/beta-redirect/index.js
+++ b/packages/beta-redirect/index.js
@@ -5,6 +5,7 @@ import EnsurePublishBetaUser from './components/EnsurePublishBetaUser';
 export default connect(
   state => ({
     hasPublishBeta: state.betaRedirect.hasPublishBeta,
+    hasNewPublishNewFreeUser: state.betaRedirect.hasNewPublishNewFreeUser,
     loading: state.betaRedirect.loading,
   }),
 )(EnsurePublishBetaUser);

--- a/packages/beta-redirect/reducer.js
+++ b/packages/beta-redirect/reducer.js
@@ -7,6 +7,7 @@ export const actionTypes = {};
 const initialState = {
   hasPublishBeta: false,
   hasPublishBetaRedirect: false,
+  hasNewPublishNewFreeUser: false,
   loading: true,
 };
 


### PR DESCRIPTION
… when newly signed up.

### Purpose
Fixing problem when redirecting newly signed up free users to New Publish, it was only displaying the loading icon instead of redirecting to new publish.

### Review
Make sure new users are redirecting either to New Publish or to Buffer Classic.

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
