### PR TITLE
[PUB-500] Addressing issue with Drag and Drop not working when intended

### DIFF
--- a/packages/profile-page/components/ProfilePage/index.jsx
+++ b/packages/profile-page/components/ProfilePage/index.jsx
@@ -108,7 +108,7 @@ const ProfilePage = ({
           growthSpace={1}
         >
           <div style={tabContentStyle}>
-            {TabContent({ tabId, profileId })}
+            <TabContent tabId={tabId} profileId={profileId} />
             {showLoadMoreButton &&
               <div style={buttonContainerStyle}>
                 <Button

--- a/packages/queue/middleware.js
+++ b/packages/queue/middleware.js
@@ -24,6 +24,15 @@ export default ({ dispatch, getState }) => next => (action) => {
         },
       }));
       break;
+    case `updatePausedSchedules_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      dispatch(dataFetchActions.fetch({
+        name: 'queuedPosts',
+        args: {
+          profileId: action.args.profileId,
+          isFetchingMore: false,
+        },
+      }));
+      break;
     case `COMPOSER_EVENT`:
       if (action.eventType === 'saved-drafts') {
         dispatch(notificationActions.createNotification({

--- a/packages/queue/middleware.test.js
+++ b/packages/queue/middleware.test.js
@@ -50,6 +50,26 @@ describe('middleware', () => {
     }));
   });
 
+  it('should fetch queuedPosts if updatePausedSchedules is successful', () => {
+    const action = {
+      type: `updatePausedSchedules_${dataFetchActionTypes.FETCH_SUCCESS}`,
+      args: {
+        profileId: 'id1',
+      },
+    };
+    middleware({ dispatch })(next)(action);
+    expect(next)
+      .toBeCalledWith(action);
+    expect(dispatch)
+      .toBeCalledWith(dataFetchActions.fetch({
+        name: 'queuedPosts',
+        args: {
+          profileId: action.args.profileId,
+          isFetchingMore: false,
+        },
+      }));
+  });
+
   it('should trigger a notification for COMPOSER_EVENT in case of success', () => {
     const action = {
       type: 'COMPOSER_EVENT',


### PR DESCRIPTION
### Purpose

We are now reloading the post list in the queue when the scheduled times get modified in the settings panel, to ensure that we are always have the right schedule post times for the posts, and the Drag and Drop works as expected as a consequence