### PR TITLE
PUB-793 | Adding notification messages for bitly auth success and faiure

### DIFF
--- a/packages/notifications-provider/utils/notifications.json
+++ b/packages/notifications-provider/utils/notifications.json
@@ -1,6 +1,12 @@
 {
   "success": {
     "connection": "You're all set! We've selected some times for you but you can tweak them in your settings",
-    "example-with-variable": "This is an example with this {{__variable__}} value"
+    "example-with-variable": "This is an example with this {{__variable__}} value",
+    "bitly-connect": "Great, your bitly account has been linked with the profile {{__variable__}}",
+    "bitly-disconnect": "Okay, your bitly account has been disconnected."
+  },
+  "error": {
+    "bitly-connect": "{{__variable__}}",
+    "bitly-disconnect": "{{__variable__}}"
   }
 }


### PR DESCRIPTION
### Purpose

When a user authenticates / disconnect with bitly we need to display some success/error messages, so I've added the messages to the notifications implementation