### PR TITLE
Disable Redux DevTools in Composer to Prevent Crash

### DIFF
--- a/packages/composer-popover/package.json
+++ b/packages/composer-popover/package.json
@@ -8,7 +8,7 @@
   },
   "author": "ana@buffer.com",
   "dependencies": {
-    "@bufferapp/composer": "2.2.6"
+    "@bufferapp/composer": "2.2.7"
   },
   "devDependencies": {
     "eslint": "3.19.0"


### PR DESCRIPTION
### Purpose

Upgrade the composer to 2.2.7.

The Redux DevTools integration inside the composer is causing New Publish to crash and preventing the composer to load in Classic (only for people with the Redux DevTools extension installed).

This change disables the integration for now.

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
