### PR TITLE
Adding null fallback for FeatureLoader component to handle failure more gracefully when no fallback is supplied

### DIFF
--- a/packages/product-features/components/FeatureLoader/index.jsx
+++ b/packages/product-features/components/FeatureLoader/index.jsx
@@ -18,7 +18,7 @@ const FeatureLoader = ({
       .map(p => p.toLowerCase());
     const currentPlan = planName.toLowerCase();
     if (!supportedPlanList.some((plan) => plan === currentPlan)) {
-      return fallback;
+      return fallback || null;
     }
   }
 
@@ -29,7 +29,7 @@ const FeatureLoader = ({
       .map(f => f.toLowerCase());
 
     if (!supportedFeatureNames.some(feature => currentFeatures.indexOf(feature) >= 0)) {
-      return fallback;
+      return fallback || null;
     }
   }
 

--- a/packages/product-features/components/FeatureLoader/story.jsx
+++ b/packages/product-features/components/FeatureLoader/story.jsx
@@ -217,4 +217,17 @@ storiesOf('FeatureLoader', module)
         </Text>
       </FeatureLoader>
     </div>
+  ))
+  .add('should not show component if no fallback is provided and feature non existant', () => (
+    <div style={defaultStyles}>
+      <FeatureLoader
+        productFeatures={fakeFeatures}
+        supportedFeatures={['not_here']}
+        supportedPlans={['free']}
+      >
+        <Text size={'large'} >
+          Pro
+        </Text>
+      </FeatureLoader>
+    </div>
   ));


### PR DESCRIPTION
### Purpose

Falling back component to null when no fallback component is passed into the parent... otherwise it can cause an error

### Notes

@anafilipadealmeida this should mean you don't need to do the `fallback={null}` thing