### PR TITLE
[PUB-867] Use new correct field for showing IG direct prompts ✅✨

### DIFF
--- a/packages/general-settings/components/GeneralSettings/index.jsx
+++ b/packages/general-settings/components/GeneralSettings/index.jsx
@@ -6,7 +6,7 @@ import LinkShortening from '../LinkShortening';
 import GoogleAnalytics from '../GoogleAnalytics';
 
 const GeneralSettings = ({
-  directPostingEnabled,
+  isInstagramBusiness,
   onSetUpDirectPostingClick,
   linkShorteners,
   profileService,
@@ -23,7 +23,7 @@ const GeneralSettings = ({
   features,
 }) => (
   <div>
-    {!directPostingEnabled &&
+    {!isInstagramBusiness &&
     <InstagramDirectPosting
       onSetUpDirectPostingClick={onSetUpDirectPostingClick}
     />
@@ -50,7 +50,7 @@ const GeneralSettings = ({
 );
 
 GeneralSettings.defaultProps = {
-  directPostingEnabled: false,
+  isInstagramBusiness: false,
   profileService: null,
   linkShorteners: null,
   loadingLinkShorteners: true,
@@ -63,7 +63,7 @@ GeneralSettings.defaultProps = {
 
 GeneralSettings.propTypes = {
   isContributor: PropTypes.bool,
-  directPostingEnabled: PropTypes.bool.isRequired,
+  isInstagramBusiness: PropTypes.bool.isRequired,
   onConnectBitlyURLClick: PropTypes.func.isRequired,
   onDisconnectBitlyURLClick: PropTypes.func.isRequired,
   onSetUpDirectPostingClick: PropTypes.func.isRequired,

--- a/packages/general-settings/components/GeneralSettings/story.jsx
+++ b/packages/general-settings/components/GeneralSettings/story.jsx
@@ -10,21 +10,21 @@ storiesOf('GeneralSettings', module)
   .addDecorator(checkA11y)
   .add('default', () => (
     <GeneralSettings
-      directPostingEnabled={false}
+      isInstagramBusiness={false}
       onSetUpDirectPostingClick={action('onSetUpDirectPosting')}
       features={features}
     />
   ))
   .add('direct posting enabled', () => (
     <GeneralSettings
-      directPostingEnabled
+      isInstagramBusiness
       onSetUpDirectPostingClick={action('onSetUpDirectPosting')}
       features={features}
     />
   ))
   .add('Google analytics enabled', () => (
     <GeneralSettings
-      directPostingEnabled={true}
+      isInstagramBusiness={true}
       onSetUpDirectPostingClick={action('onSetUpDirectPosting')}
       features={features}
     />

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -8,7 +8,7 @@ export const GeneralSettingsWithFeatureLoader = WithFeatureLoader(GeneralSetting
 
 export default connect(
     state => ({
-      directPostingEnabled: state.generalSettings.directPostingEnabled,
+      isInstagramBusiness: state.generalSettings.isInstagramBusiness,
       profileId: state.generalSettings.profileId,
       profileService: state.generalSettings.profileService,
       linkShorteners: state.generalSettings.linkShorteners,

--- a/packages/general-settings/reducer.js
+++ b/packages/general-settings/reducer.js
@@ -12,7 +12,7 @@ export const actionTypes = keyWrapper('GENERAL_SETTINGS', {
 });
 
 const initialState = {
-  directPostingEnabled: false,
+  isInstagramBusiness: false,
   profileId: null,
   showGACustomizationForm: false,
   googleAnalyticsIsEnabled: false,
@@ -23,7 +23,7 @@ export default (state = initialState, action) => {
     case profileActionTypes.SELECT_PROFILE:
       return {
         ...state,
-        directPostingEnabled: action.profile.directPostingEnabled,
+        isInstagramBusiness: action.profile.isInstagramBusiness,
         googleAnalyticsEnabled: action.profile.googleAnalyticsEnabled,
         profileId: action.profileId,
         profileService: action.profile.service,

--- a/packages/general-settings/reducer.test.js
+++ b/packages/general-settings/reducer.test.js
@@ -6,7 +6,7 @@ import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch
 describe('reducer', () => {
   it('should initialize default state', () => {
     const stateAfter = {
-      directPostingEnabled: false,
+      isInstagramBusiness: false,
       profileId: null,
       googleAnalyticsIsEnabled: false,
       showGACustomizationForm: false,
@@ -21,7 +21,7 @@ describe('reducer', () => {
 
   it('should handle SELECT_PROFILE action type', () => {
     const stateAfter = {
-      directPostingEnabled: false,
+      isInstagramBusiness: false,
       profileId: '123',
       profileService: 'twitter',
       loadingLinkShorteners: true,
@@ -33,7 +33,7 @@ describe('reducer', () => {
       type: actionTypes.SELECT_PROFILE,
       profileId: '123',
       profile: {
-        directPostingEnabled: false,
+        isInstagramBusiness: false,
         service: 'twitter',
       },
     };
@@ -45,7 +45,7 @@ describe('reducer', () => {
   it('should SHOW_GA_CUSTOMIZATION_FORM', () => {
     const stateAfter = {
       showGACustomizationForm: false,
-      directPostingEnabled: false,
+      isInstagramBusiness: false,
       googleAnalyticsIsEnabled: false,
       profileId: null,
     };
@@ -62,7 +62,7 @@ describe('reducer', () => {
 
   it('should toggle GA FETCH_SUCCESS action type', () => {
     const stateAfter = {
-      directPostingEnabled: false,
+      isInstagramBusiness: false,
       googleAnalyticsIsEnabled: false,
       profileId: null,
       showGACustomizationForm: false,

--- a/packages/pusher-sync/package.json
+++ b/packages/pusher-sync/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@bufferapp/publish-profile-sidebar": "2.0.0",
     "@bufferapp/publish-queue": "2.0.0",
-    "@bufferapp/publish-parsers": "1.9.33",
+    "@bufferapp/publish-parsers": "1.9.34",
     "pusher-js": "4.1.0"
   }
 }

--- a/packages/queue/components/InstagramDirectPostingBanner/index.jsx
+++ b/packages/queue/components/InstagramDirectPostingBanner/index.jsx
@@ -35,30 +35,20 @@ const bannerWrapper = {
 
 const InstagramDirectPostingBanner = ({
   onSetUpDirectPostingClick,
-}) => (
-  <div style={bannerWrapper}>
-    <CircleInstagramIcon color={'torchRed'} />
-    <span
-      style={textWrapperStyle}
-    >
-      <Text
-        color={'black'}
-        size={'small'}
-      >
+}) =>
+  (<div style={bannerWrapper}>
+    <CircleInstagramIcon color={'instagram'} />
+    <span style={textWrapperStyle}>
+      <Text color={'black'} size={'small'}>
         Buffer can now post directly to Instagram!
-        <span
-          style={linkWrapperStyle}
-        >
-          <Link
-            onClick={() => { onSetUpDirectPostingClick(); }}
-          >
+        <span style={linkWrapperStyle}>
+          <Link unstyled href="#" onClick={onSetUpDirectPostingClick}>
             Set up Instagram direct scheduling.
           </Link>
         </span>
       </Text>
     </span>
-  </div>
-);
+  </div>);
 
 InstagramDirectPostingBanner.propTypes = {
   onSetUpDirectPostingClick: PropTypes.func.isRequired,

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -67,9 +67,10 @@ const QueuedPosts = ({
   onMiniCalendarMonthChange,
   subprofiles,
   isInstagramProfile,
-  directPostingEnabled,
+  isInstagramBusiness,
   onSetUpDirectPostingClick,
 }) => {
+  console.log('onSetUpDirectPostingClick', onSetUpDirectPostingClick);
   if (loading) {
     return (
       <div style={loadingContainerStyle}>
@@ -117,7 +118,7 @@ const QueuedPosts = ({
         </FeatureLoader>
 
       </div>
-      {isInstagramProfile && !directPostingEnabled &&
+      {isInstagramProfile && !isInstagramBusiness &&
         <InstagramDirectPostingBanner onSetUpDirectPostingClick={onSetUpDirectPostingClick} />
       }
       {!!paused && <QueuePausedBar handleClickUnpause={onUnpauseClick} />}
@@ -130,7 +131,7 @@ const QueuedPosts = ({
         />
       }
       {showComposer && editMode &&
-        <ComposerPopover 
+        <ComposerPopover
           onSave={onComposerCreateSuccess}
           type={'queue'}
         />
@@ -189,14 +190,14 @@ QueuedPosts.propTypes = {
   onUnpauseClick: PropTypes.func.isRequired,
   showCalendar: PropTypes.bool,
   onCalendarToggleClick: PropTypes.func.isRequired,
-  onMiniCalendarMonthChange: PropTypes.func,
+  onMiniCalendarMonthChange: PropTypes.func.isRequired,
   numberOfPostsByDate: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.array,
   ]),
-  IsInstagramProfile: PropTypes.bool,
-  directPostingEnabled: PropTypes.bool,
-  onSetUpDirectPostingClick: PropTypes.func,
+  isInstagramProfile: PropTypes.bool,
+  isInstagramBusiness: PropTypes.bool,
+  onSetUpDirectPostingClick: PropTypes.func.isRequired,
 };
 
 QueuedPosts.defaultProps = {
@@ -212,8 +213,8 @@ QueuedPosts.defaultProps = {
   showCalendar: false,
   numberOfPostsByDate: null,
   subprofiles: [],
-  IsInstagramProfile: false,
-  directPostingEnabled: false,
+  isInstagramProfile: false,
+  isInstagramBusiness: false,
 };
 
 export default QueuedPosts;

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux';
+
 import { actions as profileSidebarActions } from '@bufferapp/publish-profile-sidebar';
+import { actions as generalSettingsActions } from '@bufferapp/publish-general-settings';
 import { actions } from './reducer';
+
 import QueuedPosts from './components/QueuedPosts';
 
 const formatPostLists = (posts) => {
@@ -16,33 +19,30 @@ const formatPostLists = (posts) => {
   }, []);
 };
 
-// default export = container
 export default connect(
   (state, ownProps) => {
     const profileId = ownProps.profileId;
-    const currentProfile = state.queue.byProfileId[profileId];
-    const paused =
-      (state.profileSidebar.profiles.filter(p => p.id === profileId && p.paused).length) > 0;
-    if (currentProfile) {
-      const { profileSidebar: { selectedProfile } = {} } = state;
+    const profileQueuePosts = state.queue.byProfileId[profileId];
+    const profileData = state.profileSidebar.profiles.find(p => p.id === ownProps.profileId);
+    if (profileQueuePosts && profileData) {
       return {
-        loading: currentProfile.loading,
-        loadingMore: currentProfile.loadingMore,
-        moreToLoad: currentProfile.moreToLoad,
-        page: currentProfile.page,
-        postLists: formatPostLists(currentProfile.posts),
-        total: currentProfile.total,
+        loading: profileQueuePosts.loading,
+        loadingMore: profileQueuePosts.loadingMore,
+        moreToLoad: profileQueuePosts.moreToLoad,
+        page: profileQueuePosts.page,
+        postLists: formatPostLists(profileQueuePosts.posts),
+        total: profileQueuePosts.total,
         enabledApplicationModes: state.queue.enabledApplicationModes,
         showComposer: state.queue.showComposer,
         environment: state.environment.environment,
         editMode: state.queue.editMode,
         editingPostId: state.queue.editingPostId,
-        showCalendar: currentProfile.showCalendar,
-        paused,
-        numberOfPostsByDate: currentProfile.numberOfPostsByDate,
-        subprofiles: state.profileSidebar && selectedProfile ? selectedProfile.subprofiles : [],
-        isInstagramProfile: state.profileSidebar && selectedProfile && selectedProfile.type === "instagram",
-        directPostingEnabled: state.profileSidebar && selectedProfile && selectedProfile.directPostingEnabled,
+        showCalendar: profileQueuePosts.showCalendar,
+        numberOfPostsByDate: profileQueuePosts.numberOfPostsByDate,
+        subprofiles: profileData.subprofiles || [],
+        isInstagramProfile: profileData.type === 'instagram',
+        isInstagramBusiness: profileData.isInstagramBusiness,
+        paused: profileData.paused,
       };
     }
     return {};
@@ -137,17 +137,12 @@ export default connect(
       }));
     },
     onSetUpDirectPostingClick: () => {
-      dispatch(actions.handleSetUpDirectPostingClick({
+      dispatch(generalSettingsActions.handleSetUpDirectPostingClick({
         profileId: ownProps.profileId,
       }));
     },
   }),
 )(QueuedPosts);
 
-// export reducer, actions and action types
 export reducer, { actions, actionTypes } from './reducer';
 export middleware from './middleware';
-/*
-a consumer of a package should be able to use the package in the following way:
-import Example, { actions, actionTypes, middleware, reducer } from '@bufferapp/publish-example';
-*/

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -13,6 +13,7 @@
     "@bufferapp/keywrapper": "0.2.0",
     "@bufferapp/notifications": "1.9.4",
     "@bufferapp/publish-profile-sidebar": "2.0.0",
+    "@bufferapp/publish-general-settings": "2.0.0",
     "@bufferapp/publish-shared-components": "2.0.0",
     "@bufferapp/publish-upgrade-modal": "2.0.0",
     "react-day-picker": "7.1.10"

--- a/packages/queue/reducer.js
+++ b/packages/queue/reducer.js
@@ -389,7 +389,6 @@ const profileReducer = (state = profileInitialState, action) => {
     case actionTypes.POST_CONFIRMED_DELETE:
     case actionTypes.POST_DELETED:
     case actionTypes.POST_CANCELED_DELETE:
-    case actionTypes.POST_ERROR: //eslint-disable-line
     case actionTypes.POST_IMAGE_CLICKED:
     case actionTypes.POST_IMAGE_CLOSED:
     case actionTypes.POST_IMAGE_CLICKED_NEXT:

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
     "@bufferapp/buffermetrics": "0.6.3-beta-06",
     "@bufferapp/logger": "0.7.0",
     "@bufferapp/micro-rpc": "0.1.7",
-    "@bufferapp/publish-parsers": "1.9.33",
+    "@bufferapp/publish-parsers": "1.9.34",
     "@bufferapp/publish-formatters": "1.9.29",
     "@bufferapp/session-manager": "0.7.1",
     "@bufferapp/shutdown-helper": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,10 +417,10 @@
     moment "2.19.3"
     moment-timezone "0.5.13"
 
-"@bufferapp/publish-parsers@1.9.33":
-  version "1.9.33"
-  resolved "https://registry.yarnpkg.com/@bufferapp/publish-parsers/-/publish-parsers-1.9.33.tgz#ac41af09d792cb726730cacea47cda65d8902d93"
-  integrity sha512-nyVO5cSXu3DVeilTXW9nOcWu5iBlK6RXvhbj9dY2atS6rTuoXV4zOQHf+JZmwrJWrm6eAEhnIpfi0cttDAr4lw==
+"@bufferapp/publish-parsers@1.9.34":
+  version "1.9.34"
+  resolved "https://registry.yarnpkg.com/@bufferapp/publish-parsers/-/publish-parsers-1.9.34.tgz#1ab332eac63c1016f45fdabaced9af60ba6acb66"
+  integrity sha512-AInMpuI0QLQiH4JQ5Uvfaza/pZvhYXNPVaVoJyN2rKXzdG0DrzQPChfouzWtVSGNF8NO0au40pDeRp4v3beyQg==
   dependencies:
     "@bufferapp/publish-formatters" "1.9.29"
     twitter-text "3.0.0"


### PR DESCRIPTION
### Purpose

Ensure we use the correct field when deciding to show the IG Direct banners/settings. The previous one looked right, but wasn't (See email sent to publish team for background on that 😉 )

### Notes

I also cleaned up some of the logic in the queue packages's `mapStateToProps` code. Should be a little more clear now.

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
