### PR TITLE
Update buffer-composer version to 1.10.5

### DIFF
--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -9,7 +9,7 @@
   "author": "melissa@buffer.com",
   "dependencies": {
     "@bufferapp/async-data-fetch": "1.9.3",
-    "@bufferapp/composer": "1.10.4",
+    "@bufferapp/composer": "1.10.5",
     "@bufferapp/keywrapper": "0.2.0",
     "@bufferapp/notifications": "1.9.3",
     "@bufferapp/publish-profile-sidebar": "1.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,9 +156,9 @@
     react-autocomplete "1.7.2"
     react-day-picker "6.2.1"
 
-"@bufferapp/composer@1.10.4":
-  version "1.10.4"
-  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-1.10.4.tgz#50b7ca1b253a735b5bdb603032d3b03d6c2b9dc1"
+"@bufferapp/composer@1.10.5":
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-1.10.5.tgz#01872b8ad7693a4854b1604268f42f5ed8b2bded"
   dependencies:
     "@bufferapp/buffer-js-api" "0.3.0"
     "@bufferapp/buffer-js-metrics" "0.2.0"


### PR DESCRIPTION
### Purpose
Update buffer-composer version to 1.10.5 to get custom scheduled posts on buffer-publish and to fix media elements' stack order.

### Notes
Task: [PUB-613](https://buffer.atlassian.net/browse/PUB-613)
Task: [PUB-573](https://buffer.atlassian.net/browse/PUB-573)