### PR TITLE
hide (coming soon) on analyze in the sidebar

### DIFF
--- a/packages/app-sidebar/components/AppSidebar/index.jsx
+++ b/packages/app-sidebar/components/AppSidebar/index.jsx
@@ -47,7 +47,7 @@ const AppSidebar = ({ activeProduct, user, environment, onMenuItemClick }) => (
     <PopoverButton
       icon={<AnalyzeIcon />}
       active={activeProduct === 'analyze'}
-      label="Analyze (Coming Soon)"
+      label={`Analyze ${activeProduct === 'analyze' ? '' : '(Coming Soon)'}`}
       href="https://buffer.com/analyze"
       newWindow
     />

--- a/packages/app-sidebar/components/AppSidebar/story.jsx
+++ b/packages/app-sidebar/components/AppSidebar/story.jsx
@@ -23,4 +23,14 @@ storiesOf('AppSidebar', module)
         environment={'production'}
       />
     </div>
+  ))
+  .add('should not show Coming soon if active product is Analyze', () => (
+    <div style={{ width: '65px', height: '100%', display: 'flex' }}>
+      <AppSidebar
+        activeProduct="analyze"
+        translations={translations}
+        user={fakeUser}
+        environment={'production'}
+      />
+    </div>
   ));


### PR DESCRIPTION
### Purpose
To hide the '(Coming soon)' string when we are on Analyze, as in that case we know the user has access to Analyze.

### Notes
Hey @hamstu super small one :smile:, just want to make sure I'm not missing any cases where we could have that icon active and not being an Analyze customer.

Also tried to run `jest -u` to update the snapshots but I'm getting lots of errors parsing files from node_modules. Any reason for that?

Thanks!

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
