### PR TITLE
Add image click logic to sent posts

### DIFF
--- a/packages/composer-popover/components/ComposerWrapper/index.jsx
+++ b/packages/composer-popover/components/ComposerWrapper/index.jsx
@@ -33,7 +33,7 @@ export default connect(
         case 'sent':
           options = {
             editMode: state.sent.editMode,
-            post: state.sent.byProfileId[selectedProfileId].posts.find(p => p.id === postId),
+            post: state.sent.byProfileId[selectedProfileId].posts[postId],
           };
           break;
         default:

--- a/packages/sent/components/SentPosts/index.jsx
+++ b/packages/sent/components/SentPosts/index.jsx
@@ -44,6 +44,10 @@ const SentPosts = ({
   postLists,
   onEditClick,
   onShareAgainClick,
+  onImageClick,
+  onImageClickNext,
+  onImageClickPrev,
+  onImageClose,
   onComposerCreateSuccess,
   showComposer,
   editMode,
@@ -91,6 +95,10 @@ const SentPosts = ({
         postLists={postLists}
         onEditClick={onEditClick}
         onShareAgainClick={onShareAgainClick}
+        onImageClick={onImageClick}
+        onImageClickNext={onImageClickNext}
+        onImageClickPrev={onImageClickPrev}
+        onImageClose={onImageClose}
         isSent
       />
     </div>
@@ -118,6 +126,10 @@ SentPosts.propTypes = {
   onComposerCreateSuccess: PropTypes.func.isRequired,
   onEditClick: PropTypes.func.isRequired,
   onShareAgainClick: PropTypes.func,
+  onImageClick: PropTypes.func,
+  onImageClickNext: PropTypes.func,
+  onImageClickPrev: PropTypes.func,
+  onImageClose: PropTypes.func,
 };
 
 SentPosts.defaultProps = {
@@ -130,6 +142,10 @@ SentPosts.defaultProps = {
   showComposer: false,
   editMode: false,
   onShareAgainClick: () => {},
+  onImageClick: () => {},
+  onImageClickNext: () => {},
+  onImageClickPrev: () => {},
+  onImageClose: () => {},
 };
 
 export default SentPosts;

--- a/packages/sent/components/SentPosts/index.jsx
+++ b/packages/sent/components/SentPosts/index.jsx
@@ -9,11 +9,6 @@ import {
   Text,
   LoadingAnimation,
 } from '@bufferapp/components';
-import {
-  geyser,
-  fillColor,
-  curiousBlue,
-} from '@bufferapp/components/style/color';
 import ComposerPopover from '@bufferapp/publish-composer-popover';
 
 const headerStyle = {

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -8,17 +8,15 @@ const formatPostLists = (posts) => {
   const postLists = [];
   let day;
   let newList;
-
-  posts.forEach((post) => {
-    if (post.day !== day) {
-      day = post.day;
-      newList = { listHeader: day, posts: [post] };
+  Object.keys(posts).forEach((key) => {
+    if (posts[key].day !== day) {
+      day = posts[key].day;
+      newList = { listHeader: day, posts: [posts[key]] };
       postLists.push(newList);
     } else { // if same day add to posts array of current list
-      newList.posts.push(post);
+      newList.posts.push(posts[key]);
     }
   });
-
   return postLists;
 };
 

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -8,13 +8,14 @@ const formatPostLists = (posts) => {
   const postLists = [];
   let day;
   let newList;
-  Object.keys(posts).forEach((key) => {
-    if (posts[key].day !== day) {
-      day = posts[key].day;
-      newList = { listHeader: day, posts: [posts[key]] };
+  const orderedPosts = Object.values(posts).sort((a, b) => b.due_at - a.due_at);
+  orderedPosts.forEach((post) => {
+    if (post.day !== day) {
+      day = post.day;
+      newList = { listHeader: day, posts: [post] };
       postLists.push(newList);
     } else { // if same day add to posts array of current list
-      newList.posts.push(posts[key]);
+      newList.posts.push(post);
     }
   });
   return postLists;

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -52,6 +52,30 @@ export default connect(
     onComposerCreateSuccess: () => {
       dispatch(actions.handleComposerCreateSuccess());
     },
+    onImageClick: (post) => {
+      dispatch(actions.handleImageClick({
+        post: post.post,
+        profileId: ownProps.profileId,
+      }));
+    },
+    onImageClose: (post) => {
+      dispatch(actions.handleImageClose({
+        post: post.post,
+        profileId: ownProps.profileId,
+      }));
+    },
+    onImageClickNext: (post) => {
+      dispatch(actions.handleImageClickNext({
+        post: post.post,
+        profileId: ownProps.profileId,
+      }));
+    },
+    onImageClickPrev: (post) => {
+      dispatch(actions.handleImageClickPrev({
+        post: post.post,
+        profileId: ownProps.profileId,
+      }));
+    },
   }),
 )(SentPosts);
 

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -46,8 +46,11 @@ const increasePageCount = (page) => {
   return page;
 };
 
-const determineIfMoreToLoad = (action, currentPosts) =>
-  (action.result.total > (currentPosts.length + action.result.updates.length));
+const determineIfMoreToLoad = (action, currentPosts) => {
+  const currentPostCount = Object.keys(currentPosts).length;
+  const resultUpdatesCount = Object.keys(action.result.updates).length;
+  return (action.result.total > (currentPostCount + resultUpdatesCount));
+};
 
 const getProfileId = (action) => {
   if (action.profileId) { return action.profileId; }

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -23,7 +23,7 @@ export const initialState = {
   environment: 'production',
 };
 
-const profileInitialState = {
+export const profileInitialState = {
   header,
   loading: true,
   loadingMore: false,

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -55,10 +55,53 @@ const getProfileId = (action) => {
   if (action.profile) { return action.profile.id; }
 };
 
+const getPostUpdateId = (action) => {
+  if (action.updateId) { return action.updateId; }
+  if (action.args) { return action.args.updateId; }
+  if (action.post) { return action.post.id; }
+};
+
+const postReducer = (state, action) => {
+  switch (action.type) {
+    case actionTypes.POST_IMAGE_CLICKED:
+      return {
+        ...state,
+        isLightboxOpen: true,
+        currentImage: 0,
+      };
+    case actionTypes.POST_IMAGE_CLOSED:
+      return {
+        ...state,
+        isLightboxOpen: false,
+      };
+    case actionTypes.POST_IMAGE_CLICKED_NEXT:
+      return {
+        ...state,
+        currentImage: state.currentImage + 1,
+      };
+    case actionTypes.POST_IMAGE_CLICKED_PREV:
+      return {
+        ...state,
+        currentImage: state.currentImage - 1,
+      };
+    default:
+      return state;
+  }
+};
+
 const postsReducer = (state, action) => {
   switch (action.type) {
     case queueActionTypes.POST_SENT:
       return [action.post, ...state];
+    case actionTypes.POST_IMAGE_CLICKED:
+    case actionTypes.POST_IMAGE_CLOSED:
+    case actionTypes.POST_IMAGE_CLICKED_NEXT:
+    case actionTypes.POST_IMAGE_CLICKED_PREV: {
+      return {
+        ...state,
+        [getPostUpdateId(action)]: postReducer(state[getPostUpdateId(action)], action),
+      };
+    }
     default:
       return state;
   }
@@ -95,6 +138,10 @@ const profileReducer = (state = profileInitialState, action) => {
         total: action.counts.sent,
       };
     case queueActionTypes.POST_SENT:
+    case actionTypes.POST_IMAGE_CLICKED:
+    case actionTypes.POST_IMAGE_CLOSED:
+    case actionTypes.POST_IMAGE_CLICKED_NEXT:
+    case actionTypes.POST_IMAGE_CLICKED_PREV:
       return {
         ...state,
         posts: postsReducer(state.posts, action),
@@ -113,6 +160,10 @@ export default (state = initialState, action) => {
     case `sentPosts_${dataFetchActionTypes.FETCH_FAIL}`:
     case queueActionTypes.POST_SENT:
     case queueActionTypes.POST_COUNT_UPDATED:
+    case actionTypes.POST_IMAGE_CLICKED:
+    case actionTypes.POST_IMAGE_CLOSED:
+    case actionTypes.POST_IMAGE_CLICKED_NEXT:
+    case actionTypes.POST_IMAGE_CLICKED_PREV:
       profileId = getProfileId(action);
       if (profileId) {
         return {

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -9,6 +9,10 @@ import {
 export const actionTypes = keyWrapper('SENT', {
   OPEN_COMPOSER: 0,
   HIDE_COMPOSER: 0,
+  POST_IMAGE_CLICKED: 0,
+  POST_IMAGE_CLICKED_NEXT: 0,
+  POST_IMAGE_CLICKED_PREV: 0,
+  POST_IMAGE_CLOSED: 0,
 });
 
 export const initialState = {
@@ -147,5 +151,29 @@ export const actions = {
   }),
   handleComposerCreateSuccess: () => ({
     type: actionTypes.HIDE_COMPOSER,
+  }),
+  handleImageClick: ({ post, profileId }) => ({
+    type: actionTypes.POST_IMAGE_CLICKED,
+    updateId: post.id,
+    post,
+    profileId,
+  }),
+  handleImageClickNext: ({ post, profileId }) => ({
+    type: actionTypes.POST_IMAGE_CLICKED_NEXT,
+    updateId: post.id,
+    post,
+    profileId,
+  }),
+  handleImageClickPrev: ({ post, profileId }) => ({
+    type: actionTypes.POST_IMAGE_CLICKED_PREV,
+    updateId: post.id,
+    post,
+    profileId,
+  }),
+  handleImageClose: ({ post, profileId }) => ({
+    type: actionTypes.POST_IMAGE_CLOSED,
+    updateId: post.id,
+    post,
+    profileId,
   }),
 };

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -92,7 +92,10 @@ const postReducer = (state, action) => {
 const postsReducer = (state, action) => {
   switch (action.type) {
     case queueActionTypes.POST_SENT:
-      return [action.post, ...state];
+      return {
+        ...state,
+        [getPostUpdateId(action)]: action.post,
+      };
     case actionTypes.POST_IMAGE_CLICKED:
     case actionTypes.POST_IMAGE_CLOSED:
     case actionTypes.POST_IMAGE_CLICKED_NEXT:

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -29,14 +29,14 @@ const profileInitialState = {
   loadingMore: false,
   moreToLoad: false,
   page: 1,
-  posts: [],
+  posts: {},
   total: 0,
 };
 
 const handlePosts = (action, currentPosts) => {
   let posts = action.result.updates;
   if (action.args.isFetchingMore) {
-    posts = [...currentPosts, ...posts];
+    posts = { ...currentPosts, ...posts };
   }
   return posts;
 };

--- a/packages/sent/reducer.test.js
+++ b/packages/sent/reducer.test.js
@@ -1,5 +1,5 @@
 import deepFreeze from 'deep-freeze';
-import reducer, { initialState } from './reducer';
+import reducer, { initialState, actionTypes } from './reducer';
 import {
   header,
 } from './components/SentPosts/postData';
@@ -125,5 +125,45 @@ describe('reducer', () => {
 
     expect(reducer(stateComposerVisible, action))
       .toEqual(Object.assign(initialState, { showComposer: false }));
+  });
+
+  it('should handle POST_IMAGE_CLICKED action type', () => {
+    const post = { id: '12345', text: 'i heart buffer' };
+    const postAfter = { ...post, isLightboxOpen: true, currentImage: 0 };
+    const stateBefore = {
+      byProfileId: {
+        [profileId]: {
+          header: 'Your posts for the last 30 days',
+          loading: true,
+          loadingMore: false,
+          moreToLoad: false,
+          page: 1,
+          posts: { 12345: post },
+          total: 1,
+        },
+      },
+    };
+    const stateAfter = {
+      byProfileId: {
+        [profileId]: {
+          header: 'Your posts for the last 30 days',
+          loading: true,
+          loadingMore: false,
+          moreToLoad: false,
+          page: 1,
+          posts: { 12345: postAfter },
+          total: 1,
+        },
+      },
+    };
+    const action = {
+      type: actionTypes.POST_IMAGE_CLICKED,
+      profileId,
+      post: postAfter,
+      updateId: postAfter.id,
+    };
+    deepFreeze(action);
+    expect(reducer(stateBefore, action))
+      .toEqual(stateAfter);
   });
 });

--- a/packages/sent/reducer.test.js
+++ b/packages/sent/reducer.test.js
@@ -1,5 +1,5 @@
 import deepFreeze from 'deep-freeze';
-import reducer, { initialState, actionTypes } from './reducer';
+import reducer, { initialState, profileInitialState, actionTypes } from './reducer';
 import {
   header,
 } from './components/SentPosts/postData';
@@ -26,7 +26,7 @@ describe('reducer', () => {
           loadingMore: false,
           moreToLoad: false,
           page: 1,
-          posts: [],
+          posts: {},
           total: 0,
         },
       },
@@ -83,7 +83,7 @@ describe('reducer', () => {
           loadingMore: false,
           moreToLoad: false,
           page: 1,
-          posts: [],
+          posts: {},
           total: 0,
         },
       },
@@ -132,32 +132,40 @@ describe('reducer', () => {
     const postAfter = { ...post, isLightboxOpen: true, currentImage: 0 };
     const stateBefore = {
       byProfileId: {
-        [profileId]: {
-          header: 'Your posts for the last 30 days',
-          loading: true,
-          loadingMore: false,
-          moreToLoad: false,
-          page: 1,
-          posts: { 12345: post },
-          total: 1,
-        },
+        [profileId]: Object.assign(profileInitialState, { posts: { 12345: post } }),
       },
     };
     const stateAfter = {
       byProfileId: {
-        [profileId]: {
-          header: 'Your posts for the last 30 days',
-          loading: true,
-          loadingMore: false,
-          moreToLoad: false,
-          page: 1,
-          posts: { 12345: postAfter },
-          total: 1,
-        },
+        [profileId]: Object.assign(profileInitialState, { posts: { 12345: postAfter } }),
       },
     };
     const action = {
       type: actionTypes.POST_IMAGE_CLICKED,
+      profileId,
+      post: postAfter,
+      updateId: postAfter.id,
+    };
+    deepFreeze(action);
+    expect(reducer(stateBefore, action))
+      .toEqual(stateAfter);
+  });
+
+  it('should handle POST_IMAGE_CLOSED action type', () => {
+    const post = { id: '12345', text: 'i heart buffer' };
+    const postAfter = { ...post, isLightboxOpen: false };
+    const stateBefore = {
+      byProfileId: {
+        [profileId]: Object.assign(profileInitialState, { posts: { 12345: post } }),
+      },
+    };
+    const stateAfter = {
+      byProfileId: {
+        [profileId]: Object.assign(profileInitialState, { posts: { 12345: postAfter } }),
+      },
+    };
+    const action = {
+      type: actionTypes.POST_IMAGE_CLOSED,
       profileId,
       post: postAfter,
       updateId: postAfter.id,

--- a/packages/server/rpc/sentPosts/index.js
+++ b/packages/server/rpc/sentPosts/index.js
@@ -1,4 +1,5 @@
 const { postParser } = require('@bufferapp/publish-parsers');
+const { buildPostMap } = require('@bufferapp/publish-formatters');
 const { method } = require('@bufferapp/buffer-rpc');
 const rp = require('request-promise');
 
@@ -17,8 +18,12 @@ module.exports = method(
       },
     })
       .then(result => JSON.parse(result))
-      .then(parsedResult => ({
-        total: parsedResult.total,
-        updates: parsedResult.updates.map(postParser),
-      })),
+      .then((parsedResult) => {
+        const updates = parsedResult.updates.map(postParser);
+        const mappedUpdates = buildPostMap(updates);
+        return {
+          total: parsedResult.total,
+          updates: mappedUpdates,
+        };
+      }),
 );


### PR DESCRIPTION
### Purpose
Allow a user to click and expand an image in sent posts. 

Through bugsnag, we were able to see that many users tried to click on images in Sent Posts, and the image wouldn't expand.
https://app.bugsnag.com/buffer/buffer-publish/errors/5c05d8c0223e2d0019ffff81?filters[event.since][0]=30d&filters[error.status][0]=open
### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
