### PR TITLE
Hide custom scheduled icon in case of error

### DIFF
--- a/packages/shared-components/PostFooter/index.jsx
+++ b/packages/shared-components/PostFooter/index.jsx
@@ -81,7 +81,7 @@ const PostFooter = ({
   return (<div style={getPostDetailsStyle(dragging)}>
     <div style={postActionDetailsStyle}>
       {hasError && renderErrorIcon()}
-      {isCustomScheduled && renderCustomScheduledIcon()}
+      {isCustomScheduled && !hasError && renderCustomScheduledIcon()}
       {renderText({ postDetails }, hasError)}
     </div>
     { !sent && (


### PR DESCRIPTION
### Purpose
Don't display custom scheduled icon in a post footer in case there's an error.

### Notes
Task: [PUB-671](https://buffer.atlassian.net/browse/PUB-671)