### PR TITLE
Add Analyze packages to exclusion rule and add less loader

### DIFF
--- a/packages/server/webpack.config.common.js
+++ b/packages/server/webpack.config.common.js
@@ -3,6 +3,36 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const vendor = ['react', 'react-dom', '@bufferapp/components'];
 
+/**
+ * List of analyze related packages that we'll ensure are properly transpiled.
+ * This is necessary as long as we're pulling in Analyze components.
+ * @type {Array}
+ */
+const analyzePackages = [
+  'report-list',
+  'summary-table',
+  'analyze-csv-export',
+  'analyze-png-export',
+  'analyze-shared-components',
+  'add-report',
+  'analyze-date-picker',
+  'analyze-profile-selector',
+];
+const analyzePackagesWhitelist = analyzePackages.map(imp => `(?!/@bufferapp/${imp})`).join('');
+ /**
+ * Loader required for loading and bundling the .less files that Analyze uses
+ * @type {Object}
+ */
+const analyzeLessLoader = {
+  test: /\.less$/,
+  exclude: new RegExp(`/node_modules${analyzePackagesWhitelist}/`),
+  use: [
+    'style-loader',
+    { loader: 'css-loader', options: { modules: true } },
+    'less-loader',
+  ],
+};
+
 module.exports = {
   context: __dirname,
   entry: {
@@ -16,7 +46,7 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
-        exclude: /node_modules(?!\/@bufferapp\/performance-tracking)(?!\/@bufferapp\/async-data-fetch)(?!\/@bufferapp\/components)(?!\/@bufferapp\/web-components)(?!\/@bufferapp\/composer)(?!\/@bufferapp\/unauthorized-redirect)/,
+        exclude: new RegExp(`/node_modules(?!/@bufferapp/performance-tracking)(?!/@bufferapp/async-data-fetch)(?!/@bufferapp/components)(?!/@bufferapp/web-components)(?!/@bufferapp/composer)(?!/@bufferapp/unauthorized-redirect)${analyzePackagesWhitelist}/`),
         use: {
           loader: 'babel-loader',
           options: {
@@ -38,6 +68,7 @@ module.exports = {
           'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]',
         ],
       },
+      analyzeLessLoader,
     ],
   },
   plugins: [


### PR DESCRIPTION
### Purpose
Add analyze packages to exclusion rule in webpack. Add analyze less loader for loading and bundling the .less files that Analyze uses.

### Notes
Hey @hamstu . Went ahead and added this logic so I could start importing packages. Are you happy with this or were you wanting to make changes to the logic? I'm going to branch off of this for now until I hear from you next week 😄 

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
