### PR TITLE
[PUB-993]Add notification to display when analytics are not supported

### DIFF
--- a/packages/analytics/components/AnalyticsList/index.jsx
+++ b/packages/analytics/components/AnalyticsList/index.jsx
@@ -6,6 +6,7 @@ import HourlyChart from '@bufferapp/hourly-chart';
 import PostsTable from '@bufferapp/posts-table';
 import SummaryTable from '@bufferapp/summary-table';
 import Toolbar from '../Toolbar';
+import Notification from '../Notification';
 import './analytics.css';
 
 const AnalyticsList = ({ isAnalyticsSupported }) => (
@@ -18,7 +19,7 @@ const AnalyticsList = ({ isAnalyticsSupported }) => (
       <AverageTable />
       <PostsTable />
     </div> :
-    <p>Whoops! Analytics are not supported for this social account.</p>
+    <Notification />
 );
 
 

--- a/packages/analytics/components/Notification/index.jsx
+++ b/packages/analytics/components/Notification/index.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {
+  Card,
+  Text,
+  NotificationIcon,
+} from '@bufferapp/components';
+
+const titleStyle = {
+  display: 'flex',
+};
+
+const iconStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  paddingRight: '0.5rem',
+};
+
+const contentStyle = {
+  marginTop: '0.5rem',
+};
+
+const Notification = () => (
+  <Card reducedPadding>
+    <div style={titleStyle}>
+      <span style={iconStyle}>
+        <NotificationIcon />
+      </span>
+      <Text
+        color={'outerSpace'}
+        weight={'bold'}
+      >
+        Sorry we don&apos;t support this network in our Analytics</Text>
+    </div>
+    <div style={contentStyle}>
+      <Text size={'mini'}>We only support Facebook & Twitter profiles in our analytics right now.</Text>
+    </div>
+  </Card>
+);
+
+export default Notification;

--- a/packages/analytics/components/Notification/story.jsx
+++ b/packages/analytics/components/Notification/story.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { checkA11y } from 'storybook-addon-a11y';
+import Notification from './index';
+
+storiesOf('Analytics Notification', module)
+  .addDecorator(checkA11y)
+  .add('should display notification if analytics are not supported', () => (
+    <Notification />
+));


### PR DESCRIPTION
### Purpose
Add notification to display when analytics are not supported
https://buffer.atlassian.net/browse/PUB-993
### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
