### PR TITLE
[PUB-658] Remove horizontal scroll when the composer is opened in publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/bufferapp/project-donut#readme",
   "devDependencies": {
-    "@bufferapp/components": "2.3.2",
+    "@bufferapp/components": "2.3.4",
     "@storybook/addon-storyshots": "3.4.8",
     "@storybook/react": "3.4.8",
     "axe-core": "2.2.0",

--- a/packages/queue/components/ComposerPopover/index.jsx
+++ b/packages/queue/components/ComposerPopover/index.jsx
@@ -11,6 +11,7 @@ const ComposerPopover = ({
   <Popover
     left={'0px'}
     top={'73px'}
+    width={'auto'}
     transparentOverlay={transparentOverlay}
     onOverlayClick={onSave}
   >

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,18 +143,18 @@
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@bufferapp/chronos/-/chronos-0.6.1.tgz#0213dff339459ca510103e5a72f558682a2675dd"
 
-"@bufferapp/components@2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@bufferapp/components/-/components-2.3.2.tgz#ae23bf74abc5026c30751c37711cbba4852b624f"
+"@bufferapp/components@2.3.3":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@bufferapp/components/-/components-2.3.3.tgz#eb9ca5dc4e563a76d793420a9f8f675613526cd3"
   dependencies:
     "@bufferapp/react-keyframes" "0.2.5"
     raf "3.4.0"
     react-autocomplete "1.7.2"
     react-day-picker "6.2.1"
 
-"@bufferapp/components@2.3.3":
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/@bufferapp/components/-/components-2.3.3.tgz#eb9ca5dc4e563a76d793420a9f8f675613526cd3"
+"@bufferapp/components@2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@bufferapp/components/-/components-2.3.4.tgz#b4937d958143b5c2b5d50ea831b7344b2399602d"
   dependencies:
     "@bufferapp/react-keyframes" "0.2.5"
     raf "3.4.0"


### PR DESCRIPTION
### Purpose

Popover component comes with width: 100vw causing an horizontal scroll when someone opens the composer. Updated the components package to allow `width: auto` for popover. 
https://buffer.atlassian.net/browse/PUB-658

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
