### PR TITLE
Update composer version to 2.1.8

### DIFF
--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -9,7 +9,7 @@
   "author": "melissa@buffer.com",
   "dependencies": {
     "@bufferapp/async-data-fetch": "1.9.4",
-    "@bufferapp/composer": "2.1.7",
+    "@bufferapp/composer": "2.1.8",
     "@bufferapp/keywrapper": "0.2.0",
     "@bufferapp/notifications": "1.9.4",
     "@bufferapp/publish-profile-sidebar": "^1.9.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,10 +181,10 @@
     react-autocomplete "1.7.2"
     react-day-picker "7.2.3"
 
-"@bufferapp/composer@2.1.7":
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-2.1.7.tgz#78ff475acf8e6031fe357e0c502205ef3a717b21"
-  integrity sha512-gFXyRFwyY/9eWkH9p2NUVH67HauTvLXUZ3JZ2rQ79JLO795SwfbzHK0hTZnsdpMofjfMPVV8WwwhPrhXxj4f3Q==
+"@bufferapp/composer@2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-2.1.8.tgz#665704cd978f21bacb45fc058b1db50fd88828f7"
+  integrity sha512-wKzL4lYn96pUkKAu8/0M8bP2NfaHhioxtE1VVzTid2/Fm8SE2V4Y1krw6D4gPQaLhBobxiVGb6bFcwz9gM4hxQ==
   dependencies:
     "@bufferapp/buffer-js-api" "0.3.0"
     "@bufferapp/buffer-js-metrics" "0.2.0"


### PR DESCRIPTION
### Purpose
Update composer version to 2.1.8 in fix of publish listening to classic web interfaces file. 
https://buffer.atlassian.net/browse/PUB-869
### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
