### PR TITLE
[PUB-648] Composer stacks on top of upgrade modal

### DIFF
--- a/packages/upgrade-modal/components/UpgradeModal/index.jsx
+++ b/packages/upgrade-modal/components/UpgradeModal/index.jsx
@@ -50,7 +50,7 @@ const UpgradeModal = ({
   selectCycle,
   hideModal,
 }) => (
-  <div style={{ position: 'fixed', zIndex: '1000' }}>
+  <div style={{ position: 'fixed', zIndex: '3000' }}>
     <Popover onOverlayClick={hideModal}>
       <div style={{ maxHeight: '100vh', overflow: 'auto' }}>
         <Card>


### PR DESCRIPTION
### Purpose
Fix Upgrade Modal stack order so it stays on top of the composer

### Notes
Task: [PUB-648](https://buffer.atlassian.net/browse/PUB-648)
