### PR TITLE
Follow guidelines for upgrade/Stripe `cta` tracking

### DIFF
--- a/packages/server/rpc/upgradeToPro/index.js
+++ b/packages/server/rpc/upgradeToPro/index.js
@@ -1,10 +1,20 @@
 const { method, createError } = require('@bufferapp/buffer-rpc');
 const rp = require('request-promise');
 
+const sourceCtaMap = new Map([
+  ['app_header', 'publish-app-header-getMoreOutOfBuffer-1'],
+  ['queue_limit', 'publish-composer-notifications-queueLimitUpgrade-1'],
+  ['profile_limit', 'publish-orgAdmin-connect-profileLimitUpgrade-1'],
+  ['pinterest', 'publish-orgAdmin-connect-upgradeToConnectPinterest-1'],
+  ['org_admin', 'publish-orgAdmin-planOverview-upgradeForMore-1'],
+]);
+const getCtaFromSource = source =>
+  sourceCtaMap.get(source) || (`publish-${source || 'unknown'}`);
+
 module.exports = method(
   'upgradeToPro',
   'upgrade user to the pro plan',
-  async ({ cycle, token, cta }, { session }) => {
+  async ({ cycle, token, source }, { session }) => {
     let result;
     try {
       result = await rp({
@@ -14,8 +24,8 @@ module.exports = method(
         json: true,
         form: {
           cycle,
-          cta: `publish-${cta}`,
           stripeToken: token,
+          cta: getCtaFromSource(source),
           access_token: session.publish.accessToken,
           product: 'publish',
           plan: 'pro',

--- a/packages/server/rpc/upgradeToPro/test.js
+++ b/packages/server/rpc/upgradeToPro/test.js
@@ -11,14 +11,12 @@ const session = {
   },
 };
 
-const upgradeToPro = () =>
+const upgradeToPro = source =>
   RPCEndpoint.fn({
     cycle: 'year',
     token: 'stripe token',
-    cta: 'source',
-  }, {
-      session,
-    });
+    source,
+  }, { session });
 
 describe('rpc/upgradeToPro', () => {
   it('sends over a request to Buffer\'s API with Publish\'s access token', () => {
@@ -34,12 +32,22 @@ describe('rpc/upgradeToPro', () => {
     expect(rp.mock.calls[0][0].form.stripeToken).toBe('stripe token');
   });
 
-  it('sets up product/plan to identify it is an upgrade to the Pro plan in Publish', () => {
+  it('it sends the correct cta for specific upgrade paths', () => {
+    rp.mockReturnValueOnce(Promise.resolve({}));
+    upgradeToPro('queue_limit');
+    expect(rp.mock.calls[rp.mock.calls.length - 1][0].form.cta).toBe('publish-composer-notifications-queueLimitUpgrade-1');
+  });
+
+  it('it sends a generic cta for other upgrade paths', () => {
+    rp.mockReturnValueOnce(Promise.resolve({}));
+    upgradeToPro('source');
+    expect(rp.mock.calls[rp.mock.calls.length - 1][0].form.cta).toBe('publish-source');
+  });
+
+  it('it sends an unknown cta for empty sources', () => {
     rp.mockReturnValueOnce(Promise.resolve({}));
     upgradeToPro();
-    expect(rp.mock.calls[0][0].form.plan).toBe('pro');
-    expect(rp.mock.calls[0][0].form.product).toBe('publish');
-    expect(rp.mock.calls[0][0].form.cta).toBe('publish-source');
+    expect(rp.mock.calls[rp.mock.calls.length - 1][0].form.cta).toBe('publish-unknown');
   });
 
   it('an error response gets returned too', () => {


### PR DESCRIPTION
### Purpose

Change the `cta` we're sending to the upgrade endpoint to pass a string matching the [guidelines from data](https://github.com/bufferapp/README/blob/master/runbooks/data-tracking/cta-parameters.md).

### Review

@mallen5311 Tagging you for your thoughts on these strings 😄 — let me know if anything is confusing.

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
