### PR TITLE
[PUB-888] Add source tracking to upgrade modals

### DIFF
--- a/packages/modals/middleware.js
+++ b/packages/modals/middleware.js
@@ -1,28 +1,13 @@
 import { actionTypes } from '@bufferapp/async-data-fetch';
 import { actions } from './reducer';
-
-const checkHashShowUpgradeModal = () => {
-  const hash = window.location.hash;
-  let showUpgradeModal = false;
-  let source = null;
-  if (hash.indexOf('#upgrade-to-pro') === 0) {
-    showUpgradeModal = true;
-    // #show-upgrade-modal--profile_limit => 'profile_limit'
-    source = hash.split('--')[1] || 'unknown';
-  }
-  return {
-    showUpgradeModal,
-    source,
-  };
-};
+import { shouldShowModal, getSourceFromHash } from './util/window-hash';
 
 export default ({ dispatch }) => next => (action) => {
   next(action);
   switch (action.type) {
     case `user_${actionTypes.FETCH_SUCCESS}`: {
-      const { showUpgradeModal, source } = checkHashShowUpgradeModal();
-      if (showUpgradeModal) {
-        dispatch(actions.showUpgradeModal({ source }));
+      if (shouldShowModal()) {
+        dispatch(actions.showUpgradeModal({ source: getSourceFromHash() }));
       }
       break;
     }

--- a/packages/modals/middleware.js
+++ b/packages/modals/middleware.js
@@ -1,16 +1,34 @@
+import { actionTypes } from '@bufferapp/async-data-fetch';
 import { actions } from './reducer';
+
+const checkHashShowUpgradeModal = () => {
+  const hash = window.location.hash;
+  let showUpgradeModal = false;
+  let source = null;
+  if (hash.indexOf('#upgrade-to-pro') === 0) {
+    showUpgradeModal = true;
+    // #show-upgrade-modal--profile_limit => 'profile_limit'
+    source = hash.split('--')[1] || 'unknown';
+  }
+  return {
+    showUpgradeModal,
+    source,
+  };
+};
 
 export default ({ dispatch }) => next => (action) => {
   next(action);
   switch (action.type) {
-    case 'APP_INIT':
-      if (window.location.hash === '#upgrade-to-pro') {
-        dispatch(actions.showUpgradeModal());
+    case `user_${actionTypes.FETCH_SUCCESS}`: {
+      const { showUpgradeModal, source } = checkHashShowUpgradeModal();
+      if (showUpgradeModal) {
+        dispatch(actions.showUpgradeModal({ source }));
       }
       break;
+    }
     case 'COMPOSER_EVENT':
       if (action.eventType === 'show-upgrade-modal') {
-        dispatch(actions.showUpgradeModal());
+        dispatch(actions.showUpgradeModal({ source: 'queue_limit' }));
       }
       break;
     default:

--- a/packages/modals/middleware.test.js
+++ b/packages/modals/middleware.test.js
@@ -1,26 +1,41 @@
 import middleware from './middleware';
 import { actions } from './reducer';
 
+// jest.mock('buffermetrics');
+
 // Object.defineProperty(window.location, 'hash', {
 //   writable: true,
 //   value: '#upgrade-to-pro',
 // });
 
 describe('middleware', () => {
-  it('should show modal on APP_INIT when hash is present', () => {
-    history.replaceState(undefined, undefined, '#upgrade-to-pro');
+  it('should show and track modal when hash is present', () => {
+    history.replaceState(undefined, undefined, '#upgrade-to-pro--profile_limit');
     const next = jest.fn();
     const dispatch = jest.fn();
     const action = {
-      type: 'APP_INIT',
+      type: 'user_FETCH_SUCCESS',
     };
     middleware({ dispatch })(next)(action);
     expect(next)
       .toBeCalledWith(action);
     expect(dispatch)
-      .toBeCalledWith(actions.showUpgradeModal());
+      .toBeCalledWith(actions.showUpgradeModal({ source: 'profile_limit' }));
   });
-  it('should show upgrade modal when triggered from composer', () => {
+  it('should send \'unknown\' for hash without source', () => {
+    history.replaceState(undefined, undefined, '#upgrade-to-pro');
+    const next = jest.fn();
+    const dispatch = jest.fn();
+    const action = {
+      type: 'user_FETCH_SUCCESS',
+    };
+    middleware({ dispatch })(next)(action);
+    expect(next)
+      .toBeCalledWith(action);
+    expect(dispatch)
+      .toBeCalledWith(actions.showUpgradeModal({ source: 'unknown' }));
+  });
+  it('should show and track upgrade modal when triggered from composer', () => {
     const next = jest.fn();
     const dispatch = jest.fn();
     const action = {
@@ -31,6 +46,6 @@ describe('middleware', () => {
     expect(next)
       .toBeCalledWith(action);
     expect(dispatch)
-      .toBeCalledWith(actions.showUpgradeModal());
+      .toBeCalledWith(actions.showUpgradeModal({ source: 'queue_limit' }));
   });
 });

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -10,7 +10,8 @@
   "author": "hamish@buffer.com",
   "dependencies": {
     "@bufferapp/keywrapper": "0.2.0",
-    "@bufferapp/publish-upgrade-modal": "2.0.0"
+    "@bufferapp/publish-upgrade-modal": "2.0.0",
+    "@bufferapp/buffermetrics": "0.5.2"
   },
   "devDependencies": {
     "eslint": "3.19.0"

--- a/packages/modals/reducer.js
+++ b/packages/modals/reducer.js
@@ -2,6 +2,7 @@ import keyWrapper from '@bufferapp/keywrapper';
 
 export const initialState = {
   showUpgradeModal: false,
+  upgradeModalSource: null,
 };
 
 export const actionTypes = keyWrapper('MODALS', {
@@ -15,6 +16,7 @@ export default (state = initialState, action) => {
       return {
         ...state,
         showUpgradeModal: true,
+        upgradeModalSource: action.source,
       };
     case actionTypes.HIDE_UPGRADE_MODAL:
       return {
@@ -27,8 +29,9 @@ export default (state = initialState, action) => {
 };
 
 export const actions = {
-  showUpgradeModal: () => ({
+  showUpgradeModal: ({ source }) => ({
     type: actionTypes.SHOW_UPGRADE_MODAL,
+    source,
   }),
   hideUpgradeModal: () => ({
     type: actionTypes.HIDE_UPGRADE_MODAL,

--- a/packages/modals/reducer.test.js
+++ b/packages/modals/reducer.test.js
@@ -9,16 +9,16 @@ describe('reducer', () => {
 
   describe('actions', () => {
     it('should show upgrade modal', () => {
-      expect(reducer(initialState, actions.showUpgradeModal()))
-        .toEqual(Object.assign(initialState, { showUpgradeModal: true }));
+      expect(reducer(initialState, actions.showUpgradeModal({ source: 'foo' })))
+        .toEqual(Object.assign(initialState, { showUpgradeModal: true, upgradeModalSource: 'foo' }));
     });
     it('should hide upgrade modal', () => {
       const stateWithVisibleModal = Object.assign(
         initialState,
-        { showUpgradeModal: true },
+        { showUpgradeModal: true, upgradeModalSource: 'foo' },
       );
       expect(reducer(stateWithVisibleModal, actions.hideUpgradeModal()))
-        .toEqual(Object.assign(initialState, { showUpgradeModal: false }));
+        .toEqual(Object.assign(initialState, { showUpgradeModal: false, upgradeModalSource: 'foo' }));
     });
   });
 });

--- a/packages/modals/util/window-hash.js
+++ b/packages/modals/util/window-hash.js
@@ -1,0 +1,14 @@
+const UPGRADE_TO_PRO_HASH = '#upgrade-to-pro';
+
+export const shouldShowModal = () => {
+  return window.location.hash.indexOf(UPGRADE_TO_PRO_HASH) === 0;
+}
+
+/**
+ * Gets the source from the hash in the URL.
+ * '#upgrade-to-pro--profile_limit' => 'profile_limit'
+ */
+export const getSourceFromHash = () => {
+  const hash = window.location.hash || '';
+  return hash.split('--')[1] || 'unknown';
+};

--- a/packages/server/rpc/upgradeToPro/index.js
+++ b/packages/server/rpc/upgradeToPro/index.js
@@ -14,7 +14,7 @@ module.exports = method(
         json: true,
         form: {
           cycle,
-          cta,
+          cta: `publish-${cta}`,
           stripeToken: token,
           access_token: session.publish.accessToken,
           product: 'publish',

--- a/packages/server/rpc/upgradeToPro/index.js
+++ b/packages/server/rpc/upgradeToPro/index.js
@@ -4,7 +4,7 @@ const rp = require('request-promise');
 module.exports = method(
   'upgradeToPro',
   'upgrade user to the pro plan',
-  async ({ cycle, token }, { session }) => {
+  async ({ cycle, token, cta }, { session }) => {
     let result;
     try {
       result = await rp({
@@ -14,6 +14,7 @@ module.exports = method(
         json: true,
         form: {
           cycle,
+          cta,
           stripeToken: token,
           access_token: session.publish.accessToken,
           product: 'publish',

--- a/packages/server/rpc/upgradeToPro/test.js
+++ b/packages/server/rpc/upgradeToPro/test.js
@@ -15,9 +15,10 @@ const upgradeToPro = () =>
   RPCEndpoint.fn({
     cycle: 'year',
     token: 'stripe token',
+    cta: 'source',
   }, {
-    session,
-  });
+      session,
+    });
 
 describe('rpc/upgradeToPro', () => {
   it('sends over a request to Buffer\'s API with Publish\'s access token', () => {
@@ -38,6 +39,7 @@ describe('rpc/upgradeToPro', () => {
     upgradeToPro();
     expect(rp.mock.calls[0][0].form.plan).toBe('pro');
     expect(rp.mock.calls[0][0].form.product).toBe('publish');
+    expect(rp.mock.calls[0][0].form.cta).toBe('publish-source');
   });
 
   it('an error response gets returned too', () => {

--- a/packages/stripe/middleware.js
+++ b/packages/stripe/middleware.js
@@ -39,6 +39,7 @@ export default ({ dispatch, getState }) => next => (action) => {
             name: 'upgradeToPro',
             args: {
               cycle: getState().upgradeModal.cycle,
+              cta: getState().upgradeModal.source,
               token: response.id,
             },
           }));

--- a/packages/stripe/middleware.test.js
+++ b/packages/stripe/middleware.test.js
@@ -27,6 +27,7 @@ describe('middleware', () => {
       i18n,
       upgradeModal: {
         cycle: 'year',
+        source: 'source',
       },
     }),
   };
@@ -60,6 +61,7 @@ describe('middleware', () => {
           args: {
             cycle: 'year',
             token: SUCCESS_RESPONSE.id,
+            cta: 'source',
           },
         })));
       done();

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -22,7 +22,7 @@ export default connect(
       tabId,
       profileId: ownProps.profileId,
     }))),
-    showUpgradeModal: () => dispatch(modalsActions.showUpgradeModal()),
+    showUpgradeModal: () => dispatch(modalsActions.showUpgradeModal({ source: 'app_header' })),
     onChildTabClick: childTabId => dispatch(push(generateChildTabRoute({
       tabId: ownProps.tabId,
       childTabId,

--- a/packages/upgrade-modal/middleware.js
+++ b/packages/upgrade-modal/middleware.js
@@ -1,13 +1,44 @@
+import buffermetrics from '@bufferapp/buffermetrics/client';
 import { actions as stripeActions } from '@bufferapp/stripe';
+import { actionTypes as modalsActionTypes } from '@bufferapp/publish-modals';
 import { actionTypes } from './reducer';
 
 export default ({ getState, dispatch }) => next => (action) => { // eslint-disable-line
   const card = getState().upgradeModal.card;
+  const source = getState().upgradeModal.source;
+  const userId = getState().appSidebar.user.id;
+
   next(action);
+
   switch (action.type) {
-    case actionTypes.UPGRADE:
+    case actionTypes.UPGRADE: {
       dispatch(stripeActions.validateCreditCard(card));
+      buffermetrics.trackAction({
+        application: 'PUBLISH',
+        location: 'MODALS',
+        action: 'submit_upgrade_to_pro',
+        metdata: { userId, source },
+      });
       break;
+    }
+    case modalsActionTypes.SHOW_UPGRADE_MODAL: {
+      buffermetrics.trackAction({
+        application: 'PUBLISH',
+        location: 'MODALS',
+        action: 'show_upgrade_to_pro',
+        metdata: { userId, source: action.source },
+      });
+      break;
+    }
+    case modalsActionTypes.HIDE_UPGRADE_MODAL: {
+      buffermetrics.trackAction({
+        application: 'PUBLISH',
+        location: 'MODALS',
+        action: 'hide_upgrade_to_pro',
+        metdata: { userId, source },
+      });
+      break;
+    }
     default:
       break;
   }

--- a/packages/upgrade-modal/middleware.test.js
+++ b/packages/upgrade-modal/middleware.test.js
@@ -1,0 +1,73 @@
+import { actionTypes as modalsActionTypes } from '@bufferapp/publish-modals';
+import buffermetrics from '@bufferapp/buffermetrics/client';
+
+import middleware from './middleware';
+import { actionTypes } from './reducer';
+
+jest.mock('@bufferapp/buffermetrics/client');
+
+describe('middleware', () => {
+  describe('should send tracking data', () => {
+    const next = jest.fn();
+    const dispatch = jest.fn();
+    const getState = jest.fn(() => ({
+      upgradeModal: { source: 'source' },
+      appSidebar: { user: { id: 'foo' } },
+    }));
+
+    test('when the modal opens', () => {
+      const action = {
+        type: modalsActionTypes.SHOW_UPGRADE_MODAL,
+        source: 'source',
+      };
+      middleware({ dispatch, getState })(next)(action);
+
+      expect(next)
+        .toBeCalledWith(action);
+
+      expect(buffermetrics.trackAction)
+        .toBeCalledWith({
+          application: 'PUBLISH',
+          location: 'MODALS',
+          action: 'show_upgrade_to_pro',
+          metdata: { userId: 'foo', source: 'source' },
+        });
+    });
+
+    test('when the modal closes', () => {
+      const action = {
+        type: modalsActionTypes.HIDE_UPGRADE_MODAL,
+      };
+      middleware({ dispatch, getState })(next)(action);
+
+      expect(next)
+        .toBeCalledWith(action);
+
+      expect(buffermetrics.trackAction)
+        .toBeCalledWith({
+          application: 'PUBLISH',
+          location: 'MODALS',
+          action: 'hide_upgrade_to_pro',
+          metdata: { userId: 'foo', source: 'source' },
+        });
+    });
+
+    test('when the modal form is submitted', () => {
+      const action = {
+        type: actionTypes.UPGRADE,
+      };
+      middleware({ dispatch, getState })(next)(action);
+
+      expect(next)
+        .toBeCalledWith(action);
+
+      expect(buffermetrics.trackAction)
+        .toBeCalledWith({
+          application: 'PUBLISH',
+          location: 'MODALS',
+          action: 'submit_upgrade_to_pro',
+          metdata: { userId: 'foo', source: 'source' },
+        });
+    });
+  });
+});

--- a/packages/upgrade-modal/reducer.js
+++ b/packages/upgrade-modal/reducer.js
@@ -1,4 +1,5 @@
 import keyWrapper from '@bufferapp/keywrapper';
+import { actionTypes as modalsActionTypes } from '@bufferapp/publish-modals';
 
 export const actionTypes = keyWrapper('UPGRADE_MODAL', {
   STORE_VALUE: 0,
@@ -6,9 +7,10 @@ export const actionTypes = keyWrapper('UPGRADE_MODAL', {
   SELECT_CYCLE: 0,
 });
 
-const initialState = {
+export const initialState = {
   cycle: 'year',
   card: {},
+  source: 'unknown',
 };
 
 export default (state = initialState, action) => {
@@ -25,6 +27,16 @@ export default (state = initialState, action) => {
           ...state.card,
           [action.id]: action.value,
         },
+      };
+    case modalsActionTypes.SHOW_UPGRADE_MODAL:
+      return {
+        ...state,
+        source: action.source || 'unknown',
+      };
+    case modalsActionTypes.HIDE_UPGRADE_MODAL:
+      return {
+        ...state,
+        source: initialState.source,
       };
     default:
       return state;

--- a/packages/upgrade-modal/reducer.test.js
+++ b/packages/upgrade-modal/reducer.test.js
@@ -1,4 +1,6 @@
-import reducer, { actions } from './reducer';
+import { actions as modalsActions } from '@bufferapp/publish-modals';
+
+import reducer, { initialState, actions, actionTypes } from './reducer';
 
 describe('reducer', () => {
   let state = {};
@@ -11,15 +13,23 @@ describe('reducer', () => {
     });
     it('has yearly cycle selected', () => expect(state.cycle).toBe('year'));
     it('has no card information', () => expect(state.card).toEqual({}));
+    it('has unknown source', () => expect(state.source).toEqual('unknown'));
   });
 
   it('storeValue stores card information as <id, value> pairs', () => {
     state = reducer(undefined, actions.storeValue('cardName', 'Buffer'));
-    expect(state.card.cardName).toBe('Buffer');
+    expect(state.card.cardName).toEqual('Buffer');
   });
-
   it('selectCycle changes the cycle', () => {
     state = reducer(undefined, actions.selectCycle('monthly'));
-    expect(state.cycle).toBe('monthly');
+    expect(state.cycle).toEqual('monthly');
+  });
+  it('stores the value of the source when modal is shown', () => {
+    state = reducer(undefined, modalsActions.showUpgradeModal({ source: 'lisbon2018' }));
+    expect(state.source).toEqual('lisbon2018');
+  });
+  it('resets the value of the source when modal is closed', () => {
+    state = reducer(undefined, modalsActions.hideUpgradeModal());
+    expect(state.source).toBe(initialState.source);
   });
 });


### PR DESCRIPTION
### Purpose

Adds source tracking to the upgrade modal so we can get a better idea of where upgrades are coming from.

https://buffer.atlassian.net/browse/PUB-888

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
