### PR TITLE
Change composer popover width from auto to 100%

### DIFF
--- a/packages/queue/components/ComposerPopover/index.jsx
+++ b/packages/queue/components/ComposerPopover/index.jsx
@@ -11,7 +11,7 @@ const ComposerPopover = ({
   <Popover
     left={'0px'}
     top={'73px'}
-    width={'auto'}
+    width={'100%'}
     transparentOverlay={transparentOverlay}
     onOverlayClick={onSave}
   >


### PR DESCRIPTION
### Purpose

Change composer popover width from auto to 100% to allow users to click outside the composer to close it. 

### Notes

This is from a bug fix I made earlier today regarding the horizontal scroll. Width set to auto causes the user to not have the option to close out of the composer. https://buffer.atlassian.net/browse/PUB-658

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
