### PR TITLE
[WIP] Add compare-chart component to analytics

### DIFF
--- a/analyze.config.js
+++ b/analyze.config.js
@@ -12,6 +12,7 @@ const analyzePackages = [
   'analyze-profile-selector',
   'analyze-shared-components',
   'average-table',
+  'compare-chart',
   'micro-rpc',
   'report-list',
   'summary-table',

--- a/packages/analytics/index.js
+++ b/packages/analytics/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import AverageTable from '@bufferapp/average-table';
+import CompareChart from '@bufferapp/compare-chart';
 import SummaryTable from '@bufferapp/summary-table';
 import Toolbar from './components/Toolbar';
 import './analytics.css';
@@ -9,6 +10,7 @@ const Analytics = () => (
     <Toolbar />
     <SummaryTable />
     <AverageTable />
+    <CompareChart />
   </div>
 );
 

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -11,6 +11,7 @@
     "@bufferapp/analyze-date-picker": "0.65.0",
     "@bufferapp/analyze-shared-components": "0.64.0",
     "@bufferapp/average-table": "0.67.0",
+    "@bufferapp/compare-chart": "0.67.0",
     "@bufferapp/summary-table": "0.67.0",
     "numeral": "^2.0.6"
   }

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -38,6 +38,7 @@ const toggleGoogleAnalytics = require('./toggleGoogleAnalytics');
 // Analytics from Analyze -- Delete when we switch to Analyze
 const analyticsStartDate = require('./analytics/analyticsStartDate');
 const average = require('./analytics/average');
+const compare = require('./analytics/compare');
 const getReport = require('./analytics/getReport');
 const summaryMethod = require('./analytics/summary');
 
@@ -79,6 +80,7 @@ module.exports = rpc(
   toggleGoogleAnalytics,
   analyticsStartDate,
   average,
+  compare,
   getReport,
   summaryMethod,
 );

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -32,6 +32,7 @@ import { middleware as defaultPageMiddleware } from '@bufferapp/default-page';
 import { middleware as notificationsProviderMiddleware } from '@bufferapp/publish-notifications-provider';
 // Remove analytics middleware when publish switches to analyze
 import { middleware as averageMiddleware } from '@bufferapp/average-table';
+import { middleware as compareChartMiddleware } from '@bufferapp/compare-chart';
 import { middleware as datePickerMiddleware } from '@bufferapp/analyze-date-picker';
 import { middleware as profileSelectorMiddleware } from '@bufferapp/analyze-profile-selector';
 import { middleware as summaryTableMiddleware } from '@bufferapp/summary-table';
@@ -90,6 +91,7 @@ const configureStore = (initialstate) => {
         bufferMetricsMiddleware,
         draftsMiddleware,
         averageMiddleware,
+        compareChartMiddleware,
         datePickerMiddleware,
         notificationsProviderMiddleware,
         profileSelectorMiddleware,

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -15,6 +15,7 @@
     "@bufferapp/average-table": "0.67.0",
     "@bufferapp/buffermetrics": "0.6.3-beta-06",
     "@bufferapp/close-account": "2.0.0",
+    "@bufferapp/compare-chart": "0.67.0",
     "@bufferapp/edit-email": "2.0.0",
     "@bufferapp/environment": "1.9.4",
     "@bufferapp/maintenance-redirect": "2.0.0",

--- a/packages/store/reducers.js
+++ b/packages/store/reducers.js
@@ -26,6 +26,7 @@ import { reducer as twoFactorAuthReducer } from '@bufferapp/publish-two-factor-a
 import { reducer as closeAccountReducer } from '@bufferapp/close-account';
 // Remove analytics reducers when publish switches to Analyze
 import { reducer as averageReducer } from '@bufferapp/average-table';
+import { reducer as compareChartReducer } from '@bufferapp/compare-chart';
 import { reducer as datePickerReducer } from '@bufferapp/analyze-date-picker';
 import { reducer as profileReducer } from '@bufferapp/analyze-profile-selector';
 import { reducer as reportListReducer } from '@bufferapp/report-list';
@@ -59,6 +60,7 @@ export default combineReducers({
   profiles: profileReducer,
   generalSettings: generalSettingsReducer,
   postingSchedule: postingScheduleReducer,
+  compare: compareChartReducer,
   date: datePickerReducer,
   reportList: reportListReducer,
   summary: summaryTableReducer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -275,6 +275,22 @@
   resolved "https://registry.yarnpkg.com/@bufferapp/chronos/-/chronos-0.6.1.tgz#0213dff339459ca510103e5a72f558682a2675dd"
   integrity sha1-AhPf8zlFnKUQED5acvVYaComdd0=
 
+"@bufferapp/compare-chart@0.67.0":
+  version "0.67.0"
+  resolved "https://registry.yarnpkg.com/@bufferapp/compare-chart/-/compare-chart-0.67.0.tgz#73418b6684ed538704effb99732974859f0fc863"
+  integrity sha512-0rgCEmKPmbmc816okTIN+xbbG2io+daWV1W3Sc6SQDb+jJzcFgu6XI3zSuIWWplIUzDFCfL3tmVeQirt9HcGGw==
+  dependencies:
+    "@bufferapp/add-report" "^0.67.0"
+    "@bufferapp/analyze-csv-export" "^0.65.1"
+    "@bufferapp/analyze-date-picker" "^0.65.0"
+    "@bufferapp/analyze-decorators" "^0.15.2"
+    "@bufferapp/analyze-png-export" "^0.61.0"
+    "@bufferapp/analyze-profile-selector" "^0.65.0"
+    "@bufferapp/analyze-shared-components" "^0.64.0"
+    "@bufferapp/async-data-fetch" "0.5.36-beta01"
+    react-highcharts "^16.0.2"
+    react-simple-dropdown "3.0.0"
+
 "@bufferapp/components@2.1.1-alpha.6":
   version "2.1.1-alpha.6"
   resolved "https://registry.yarnpkg.com/@bufferapp/components/-/components-2.1.1-alpha.6.tgz#719f6f27496ad5ae63d82782fdb53662e3e95cfe"


### PR DESCRIPTION
### Purpose
As a B4B user, I am able to view and interact with Engagement and Audience (compare-chart component) analytics.

https://buffer.atlassian.net/browse/PUB-918
### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
