### PR TITLE
Add Drafts Tabs

### DIFF
--- a/packages/profile-page/components/ProfilePage/index.jsx
+++ b/packages/profile-page/components/ProfilePage/index.jsx
@@ -5,6 +5,7 @@ import { Redirect } from 'react-router';
 
 import QueuedPosts from '@bufferapp/publish-queue';
 import SentPosts from '@bufferapp/publish-sent';
+import DraftList from '@bufferapp/publish-drafts'
 import ProfileSettings from '@bufferapp/publish-settings';
 import TabNavigation from '@bufferapp/publish-tabs';
 import ProfileSidebar from '@bufferapp/publish-profile-sidebar';
@@ -53,6 +54,12 @@ const TabContent = ({ tabId, profileId }) => {
           profileId={profileId}
         />
       );
+    case 'drafts':
+      return (
+        <DraftList
+          profileId={profileId}
+        />
+      );
     case 'settings':
       return (
         <ProfileSettings
@@ -87,7 +94,7 @@ const ProfilePage = ({
   moreToLoad,
   page,
 }) => {
-  const isPostsTab = ['queue', 'sent'].includes(tabId);
+  const isPostsTab = ['queue', 'sent', 'drafts'].includes(tabId);
   const handleScroll = (o) => {
     const reachedBottom = o.scrollHeight - o.scrollTop === o.clientHeight;
     if (reachedBottom && moreToLoad && isPostsTab && !loadingMore) {

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -4,6 +4,7 @@ import createHistory from 'history/createBrowserHistory';
 import { createMiddleware as createBufferMetricsMiddleware } from '@bufferapp/buffermetrics/redux';
 import { middleware as queueMiddleware } from '@bufferapp/publish-queue';
 import { middleware as sentMiddleware } from '@bufferapp/publish-sent';
+import { middleware as draftsMiddleware } from '@bufferapp/publish-drafts';
 import { middleware as settingsMiddleware } from '@bufferapp/publish-settings';
 import { middleware as profileSidebarMiddleware } from '@bufferapp/publish-profile-sidebar';
 import { middleware as appSidebarMiddleware } from '@bufferapp/app-sidebar';
@@ -79,6 +80,7 @@ const configureStore = (initialstate) => {
         defaultPageMiddleware,
         maintenanceRedirectMiddleware,
         bufferMetricsMiddleware,
+        draftsMiddleware,
       ),
     ),
   );

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -23,6 +23,7 @@
     "@bufferapp/publish-example": "1.9.3",
     "@bufferapp/publish-i18n": "^1.9.25",
     "@bufferapp/publish-modals": "^1.9.25",
+    "@bufferapp/publish-drafts": "^1.9.25",
     "@bufferapp/publish-profile-sidebar": "^1.9.25",
     "@bufferapp/publish-pusher-sync": "^1.9.25",
     "@bufferapp/publish-queue": "^1.9.25",

--- a/packages/store/reducers.js
+++ b/packages/store/reducers.js
@@ -4,6 +4,7 @@ import { routerReducer } from 'react-router-redux';
 import { reducer as tabsReducer } from '@bufferapp/publish-tabs';
 import { reducer as queueReducer } from '@bufferapp/publish-queue';
 import { reducer as sentReducer } from '@bufferapp/publish-sent';
+import { reducer as draftsReducer } from '@bufferapp/publish-drafts';
 import { reducer as settingsReducer } from '@bufferapp/publish-settings';
 import { reducer as i18nReducer } from '@bufferapp/publish-i18n';
 import { reducer as profileSidebarReducer } from '@bufferapp/publish-profile-sidebar';
@@ -47,4 +48,5 @@ export default combineReducers({
   twoFactorAuth: twoFactorAuthReducer,
   closeAccount: closeAccountReducer,
   productFeatures: productFeaturesReducer,
+  drafts: draftsReducer,
 });

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -29,6 +29,7 @@ const TabNavigation = ({
     >
       <Tab tabId={'queue'}>Queue</Tab>
       <Tab tabId={'sent'}>Sent Posts</Tab>
+      <Tab tabId={'drafts'}>Drafts</Tab>
       <Tab tabId={'settings'}>Settings</Tab>
       {shouldShowUpgradeCta &&
         <div style={upgradeCtaStyle}>

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -21,6 +21,7 @@ const TabNavigation = ({
   onTabClick,
   shouldShowUpgradeCta,
   showUpgradeModal,
+  hasDraftsFeatureFlip,
 }) =>
   /* wrapper div with "tabs" id necessary as a selector
   for a11y focus after selecting profile in sidebar */
@@ -31,13 +32,13 @@ const TabNavigation = ({
     >
       <Tab tabId={'queue'}>Queue</Tab>
       <Tab tabId={'sent'}>Sent Posts</Tab>
-      {isBusinessAccount && isManager &&
+      {hasDraftsFeatureFlip && isBusinessAccount && isManager &&
         <Tab tabId={'awaitingApproval'}>Awaiting Approval</Tab>
       }
-      {isBusinessAccount && !isManager &&
+      {hasDraftsFeatureFlip && isBusinessAccount && !isManager &&
         <Tab tabId={'pendingApproval'}>Pending Approval</Tab>
       }
-      {isBusinessAccount &&
+      {hasDraftsFeatureFlip && isBusinessAccount &&
         <Tab tabId={'drafts'}>Drafts</Tab>
       }
       <Tab tabId={'settings'}>Settings</Tab>
@@ -62,6 +63,7 @@ const TabNavigation = ({
 
 TabNavigation.defaultProps = {
   shouldShowUpgradeCta: false,
+  hasDraftsFeatureFlip: false,
 };
 
 TabNavigation.propTypes = {
@@ -69,6 +71,7 @@ TabNavigation.propTypes = {
   onTabClick: PropTypes.func.isRequired,
   shouldShowUpgradeCta: PropTypes.bool.isRequired,
   showUpgradeModal: PropTypes.func.isRequired,
+  hasDraftsFeatureFlip: PropTypes.bool
 };
 
 export default TabNavigation;

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -13,7 +13,7 @@ export default connect(
     isManager: state.profileSidebar.selectedProfile.isManager,
     selectedTabId: ownProps.tabId,
     shouldShowUpgradeCta: state.appSidebar.user.is_free_user,
-    hasDraftsFeatureFlip: state.appSidebar.user.features.includes('drafts_new-publish'),
+    hasDraftsFeatureFlip: state.appSidebar.user.features.includes('drafts_new_publish'),
   }),
   (dispatch, ownProps) => ({
     onTabClick: tabId => dispatch(push(generateProfilePageRoute({

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -13,7 +13,7 @@ export default connect(
     isManager: state.profileSidebar.selectedProfile.isManager,
     selectedTabId: ownProps.tabId,
     shouldShowUpgradeCta: state.appSidebar.user.is_free_user,
-    hasDraftsFeatureFlip: state.appSidebar.user.features.includes('drafts_new_publish'),
+    hasDraftsFeatureFlip: state.appSidebar.user.features ? state.appSidebar.user.features.includes('drafts_new_publish') : false,
   }),
   (dispatch, ownProps) => ({
     onTabClick: tabId => dispatch(push(generateProfilePageRoute({

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -13,6 +13,7 @@ export default connect(
     isManager: state.profileSidebar.selectedProfile.isManager,
     selectedTabId: ownProps.tabId,
     shouldShowUpgradeCta: state.appSidebar.user.is_free_user,
+    hasDraftsFeatureFlip: state.appSidebar.user.features.includes('drafts_new-publish'),
   }),
   (dispatch, ownProps) => ({
     onTabClick: tabId => dispatch(push(generateProfilePageRoute({


### PR DESCRIPTION
### Purpose
Add Drafts Tabs for B4B (under feature flip drafts_new_publish). The content inside the drafts is still a WIP, but since it's under the feature flip that's ok :)

### Notes
https://paper.dropbox.com/doc/Scoping-Drafts-for-B4B-in-New-Publish--APgxFyo0k4hehN9AhXk05A~GAg-lhOmSwceGa305exIkk3Ml
