### PR TITLE
Upgrade chart version and migrate to multi yaml format

### DIFF
--- a/helm/buffer-publish.dev.yaml
+++ b/helm/buffer-publish.dev.yaml
@@ -1,0 +1,9 @@
+namespace: dev
+track: staging
+replicaCount: 1
+deploymentUrl: "publish.dev.buffer.com"
+ingress:
+  enabled: true
+  path: /
+  annotations:
+    kubernetes.io/ingress.class: nginx

--- a/helm/buffer-publish.yaml
+++ b/helm/buffer-publish.yaml
@@ -1,5 +1,6 @@
 name: buffer-publish # Override to be the name of the application
 track: stable # stable | canary
+namespace: buffer
 replicaCount: 5
 deploymentUrl: "publish.buffer.com"
 chart: "buffercharts/buffer-service"

--- a/helm/buffer-publish.yaml
+++ b/helm/buffer-publish.yaml
@@ -1,6 +1,14 @@
 name: buffer-publish # Override to be the name of the application
 track: stable # stable | canary
 replicaCount: 5
+deploymentUrl: "publish.buffer.com"
+chart: "buffercharts/buffer-service"
+chartVersion: "1.0.1"
+cdEnabled: true
+cdBranchEnabled: true
+dockerfile: Dockerfile
+channel: eng-proj-kuberdash
+clusterName: "kubeeast"
 image:
   repository: bufferapp/buffer-publish # Override with the docker image
   tag: latest # this will be overriden by the build process
@@ -87,8 +95,4 @@ service:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:980620087509:certificate/6b704a93-67de-444c-89fc-9f659bf2dd42
 ingress:
-  enabled: true
-  path: /
-  annotations:
-    kubernetes.io/ingress.class: nginx
-  serviceDevUrl: "publish.dev.buffer.com"
+  enabled: false

--- a/helm/config.json
+++ b/helm/config.json
@@ -1,8 +1,0 @@
-{
-    "config": {
-        "chart": "https://github.com/bufferapp/helm-chart-base-templates/releases/download/v0.3.1/buffer-service-0.3.1.tgz",
-        "name": "buffer-publish",
-        "namespace": "buffer",
-        "deployment_url": "publish.buffer.com"
-    }
-}

--- a/helm/config.json
+++ b/helm/config.json
@@ -1,6 +1,6 @@
 {
     "config": {
-        "chart": "https://github.com/bufferapp/helm-chart-base-templates/releases/download/v0.2.1/buffer-service-0.2.1.tgz",
+        "chart": "https://github.com/bufferapp/helm-chart-base-templates/releases/download/v0.3.1/buffer-service-0.3.1.tgz",
         "name": "buffer-publish",
         "namespace": "buffer",
         "deployment_url": "publish.buffer.com"


### PR DESCRIPTION
### Purpose

To bring the buffer-publish repo into the new form of deployments where developers can manage their own resources.

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
