### PR TITLE
Add distinction for custom scheduled posts in the queue

### DIFF
--- a/packages/shared-components/PostFooter/index.jsx
+++ b/packages/shared-components/PostFooter/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   Text,
   WarningIcon,
+  ClockIcon,
 } from '@bufferapp/components';
 import {
   borderWidth,
@@ -39,9 +40,10 @@ const postControlsStyle = {
 
 /* eslint-disable react/prop-types */
 
-const renderIcon = () =>
+const renderIcon = ({ postDetails }, hasError) =>
   (<div style={postActionDetailsIconStyle}>
-    <WarningIcon color={'torchRed'} />
+    {hasError ? <WarningIcon color={'torchRed'} /> : ''}
+    {postDetails.isCustomScheduled ? <ClockIcon color={'outerSpace'} /> : ''}
   </div>);
 
 const renderText = ({ postDetails }, hasError) =>
@@ -73,7 +75,7 @@ const PostFooter = ({
   const hasError = postDetails.error && postDetails.error.length > 0;
   return (<div style={getPostDetailsStyle(dragging)}>
     <div style={postActionDetailsStyle}>
-      {hasError && renderIcon()}
+      {renderIcon({ postDetails }, hasError)}
       {renderText({ postDetails }, hasError)}
     </div>
     { !sent && (

--- a/packages/shared-components/PostFooter/index.jsx
+++ b/packages/shared-components/PostFooter/index.jsx
@@ -40,10 +40,14 @@ const postControlsStyle = {
 
 /* eslint-disable react/prop-types */
 
-const renderIcon = ({ postDetails }, hasError) =>
+const renderCustomScheduledIcon = () =>
   (<div style={postActionDetailsIconStyle}>
-    {hasError ? <WarningIcon color={'torchRed'} /> : ''}
-    {postDetails.isCustomScheduled ? <ClockIcon color={'outerSpace'} /> : ''}
+    <ClockIcon color={'outerSpace'} />
+  </div>);
+
+const renderErrorIcon = () =>
+  (<div style={postActionDetailsIconStyle}>
+    <WarningIcon color={'torchRed'} />
   </div>);
 
 const renderText = ({ postDetails }, hasError) =>
@@ -73,9 +77,11 @@ const PostFooter = ({
   dragging,
 }) => {
   const hasError = postDetails.error && postDetails.error.length > 0;
+  const isCustomScheduled = postDetails.isCustomScheduled;
   return (<div style={getPostDetailsStyle(dragging)}>
     <div style={postActionDetailsStyle}>
-      {renderIcon({ postDetails }, hasError)}
+      {hasError && renderErrorIcon()}
+      {isCustomScheduled && renderCustomScheduledIcon()}
       {renderText({ postDetails }, hasError)}
     </div>
     { !sent && (

--- a/packages/shared-components/PostFooter/story.jsx
+++ b/packages/shared-components/PostFooter/story.jsx
@@ -11,6 +11,11 @@ const postDetails = {
   postAction: 'This post will be sent at 9:21 (GMT)',
 };
 
+const postDetailsCustomScheduled = {
+  postAction: 'This post is custom scheduled for 9:21 (GMT)',
+  isCustomScheduled: true,
+};
+
 const postDetailsError = {
   postAction: 'This post will be sent at 9:21 (GMT)',
   error: 'Woops! Something went wrong. Try again?',
@@ -32,6 +37,12 @@ storiesOf('PostFooter', module)
   .add('sent post', () => (
     <PostFooter
       postDetails={postDetails}
+      sent
+    />
+  ))
+  .add('custom scheduled post', () => (
+    <PostFooter
+      postDetails={postDetailsCustomScheduled}
       sent
     />
   ))

--- a/packages/utils/postParser.js
+++ b/packages/utils/postParser.js
@@ -29,7 +29,7 @@ const getPostActionString = ({ post }) => {
   );
 
   if (post.scheduled_at) {
-    return `This post ${post.sent_at ? 'was ' : 'is '} custom scheduled for ${dateString}.`;
+    return `This post ${post.sent_at ? 'was' : 'is'} custom scheduled for ${dateString}.`;
   }
   return `This post ${post.sent_at ? 'was' : 'will be'} sent ${dateString}.`;
 };

--- a/packages/utils/postParser.js
+++ b/packages/utils/postParser.js
@@ -27,6 +27,10 @@ const getPostActionString = ({ post }) => {
       twentyFourHourTime: post.twentyfour_hour_time,
     },
   );
+
+  if (post.scheduled_at) {
+    return `This post ${post.sent_at ? 'was ' : 'is '} custom scheduled for ${dateString}.`;
+  }
   return `This post ${post.sent_at ? 'was' : 'will be'} sent ${dateString}.`;
 };
 
@@ -34,6 +38,7 @@ const getPostDetails = ({ post }) => ({
   postAction: getPostActionString({ post }),
   isRetweet: post.retweet !== undefined,
   error: post.error || '',
+  isCustomScheduled: post.scheduled_at ? true : false,
 });
 
 const getRetweetProfileInfo = (post) => {

--- a/packages/utils/postParser.test.js
+++ b/packages/utils/postParser.test.js
@@ -1,47 +1,124 @@
 import postParser from './postParser';
 
-const tweet = {
-  profile_service: 'twitter',
-  text: 'What Do the New Twitter Rules Mean for Social Media Managers (and Buffer Customers) https://buff.ly/2JNS3tL',
-  type: 'text',
-};
-const retweet = {
-  profile_service: 'twitter',
-  retweet: {
-    user_id: 19475858,
-    tweet_id: '990952846110658560',
-    username: 'LouPas',
-    url: 'https://twitter.com/LouPas/status/990952846110658560',
-    created_at: 1525096544,
-    created_at_string: 'Mon Apr 30 13:55:44 +0000 2018',
-    profile_name: 'Lou Paskalis',
-    text: '“The Daily has more listeners that the New York Times has readers. We are the new front page and reporters want to be on our show because of the power of that megaphone. You don’t skim a podcast” Michael Barbaro, TheDaily, #NewFronts https://t.co/zJR5wjR6e5',
-    avatars: {
-      http: 'http://pbs.twimg.com/profile_images/867425050043052033/Ci4OgTlV_normal.jpg',
-      https: 'https://pbs.twimg.com/profile_images/867425050043052033/Ci4OgTlV_normal.jpg',
-    },
-    comment: 'Fascinating #Really',
-    comment_formatted: 'Fascinating <a href="https://twitter.com/#!/search?q=%23Really" title="#Really" class="hashtag" rel="external nofollow" target="_blank">#Really</a>',
-  },
-  retweeted_tweet_id: '990952846110658560',
-  text: 'Fascinating',
-  text_formatted: '“The Daily has more listeners that the New York Times has readers. We are the new front page and reporters want to be on our show because of the power of that megaphone. You don’t skim a podcast” Michael Barbaro, TheDaily, <a href="https://twitter.com/#!/search?q=%23NewFronts" title="#NewFronts" class="hashtag" rel="external nofollow" target="_blank">#NewFronts</a> <a class="url" href="https://t.co/zJR5wjR6e5" rel="external nofollow" target="_blank">https://t.co/zJR5wjR6e5</a>',
-  type: 'retweet',
-};
-
 describe('post parser', () => {
-  it('extracts links from retweet', () => {
-    const parsedPost = postParser(retweet);
-    expect(parsedPost.links).toHaveLength(2);
-  });
+  describe('retweets', () => {
+    const retweet = {
+      profile_service: 'twitter',
+      retweet: {
+        user_id: 19475858,
+        tweet_id: '990952846110658560',
+        username: 'LouPas',
+        url: 'https://twitter.com/LouPas/status/990952846110658560',
+        created_at: 1525096544,
+        created_at_string: 'Mon Apr 30 13:55:44 +0000 2018',
+        profile_name: 'Lou Paskalis',
+        text: '“The Daily has more listeners that the New York Times has readers. We are the new front page and reporters want to be on our show because of the power of that megaphone. You don’t skim a podcast” Michael Barbaro, TheDaily, #NewFronts https://t.co/zJR5wjR6e5',
+        avatars: {
+          http: 'http://pbs.twimg.com/profile_images/867425050043052033/Ci4OgTlV_normal.jpg',
+          https: 'https://pbs.twimg.com/profile_images/867425050043052033/Ci4OgTlV_normal.jpg',
+        },
+        comment: 'Fascinating #Really',
+        comment_formatted: 'Fascinating <a href="https://twitter.com/#!/search?q=%23Really" title="#Really" class="hashtag" rel="external nofollow" target="_blank">#Really</a>',
+      },
+      retweeted_tweet_id: '990952846110658560',
+      text: 'Fascinating',
+      text_formatted: '“The Daily has more listeners that the New York Times has readers. We are the new front page and reporters want to be on our show because of the power of that megaphone. You don’t skim a podcast” Michael Barbaro, TheDaily, <a href="https://twitter.com/#!/search?q=%23NewFronts" title="#NewFronts" class="hashtag" rel="external nofollow" target="_blank">#NewFronts</a> <a class="url" href="https://t.co/zJR5wjR6e5" rel="external nofollow" target="_blank">https://t.co/zJR5wjR6e5</a>',
+      type: 'retweet',
+    };
 
-  it('stores links from retweet comment in retweetCommentLinks', () => {
-    const parsedPost = postParser(retweet);
-    expect(parsedPost.retweetCommentLinks).toHaveLength(1);
+    it('extracts links from retweet', () => {
+      const parsedPost = postParser(retweet);
+      expect(parsedPost.links).toHaveLength(2);
+    });
+
+    it('stores links from retweet comment in retweetCommentLinks', () => {
+      const parsedPost = postParser(retweet);
+      expect(parsedPost.retweetCommentLinks).toHaveLength(1);
+    });
   });
 
   it('does not extract retweetCommentLinks if there is no retweetComment', () => {
+    const tweet = {
+      profile_service: 'twitter',
+      text: 'What Do the New Twitter Rules Mean for Social Media Managers (and Buffer Customers) https://buff.ly/2JNS3tL',
+      type: 'text',
+    };
     const parsedPost = postParser(tweet);
     expect(parsedPost.retweetCommentLinks).toHaveLength(0);
+  });
+
+  it('displays a personalized postAction if it is a custom scheduled post', () => {
+    const customScheduledPost = {
+      text: 'Sample post',
+      due_at: 1141252640,
+      scheduled_at: 1141252640,
+    };
+    const parsedPost = postParser(customScheduledPost);
+    expect(parsedPost.postDetails).toBeDefined();
+    expect(parsedPost.postDetails.isCustomScheduled).toBe(true);
+    expect(parsedPost.postDetails.postAction).toEqual('This post is custom scheduled for March 1st at 10:37 PM (UTC).');
+  });
+
+  it('displays a personalized postAction if user has no scheduled posting times', () => {
+    const postWithNoSchedule = {
+      due_at: 0,
+    };
+    const parsedPost = postParser(postWithNoSchedule);
+    expect(parsedPost.postDetails).toBeDefined();
+    expect(parsedPost.postDetails.postAction).toEqual('No Time Set');
+  });
+
+  it('identifies type as text when post has no media property', () => {
+    const post = {
+      text: 'text',
+    };
+    const parsedPost = postParser(post);
+    expect(parsedPost.type).toEqual('text');
+  });
+
+  it('identifies type as image when post has media and media.picture properties', () => {
+    const imagePost = {
+      media: {
+        picture: 'pic',
+      },
+    };
+    const parsedPost = postParser(imagePost);
+    expect(parsedPost.type).toEqual('image');
+    expect(parsedPost.imageUrls).toEqual([]);
+  });
+
+  it('identifies type as multipleImage when post has media, media.picture and extra_media properties', () => {
+    const multipleImagePost = {
+      media: {
+        picture: 'pic',
+      },
+      extra_media: [{
+        photo: 'photo',
+        picture: 'picture',
+      }],
+    };
+    const parsedPost = postParser(multipleImagePost);
+    expect(parsedPost.type).toEqual('multipleImage');
+    expect(parsedPost.imageUrls).toEqual(['pic', 'photo']);
+  });
+
+  it('identifies type as video when post has media and media.video properties', () => {
+    const videoPost = {
+      media: {
+        video: 'video',
+      },
+    };
+    const parsedPost = postParser(videoPost);
+    expect(parsedPost.type).toEqual('video');
+  });
+
+  it('identifies type as link when post has media and media.link properties', () => {
+    const linkPost = {
+      media: {
+        link: 'https://sample.pt',
+      },
+    };
+    const parsedPost = postParser(linkPost);
+    expect(parsedPost.type).toEqual('link');
   });
 });


### PR DESCRIPTION
### Purpose
Add a dedicated footer message in the queue for custom scheduled posts.

### Notes
[PUB-539](https://buffer.atlassian.net/browse/PUB-539)
We will only be able to see this properly with buffer-composer on 1.10.4 or higher (adds ability to custom schedule posts)
