### PR TITLE
Remove average-table and profile-selector from analytics

### DIFF
--- a/packages/analytics/index.js
+++ b/packages/analytics/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import AverageTable from '@bufferapp/average-table';
 import SummaryTable from '@bufferapp/summary-table';
 import Toolbar from './components/Toolbar';
 import './analytics.css';
@@ -8,7 +7,6 @@ const Analytics = () => (
   <div>
     <Toolbar />
     <SummaryTable />
-    <AverageTable />
   </div>
 );
 

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -37,7 +37,6 @@ const changeLinkShortener = require('./changeLinkShortener');
 const toggleGoogleAnalytics = require('./toggleGoogleAnalytics');
 // Analytics from Analyze -- Delete when we switch to Analyze
 const analyticsStartDate = require('./analytics/analyticsStartDate');
-const average = require('./analytics/average');
 const getReport = require('./analytics/getReport');
 const summaryMethod = require('./analytics/summary');
 
@@ -78,7 +77,6 @@ module.exports = rpc(
   changeLinkShortener,
   toggleGoogleAnalytics,
   analyticsStartDate,
-  average,
   getReport,
   summaryMethod,
 );

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -31,9 +31,7 @@ import { middleware as maintenanceRedirectMiddleware } from '@bufferapp/maintena
 import { middleware as defaultPageMiddleware } from '@bufferapp/default-page';
 import { middleware as notificationsProviderMiddleware } from '@bufferapp/publish-notifications-provider';
 // Remove analytics middleware when publish switches to analyze
-import { middleware as averageMiddleware } from '@bufferapp/average-table';
 import { middleware as datePickerMiddleware } from '@bufferapp/analyze-date-picker';
-import { middleware as profileSelectorMiddleware } from '@bufferapp/analyze-profile-selector';
 import { middleware as summaryTableMiddleware } from '@bufferapp/summary-table';
 import performanceMiddleware from '@bufferapp/performance-tracking/middleware';
 import reducers from './reducers';
@@ -89,10 +87,8 @@ const configureStore = (initialstate) => {
         maintenanceRedirectMiddleware,
         bufferMetricsMiddleware,
         draftsMiddleware,
-        averageMiddleware,
         datePickerMiddleware,
         notificationsProviderMiddleware,
-        profileSelectorMiddleware,
         summaryTableMiddleware,
       ),
     ),

--- a/packages/store/reducers.js
+++ b/packages/store/reducers.js
@@ -25,9 +25,7 @@ import { reducer as manageAppsReducer } from '@bufferapp/manage-apps-extras';
 import { reducer as twoFactorAuthReducer } from '@bufferapp/publish-two-factor-auth';
 import { reducer as closeAccountReducer } from '@bufferapp/close-account';
 // Remove analytics reducers when publish switches to Analyze
-import { reducer as averageReducer } from '@bufferapp/average-table';
 import { reducer as datePickerReducer } from '@bufferapp/analyze-date-picker';
-import { reducer as profileReducer } from '@bufferapp/analyze-profile-selector';
 import { reducer as reportListReducer } from '@bufferapp/report-list';
 import { reducer as summaryTableReducer } from '@bufferapp/summary-table';
 
@@ -41,7 +39,6 @@ export default combineReducers({
   profileSidebar: profileSidebarReducer,
   appSidebar: appSidebarReducer,
   asyncDataFetch: asyncDataFetchReducer,
-  average: averageReducer,
   notifications: notificationsReducer,
   environment: environmentReducer,
   appSwitcher: appSwitcherReducer,
@@ -56,7 +53,6 @@ export default combineReducers({
   closeAccount: closeAccountReducer,
   productFeatures: productFeaturesReducer,
   drafts: draftsReducer,
-  profiles: profileReducer,
   generalSettings: generalSettingsReducer,
   postingSchedule: postingScheduleReducer,
   date: datePickerReducer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,10 +305,10 @@
     react-autocomplete "1.7.2"
     react-day-picker "6.2.1"
 
-"@bufferapp/composer@2.2.6":
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-2.2.6.tgz#e8271cbcc8c7537e4c4a133f6fa057c4ae69bdb2"
-  integrity sha512-gUGmsj9ovygEDPj1oVrmb6VXv2gW2TfhTQVKNRWLBcaHbjHVqPC8CtXJWthwhGsbwSlgYo5M0tNo4TJolnUtmA==
+"@bufferapp/composer@2.2.7":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-2.2.7.tgz#4cade826ad0988ac96cfebc64d6a9107d76c00a7"
+  integrity sha512-Lflwwsm5KI5vMXjeYEXC+1qHqwwQonG4bSwXRQQsLFcqIykNJlKpQjxeFcsCppAP9qHNYrWNyEr2udpP2uP84w==
   dependencies:
     "@bufferapp/buffer-js-api" "0.3.0"
     "@bufferapp/buffer-js-metrics" "0.2.0"


### PR DESCRIPTION
### Purpose
Remove average-table and profile-selector from analytics because of analyze package conflicts with store
### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
