### PR TITLE
Fixing Show/hide calendar box shadow looking off.

### DIFF
--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -35,9 +35,11 @@ const loadingContainerStyle = {
 };
 
 const buttonStyle = {
-  height: '40px',
+  height: '37px',
   marginLeft: '1.5rem',
   minWidth: '150px',
+  alignItems: 'center',
+  display: 'flex',
 };
 
 const QueuedPosts = ({


### PR DESCRIPTION
### Purpose
Making small adjustments to the Show/Hide Calendar button styles to fix box-shadow.
