### PR TITLE
Fixing styles for broken calendar on edit

### DIFF
--- a/packages/server/index.html
+++ b/packages/server/index.html
@@ -80,6 +80,12 @@
           transform: translateY(0);
         }
       }
+      /*
+      @todo: remove this class once analyze-shared-components is fixed
+      */
+      .DayPicker-Weekdays {
+        display: block;
+      }
     </style>
     {{{bugsnagScript}}}
     {{{stripeScript}}}


### PR DESCRIPTION
### Purpose
Adding a class to fix the calendar style bug when editing a post on queued tab.

### Notes
I realize this isn't the best approach, it's a temporary quick one, so when we find out how to exclude the styles that are actually affecting here we should remove this line
