### PR TITLE
Google Analytics Component

### DIFF
--- a/packages/general-settings/components/GeneralSettings/index.jsx
+++ b/packages/general-settings/components/GeneralSettings/index.jsx
@@ -13,6 +13,8 @@ const GeneralSettings = ({
   loadingLinkShorteners,
   onLinkShortenerOptionSelect,
   selectedShortener,
+  onShowGACustomizationFormClick,
+  showGACustomizationForm,
 }) => (
   <div>
     {!directPostingEnabled &&
@@ -28,7 +30,10 @@ const GeneralSettings = ({
       selectedShortener={selectedShortener}
     />
     <Divider />
-    <GoogleAnalytics />
+    <GoogleAnalytics
+      onShowGACustomizationFormClick={onShowGACustomizationFormClick}
+      showGACustomizationForm={showGACustomizationForm}
+    />
   </div>
 );
 
@@ -39,6 +44,7 @@ GeneralSettings.defaultProps = {
   loadingLinkShorteners: true,
   onLinkShortenerOptionSelect: null,
   selectedShortener: null,
+  showGACustomizationForm: false,
 };
 
 GeneralSettings.propTypes = {
@@ -56,6 +62,8 @@ GeneralSettings.propTypes = {
   loadingLinkShorteners: PropTypes.bool,
   profileService: PropTypes.string,
   selectedShortener: PropTypes.string,
+  onShowGACustomizationFormClick: PropTypes.func.isRequired,
+  showGACustomizationForm: PropTypes.bool.isRequired,
 };
 
 export default GeneralSettings;

--- a/packages/general-settings/components/GeneralSettings/index.jsx
+++ b/packages/general-settings/components/GeneralSettings/index.jsx
@@ -17,6 +17,8 @@ const GeneralSettings = ({
   showGACustomizationForm,
   googleAnalyticsIsEnabled,
   onToggleGoogleAnalyticsClick,
+  // This should be removed once Google Analytics feature is complete - Lola, Nov 2018
+  workInProgress,
 }) => (
   <div>
     {!directPostingEnabled &&
@@ -32,12 +34,14 @@ const GeneralSettings = ({
       selectedShortener={selectedShortener}
     />
     <Divider />
-    <GoogleAnalytics
-      onShowGACustomizationFormClick={onShowGACustomizationFormClick}
-      showGACustomizationForm={showGACustomizationForm}
-      googleAnalyticsIsEnabled={googleAnalyticsIsEnabled}
-      onToggleGoogleAnalyticsClick={onToggleGoogleAnalyticsClick}
-    />
+    {!workInProgress &&
+      <GoogleAnalytics
+        onShowGACustomizationFormClick={onShowGACustomizationFormClick}
+        showGACustomizationForm={showGACustomizationForm}
+        googleAnalyticsIsEnabled={googleAnalyticsIsEnabled}
+        onToggleGoogleAnalyticsClick={onToggleGoogleAnalyticsClick}
+      />
+    }
   </div>
 );
 

--- a/packages/general-settings/components/GeneralSettings/index.jsx
+++ b/packages/general-settings/components/GeneralSettings/index.jsx
@@ -15,6 +15,8 @@ const GeneralSettings = ({
   selectedShortener,
   onShowGACustomizationFormClick,
   showGACustomizationForm,
+  googleAnalyticsIsEnabled,
+  onToggleGoogleAnalyticsClick,
 }) => (
   <div>
     {!directPostingEnabled &&
@@ -33,6 +35,8 @@ const GeneralSettings = ({
     <GoogleAnalytics
       onShowGACustomizationFormClick={onShowGACustomizationFormClick}
       showGACustomizationForm={showGACustomizationForm}
+      googleAnalyticsIsEnabled={googleAnalyticsIsEnabled}
+      onToggleGoogleAnalyticsClick={onToggleGoogleAnalyticsClick}
     />
   </div>
 );
@@ -45,6 +49,7 @@ GeneralSettings.defaultProps = {
   onLinkShortenerOptionSelect: null,
   selectedShortener: null,
   showGACustomizationForm: false,
+  googleAnalyticsIsEnabled: false,
 };
 
 GeneralSettings.propTypes = {
@@ -64,6 +69,8 @@ GeneralSettings.propTypes = {
   selectedShortener: PropTypes.string,
   onShowGACustomizationFormClick: PropTypes.func.isRequired,
   showGACustomizationForm: PropTypes.bool.isRequired,
+  googleAnalyticsIsEnabled: PropTypes.bool,
+  onToggleGoogleAnalyticsClick: PropTypes.func.isRequired,
 };
 
 export default GeneralSettings;

--- a/packages/general-settings/components/GeneralSettings/index.jsx
+++ b/packages/general-settings/components/GeneralSettings/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Divider } from '@bufferapp/components';
 import InstagramDirectPosting from '../InstagramDirectPosting';
 import LinkShortening from '../LinkShortening';
+import GoogleAnalytics from '../GoogleAnalytics';
 
 const GeneralSettings = ({
   directPostingEnabled,
@@ -27,6 +28,7 @@ const GeneralSettings = ({
       selectedShortener={selectedShortener}
     />
     <Divider />
+    <GoogleAnalytics />
   </div>
 );
 

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -8,6 +8,11 @@ import {
 const enableGoogleAnalyticsStyle = {
   display: 'flex',
   flex: 1,
+  flexDirection: 'row',
+  marginBottom: '0.5rem',
+};
+
+const generalTextWrapperStyle = {
   flexDirection: 'column',
   marginBottom: '0.5rem',
 };

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -81,7 +81,7 @@ const GoogleAnalytics = ({
         />
       </div>
     </div>
-    <Button>
+    <Button secondary>
       Customize Campaign Tracking
     </Button>
   </div>

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Text, Toggle, Divider,
+} from '@bufferapp/components';
+
+const enableGoogleAnalyticsStyle = {
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'row',
+  marginBottom: '0.5rem',
+};
+
+const generalTextWrapperStyle = {
+  display: 'flex',
+  marginBottom: '0.5rem',
+};
+
+const headerTextWrapperStyle = {
+  display: 'flex',
+  marginBottom: '0.5rem',
+  marginTop: '1rem',
+};
+
+const toggleTextWrapperStyle = {
+  display: 'flex',
+  marginBottom: '0.5rem',
+  width: '80%',
+};
+
+const enableGoogleAnalyticsToggleStyle = {
+  marginBottom: '1.5rem',
+  marginTop: '1rem',
+  textAlign: 'right',
+  whiteSpace: 'nowrap',
+};
+
+
+const GoogleAnalytics = ({
+  // isEnabled,
+  // transition,
+  // machineState,
+}) => (
+  <div>
+    <div style={headerTextWrapperStyle}>
+      <Text
+        color={'black'}
+        weight={'medium'}
+      >
+        Google Analytics Campaign Tracking
+      </Text>
+    </div>
+    <div style={generalTextWrapperStyle}>
+      <Text>
+        With campaign tracking enabled in Buffer, you will be able to see how much traffic
+        you receive from social media posts directly inside your Google Analytics dashboard. You
+        can disable this below if you'd like.
+      </Text>
+    </div>
+    <Divider />
+    <div style={headerTextWrapperStyle}>
+      <Text
+        color={'black'}
+      >
+        Enable Campaign Tracking
+      </Text>
+    </div>
+    <div style={enableGoogleAnalyticsStyle}>
+      <div style={toggleTextWrapperStyle}>
+        <Text>
+          This enables Google Analytics Tracking via UTM parameters added to links you share.
+          (This will override any existing UTM parameters)
+        </Text>
+      </div>
+      <div style={enableGoogleAnalyticsToggleStyle}>
+        <Toggle
+          on={console.log("enabled")}
+          onClick={console.log("clicked")}
+          disabled={console.log("disabled")}
+        />
+      </div>
+    </div>
+  </div>
+);
+
+GoogleAnalytics.propTypes = {
+  onSetUpDirectPostingClick: PropTypes.func.isRequired,
+};
+
+export default GoogleAnalytics;

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -114,12 +114,16 @@ const GoogleAnalytics = ({
         </div>
       </form>
     }
-    <Button
-      secondary
-      onClick={() => { onShowGACustomizationFormClick(); }}
-    >
-      Customize Campaign Tracking
-    </Button>
+    {!showGACustomizationForm &&
+      <Button
+        secondary
+        onClick={() => {
+          onShowGACustomizationFormClick();
+        }}
+      >
+        Customize Campaign Tracking
+      </Button>
+    }
   </div>
 );
 

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Text, Toggle, Divider,
-  Button,
+  Button, Input,
 } from '@bufferapp/components';
 
 const enableGoogleAnalyticsStyle = {
@@ -12,7 +12,7 @@ const enableGoogleAnalyticsStyle = {
   marginBottom: '0.5rem',
 };
 
-const generalTextWrapperStyle = {
+const generalWrapperStyle = {
   display: 'flex',
   marginBottom: '0.5rem',
 };
@@ -29,12 +29,16 @@ const toggleTextWrapperStyle = {
   width: '80%',
 };
 
-const enableGoogleAnalyticsToggleStyle = {
+const switchStyle = {
   marginBottom: '1.5rem',
   marginTop: '1rem',
   textAlign: 'right',
   whiteSpace: 'nowrap',
 };
+
+const inputStyle = {
+  marginRight: '0.5rem',
+}
 
 
 const GoogleAnalytics = ({
@@ -51,7 +55,7 @@ const GoogleAnalytics = ({
         Google Analytics Campaign Tracking
       </Text>
     </div>
-    <div style={generalTextWrapperStyle}>
+    <div style={generalWrapperStyle}>
       <Text>
         With campaign tracking enabled in Buffer, you will be able to see how much traffic
         you receive from social media posts directly inside your Google Analytics dashboard. You
@@ -73,7 +77,7 @@ const GoogleAnalytics = ({
           (This will override any existing UTM parameters)
         </Text>
       </div>
-      <div style={enableGoogleAnalyticsToggleStyle}>
+      <div style={switchStyle}>
         <Toggle
           on={console.log("enabled")}
           onClick={console.log("clicked")}
@@ -81,6 +85,31 @@ const GoogleAnalytics = ({
         />
       </div>
     </div>
+    <form style={generalWrapperStyle}>
+      <div style={inputStyle}>
+        <Input
+          label={'Campaign Name'}
+          placeholder={'buffer'}
+        />
+      </div>
+      <div style={inputStyle}>
+        <Input
+          label={'Campaign Source'}
+          placeholder={'bufferapp.com'}
+        />
+      </div>
+      <div style={inputStyle}>
+        <Input
+          label={'Campaign Medium'}
+          placeholder={'social'}
+        />
+      </div>
+      <div style={switchStyle}>
+        <Button>
+          Update Tracking
+        </Button>
+      </div>
+    </form>
     <Button secondary>
       Customize Campaign Tracking
     </Button>

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -17,6 +17,12 @@ const generalWrapperStyle = {
   marginBottom: '0.5rem',
 };
 
+const formWrapperStyle = {
+  marginBottom: '0.5rem',
+  width: '50%',
+};
+
+
 const headerTextWrapperStyle = {
   display: 'flex',
   marginBottom: '0.5rem',
@@ -33,6 +39,12 @@ const switchStyle = {
   marginBottom: '1.5rem',
   marginTop: '1rem',
   textAlign: 'right',
+  whiteSpace: 'nowrap',
+};
+
+const switchStyleTwo = {
+  marginBottom: '1.5rem',
+  marginTop: '1rem',
   whiteSpace: 'nowrap',
 };
 
@@ -88,7 +100,7 @@ const GoogleAnalytics = ({
       </div>
     </div>
     {showGACustomizationForm &&
-      <form style={generalWrapperStyle}>
+      <form style={formWrapperStyle}>
         <div style={inputStyle}>
           <Input
             label={'Campaign Name'}
@@ -107,7 +119,7 @@ const GoogleAnalytics = ({
             placeholder={'social'}
           />
         </div>
-        <div style={switchStyle}>
+        <div style={switchStyleTwo}>
           <Button>
             Update Tracking
           </Button>

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -45,6 +45,8 @@ const GoogleAnalytics = ({
   // isEnabled,
   // transition,
   // machineState,
+  showGACustomizationForm,
+  onShowGACustomizationFormClick,
 }) => (
   <div>
     <div style={headerTextWrapperStyle}>
@@ -85,39 +87,45 @@ const GoogleAnalytics = ({
         />
       </div>
     </div>
-    <form style={generalWrapperStyle}>
-      <div style={inputStyle}>
-        <Input
-          label={'Campaign Name'}
-          placeholder={'buffer'}
-        />
-      </div>
-      <div style={inputStyle}>
-        <Input
-          label={'Campaign Source'}
-          placeholder={'bufferapp.com'}
-        />
-      </div>
-      <div style={inputStyle}>
-        <Input
-          label={'Campaign Medium'}
-          placeholder={'social'}
-        />
-      </div>
-      <div style={switchStyle}>
-        <Button>
-          Update Tracking
-        </Button>
-      </div>
-    </form>
-    <Button secondary>
+    {showGACustomizationForm &&
+      <form style={generalWrapperStyle}>
+        <div style={inputStyle}>
+          <Input
+            label={'Campaign Name'}
+            placeholder={'buffer'}
+          />
+        </div>
+        <div style={inputStyle}>
+          <Input
+            label={'Campaign Source'}
+            placeholder={'bufferapp.com'}
+          />
+        </div>
+        <div style={inputStyle}>
+          <Input
+            label={'Campaign Medium'}
+            placeholder={'social'}
+          />
+        </div>
+        <div style={switchStyle}>
+          <Button>
+            Update Tracking
+          </Button>
+        </div>
+      </form>
+    }
+    <Button
+      secondary
+      onClick={() => { onShowGACustomizationFormClick(); }}
+    >
       Customize Campaign Tracking
     </Button>
   </div>
 );
 
 GoogleAnalytics.propTypes = {
-  onSetUpDirectPostingClick: PropTypes.func.isRequired,
+  showGACustomizationForm: PropTypes.bool.isRequired,
+  onShowGACustomizationFormClick: PropTypes.func.isRequired,
 };
 
 export default GoogleAnalytics;

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Text, Toggle, Divider,
-  Button, Input,
+  Button, Input, Card,
 } from '@bufferapp/components';
 
 const enableGoogleAnalyticsStyle = {
   display: 'flex',
   flex: 1,
-  flexDirection: 'row',
+  flexDirection: 'column',
   marginBottom: '0.5rem',
 };
 
@@ -25,31 +25,18 @@ const formWrapperStyle = {
 
 const headerTextWrapperStyle = {
   display: 'flex',
-  marginBottom: '0.5rem',
+  marginBottom: '1rem',
   marginTop: '1rem',
-};
-
-const toggleTextWrapperStyle = {
-  display: 'flex',
-  marginBottom: '0.5rem',
-  width: '80%',
 };
 
 const switchStyle = {
-  marginBottom: '1.5rem',
-  marginTop: '1rem',
-  textAlign: 'right',
-  whiteSpace: 'nowrap',
-};
-
-const switchStyleTwo = {
   marginBottom: '1.5rem',
   marginTop: '1rem',
   whiteSpace: 'nowrap',
 };
 
 const inputStyle = {
-  marginRight: '0.5rem',
+  marginTop: '0.5rem',
 }
 
 
@@ -60,7 +47,7 @@ const GoogleAnalytics = ({
   showGACustomizationForm,
   onShowGACustomizationFormClick,
 }) => (
-  <div>
+  <Card>
     <div style={headerTextWrapperStyle}>
       <Text
         color={'black'}
@@ -70,7 +57,9 @@ const GoogleAnalytics = ({
       </Text>
     </div>
     <div style={generalWrapperStyle}>
-      <Text>
+      <Text
+        size={'small'}
+      >
         With campaign tracking enabled in Buffer, you will be able to see how much traffic
         you receive from social media posts directly inside your Google Analytics dashboard. You
         can disable this below if you'd like.
@@ -85,14 +74,21 @@ const GoogleAnalytics = ({
       </Text>
     </div>
     <div style={enableGoogleAnalyticsStyle}>
-      <div style={toggleTextWrapperStyle}>
-        <Text>
-          This enables Google Analytics Tracking via UTM parameters added to links you share.
-          (This will override any existing UTM parameters)
-        </Text>
-      </div>
+      <Text
+        size={'small'}
+      >
+        This enables Google Analytics Tracking via UTM parameters added to links you share.
+      </Text>
+      <Text
+        size={'small'}
+        weight={'bold'}
+      >
+        (This will override any existing UTM parameters)
+      </Text>
       <div style={switchStyle}>
         <Toggle
+          onText={'Campaign tracking:'}
+          offText={'Campaign tracking:'}
           on={console.log("enabled")}
           onClick={console.log("clicked")}
           disabled={console.log("disabled")}
@@ -100,31 +96,56 @@ const GoogleAnalytics = ({
       </div>
     </div>
     {showGACustomizationForm &&
-      <form style={formWrapperStyle}>
-        <div style={inputStyle}>
-          <Input
-            label={'Campaign Name'}
-            placeholder={'buffer'}
-          />
+      <div>
+        <Divider />
+        <div style={headerTextWrapperStyle}>
+          <Text
+            color={'black'}
+          >
+            Customise Campaign Tracking
+          </Text>
         </div>
-        <div style={inputStyle}>
-          <Input
-            label={'Campaign Source'}
-            placeholder={'bufferapp.com'}
-          />
-        </div>
-        <div style={inputStyle}>
-          <Input
-            label={'Campaign Medium'}
-            placeholder={'social'}
-          />
-        </div>
-        <div style={switchStyleTwo}>
-          <Button>
-            Update Tracking
-          </Button>
-        </div>
-      </form>
+        <form style={formWrapperStyle}>
+          <div style={inputStyle}>
+            <Text
+              weight={'medium'}
+              color={'black'}
+            >
+              Campaign Name
+            </Text>
+            <Input
+              placeholder={'buffer'}
+            />
+          </div>
+          <div style={inputStyle}>
+            <Text
+              weight={'medium'}
+              color={'black'}
+            >
+              Campaign Source
+            </Text>
+            <Input
+              placeholder={'bufferapp.com'}
+            />
+          </div>
+          <div style={inputStyle}>
+            <Text
+              weight={'medium'}
+              color={'black'}
+            >
+              Campaign Medium
+            </Text>
+            <Input
+              placeholder={'social'}
+            />
+          </div>
+          <div style={switchStyle}>
+            <Button>
+              Save Changes
+            </Button>
+          </div>
+        </form>
+      </div>
     }
     {!showGACustomizationForm &&
       <Button
@@ -136,7 +157,7 @@ const GoogleAnalytics = ({
         Customize Campaign Tracking
       </Button>
     }
-  </div>
+  </Card>
 );
 
 GoogleAnalytics.propTypes = {

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -8,11 +8,6 @@ import {
 const enableGoogleAnalyticsStyle = {
   display: 'flex',
   flex: 1,
-  flexDirection: 'row',
-  marginBottom: '0.5rem',
-};
-
-const generalTextWrapperStyle = {
   flexDirection: 'column',
   marginBottom: '0.5rem',
 };

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -37,16 +37,14 @@ const switchStyle = {
 
 const inputStyle = {
   marginTop: '0.5rem',
-}
-
+};
 
 const GoogleAnalytics = ({
-  // isEnabled,
-  // transition,
-  // machineState,
+  googleAnalyticsIsEnabled,
   showGACustomizationForm,
   onShowGACustomizationFormClick,
-}) => (
+  onToggleGoogleAnalyticsClick,
+  }) => (
   <Card>
     <div style={headerTextWrapperStyle}>
       <Text
@@ -89,9 +87,8 @@ const GoogleAnalytics = ({
         <Toggle
           onText={'Campaign tracking:'}
           offText={'Campaign tracking:'}
-          on={console.log("enabled")}
-          onClick={console.log("clicked")}
-          disabled={console.log("disabled")}
+          on={googleAnalyticsIsEnabled}
+          onClick={() => { onToggleGoogleAnalyticsClick(); }}
         />
       </div>
     </div>
@@ -147,7 +144,7 @@ const GoogleAnalytics = ({
         </form>
       </div>
     }
-    {!showGACustomizationForm &&
+    {!showGACustomizationForm && googleAnalyticsIsEnabled &&
       <Button
         secondary
         onClick={() => {
@@ -163,6 +160,7 @@ const GoogleAnalytics = ({
 GoogleAnalytics.propTypes = {
   showGACustomizationForm: PropTypes.bool.isRequired,
   onShowGACustomizationFormClick: PropTypes.func.isRequired,
+  googleAnalyticsIsEnabled: PropTypes.bool.isRequired,
 };
 
 export default GoogleAnalytics;

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -22,7 +22,6 @@ const formWrapperStyle = {
   width: '50%',
 };
 
-
 const headerTextWrapperStyle = {
   display: 'flex',
   marginBottom: '1rem',
@@ -161,6 +160,7 @@ GoogleAnalytics.propTypes = {
   showGACustomizationForm: PropTypes.bool.isRequired,
   onShowGACustomizationFormClick: PropTypes.func.isRequired,
   googleAnalyticsIsEnabled: PropTypes.bool.isRequired,
+  onToggleGoogleAnalyticsClick: PropTypes.func.isRequired,
 };
 
 export default GoogleAnalytics;

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Text, Toggle, Divider,
+  Button,
 } from '@bufferapp/components';
 
 const enableGoogleAnalyticsStyle = {
@@ -80,6 +81,9 @@ const GoogleAnalytics = ({
         />
       </div>
     </div>
+    <Button>
+      Customize Campaign Tracking
+    </Button>
   </div>
 );
 

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -21,11 +21,8 @@ export default connect(
           profileId: ownProps.profileId,
         }));
       },
-      onLinkShortenerOptionSelect: (event) => {
-        dispatch(actions.handleOnSelectLinkShortenerChange({
-          profileId: ownProps.profileId,
-          domain: event.target.value,
-        }));
+      onShowGACustomizationFormClick: () => {
+        dispatch(actions.handleShowGACustomizationFormClick());
       },
       onShowGACustomizationFormClick: () => {
         dispatch(actions.handleShowGACustomizationFormClick());

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -10,6 +10,7 @@ export default connect(
       linkShorteners: state.generalSettings.linkShorteners,
       loadingLinkShorteners: state.generalSettings.loadingLinkShorteners,
       selectedShortener: state.generalSettings.selectedShortener,
+      showGACustomizationForm: state.generalSettings.showGACustomizationForm,
     }),
     (dispatch, ownProps) => ({
       onSetUpDirectPostingClick: () => {
@@ -22,6 +23,9 @@ export default connect(
           profileId: ownProps.profileId,
           domain: event.target.value,
         }));
+      },
+      onShowGACustomizationFormClick: () => {
+        dispatch(actions.handleShowGACustomizationFormClick());
       },
     }),
 )(GeneralSettings);

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -11,6 +11,7 @@ export default connect(
       loadingLinkShorteners: state.generalSettings.loadingLinkShorteners,
       selectedShortener: state.generalSettings.selectedShortener,
       showGACustomizationForm: state.generalSettings.showGACustomizationForm,
+      googleAnalyticsIsEnabled: state.generalSettings.googleAnalyticsIsEnabled,
     }),
     (dispatch, ownProps) => ({
       onSetUpDirectPostingClick: () => {
@@ -26,6 +27,9 @@ export default connect(
       },
       onShowGACustomizationFormClick: () => {
         dispatch(actions.handleShowGACustomizationFormClick());
+      },
+      onToggleGoogleAnalyticsClick: () => {
+        dispatch(actions.handleGoogleAnalyticsToggle());
       },
     }),
 )(GeneralSettings);

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -24,8 +24,11 @@ export default connect(
       onShowGACustomizationFormClick: () => {
         dispatch(actions.handleShowGACustomizationFormClick());
       },
-      onShowGACustomizationFormClick: () => {
-        dispatch(actions.handleShowGACustomizationFormClick());
+      onLinkShortenerOptionSelect: (event) => {
+        dispatch(actions.handleOnSelectLinkShortenerChange({
+          profileId: ownProps.profileId,
+          domain: event.target.value,
+        }));
       },
       onToggleGoogleAnalyticsClick: () => {
         dispatch(actions.handleGoogleAnalyticsToggle());

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -12,6 +12,8 @@ export default connect(
       selectedShortener: state.generalSettings.selectedShortener,
       showGACustomizationForm: state.generalSettings.showGACustomizationForm,
       googleAnalyticsIsEnabled: state.generalSettings.googleAnalyticsIsEnabled,
+      // This should be removed once the Google Analytics feature is complete - Lola, Nov 2018
+      workInProgress: true,
     }),
     (dispatch, ownProps) => ({
       onSetUpDirectPostingClick: () => {

--- a/packages/general-settings/reducer.js
+++ b/packages/general-settings/reducer.js
@@ -70,10 +70,8 @@ export const actions = {
     type: actionTypes.SHOW_GA_CUSTOMIZATION_FORM,
   }),
   handleOnSelectLinkShortenerChange: ({ profileId, domain }) => ({
-    handleShowGACustomizationFormClick: () => ({
-      type: actionTypes.CHANGE_SELECTED_LINK_SHORTENER, type: actionTypes.SHOW_GA_CUSTOMIZATION_FORM,
-      profileId,
-    }),
+    type: actionTypes.CHANGE_SELECTED_LINK_SHORTENER,
+    profileId,
     domain,
   }),
   handleGoogleAnalyticsToggle: () => ({

--- a/packages/general-settings/reducer.js
+++ b/packages/general-settings/reducer.js
@@ -6,12 +6,14 @@ export const actionTypes = keyWrapper('GENERAL_SETTINGS', {
   SET_DIRECT_POSTING: 0,
   CHANGE_SELECTED_LINK_SHORTENER: 0,
   SHOW_GA_CUSTOMIZATION_FORM: 0,
+  TOGGLE_GOOGLE_ANALYTICS: 0,
 });
 
 const initialState = {
   directPostingEnabled: false,
   profileId: null,
   showGACustomizationForm: false,
+  googleAnalyticsIsEnabled: false,
 };
 
 export default (state = initialState, action) => {
@@ -49,6 +51,11 @@ export default (state = initialState, action) => {
         ...state,
         showGACustomizationForm: true,
       };
+    case actionTypes.TOGGLE_GOOGLE_ANALYTICS:
+      return {
+        ...state,
+        googleAnalyticsIsEnabled: !state.googleAnalyticsIsEnabled,
+      };
     default:
       return state;
   }
@@ -66,5 +73,8 @@ export const actions = {
   }),
   handleShowGACustomizationFormClick: () => ({
     type: actionTypes.SHOW_GA_CUSTOMIZATION_FORM,
+  }),
+  handleGoogleAnalyticsToggle: () => ({
+    type: actionTypes.TOGGLE_GOOGLE_ANALYTICS,
   }),
 };

--- a/packages/general-settings/reducer.js
+++ b/packages/general-settings/reducer.js
@@ -5,11 +5,13 @@ import keyWrapper from '@bufferapp/keywrapper';
 export const actionTypes = keyWrapper('GENERAL_SETTINGS', {
   SET_DIRECT_POSTING: 0,
   CHANGE_SELECTED_LINK_SHORTENER: 0,
+  SHOW_GA_CUSTOMIZATION_FORM: 0,
 });
 
 const initialState = {
   directPostingEnabled: false,
   profileId: null,
+  showGACustomizationForm: false,
 };
 
 export default (state = initialState, action) => {
@@ -42,6 +44,11 @@ export default (state = initialState, action) => {
         loadingLinkShorteners: false,
         selectedShortener: null,
       };
+    case actionTypes.SHOW_GA_CUSTOMIZATION_FORM:
+      return {
+        ...state,
+        showGACustomizationForm: true,
+      };
     default:
       return state;
   }
@@ -56,5 +63,8 @@ export const actions = {
     type: actionTypes.CHANGE_SELECTED_LINK_SHORTENER,
     profileId,
     domain,
+  }),
+  handleShowGACustomizationFormClick: () => ({
+    type: actionTypes.SHOW_GA_CUSTOMIZATION_FORM,
   }),
 };

--- a/packages/general-settings/reducer.js
+++ b/packages/general-settings/reducer.js
@@ -66,10 +66,8 @@ export const actions = {
     type: actionTypes.SET_DIRECT_POSTING,
     profileId: action.profileId,
   }),
-  handleOnSelectLinkShortenerChange: ({ profileId, domain }) => ({
-    type: actionTypes.CHANGE_SELECTED_LINK_SHORTENER,
-    profileId,
-    domain,
+  handleShowGACustomizationFormClick: () => ({
+    type: actionTypes.SHOW_GA_CUSTOMIZATION_FORM,
   }),
   handleShowGACustomizationFormClick: () => ({
     type: actionTypes.SHOW_GA_CUSTOMIZATION_FORM,

--- a/packages/general-settings/reducer.js
+++ b/packages/general-settings/reducer.js
@@ -69,8 +69,12 @@ export const actions = {
   handleShowGACustomizationFormClick: () => ({
     type: actionTypes.SHOW_GA_CUSTOMIZATION_FORM,
   }),
-  handleShowGACustomizationFormClick: () => ({
-    type: actionTypes.SHOW_GA_CUSTOMIZATION_FORM,
+  handleOnSelectLinkShortenerChange: ({ profileId, domain }) => ({
+    handleShowGACustomizationFormClick: () => ({
+      type: actionTypes.CHANGE_SELECTED_LINK_SHORTENER, type: actionTypes.SHOW_GA_CUSTOMIZATION_FORM,
+      profileId,
+    }),
+    domain,
   }),
   handleGoogleAnalyticsToggle: () => ({
     type: actionTypes.TOGGLE_GOOGLE_ANALYTICS,

--- a/packages/general-settings/reducer.test.js
+++ b/packages/general-settings/reducer.test.js
@@ -7,6 +7,8 @@ describe('reducer', () => {
     const stateAfter = {
       directPostingEnabled: false,
       profileId: null,
+      googleAnalyticsIsEnabled: false,
+      showGACustomizationForm: false,
     };
     const action = {
       type: 'INIT',
@@ -23,6 +25,8 @@ describe('reducer', () => {
       profileService: 'twitter',
       loadingLinkShorteners: true,
       selectedShortener: null,
+      googleAnalyticsIsEnabled: false,
+      showGACustomizationForm: false,
     };
     const action = {
       type: actionTypes.SELECT_PROFILE,


### PR DESCRIPTION
### Purpose
Create the Google Analytics component

**Google Analytics Disabled:**
<img width="800" alt="screenshot 2018-11-01 at 07 44 38" src="https://user-images.githubusercontent.com/7262392/47839639-56310780-ddab-11e8-83d9-9595245873ba.png">

**Google Analytics Enabled:**
<img width="811" alt="screenshot 2018-11-01 at 07 44 51" src="https://user-images.githubusercontent.com/7262392/47839640-56310780-ddab-11e8-8d70-7d8c78c25ad7.png">

**Customise Google Analytics triggered:**
<img width="805" alt="screenshot 2018-11-01 at 07 45 06" src="https://user-images.githubusercontent.com/7262392/47839641-56310780-ddab-11e8-9efa-dfe9a4126214.png">


### Notes
The text for the form labels are a little bigger than the designs and this is because there doesn't currently exist a font-size that's similar to the size in the design, however the styles for the general components (Card, Text, etc) are undergoing a refresh and so will look better once complete.
I've added a `workInProgress` flag for this component to hide it from view of the user until the whole Google Analytics feature is complete.

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
