### PR TITLE
[PUB-946] Redirect user to queue if they do not have access to routes

### DIFF
--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Redirect } from 'react-router';
 import PropTypes from 'prop-types';
 import {
   Tabs,
@@ -32,6 +33,23 @@ const TabNavigation = ({
   profileId,
 }) => {
   const selectedChildTab = selectedChildTabId || 'general-settings';
+  const shouldRedirectTabId = (tabId) => {
+    if (tabId === selectedTabId) {
+      return (
+        <Redirect to="/" />
+      );
+    }
+  };
+  const shouldRedirectChildTabId = () => {
+    switch (selectedChildTabId) {
+      case 'posting-schedule':
+      case 'general-settings':
+        return (
+          <Redirect to="/" />
+        );
+      default: // do nothing
+    }
+  };
   return (
     /* wrapper div with "tabs" id necessary as a selector
     for a11y focus after selecting profile in sidebar */
@@ -42,15 +60,20 @@ const TabNavigation = ({
       >
         <Tab tabId={'queue'}>Queue</Tab>
         <Tab tabId={'sent'}>Sent Posts</Tab>
-        {isBusinessAccount && <Tab tabId={'analytics'}>Analytics</Tab>}
-        {hasDraftsFeatureFlip && isBusinessAccount && isManager &&
-          <Tab tabId={'awaitingApproval'}>Awaiting Approval</Tab>
+        {isBusinessAccount ? <Tab tabId={'analytics'}>Analytics</Tab> :
+          shouldRedirectTabId('analytics')
         }
-        {hasDraftsFeatureFlip && isBusinessAccount && !isManager &&
-          <Tab tabId={'pendingApproval'}>Pending Approval</Tab>
+        {hasDraftsFeatureFlip && isBusinessAccount && isManager ?
+          <Tab tabId={'awaitingApproval'}>Awaiting Approval</Tab> :
+            shouldRedirectTabId('awaitingApproval')
         }
-        {hasDraftsFeatureFlip && isBusinessAccount &&
-          <Tab tabId={'drafts'}>Drafts</Tab>
+        {hasDraftsFeatureFlip && isBusinessAccount && !isManager ?
+          <Tab tabId={'pendingApproval'}>Pending Approval</Tab> :
+            shouldRedirectTabId('pendingApproval')
+        }
+        {hasDraftsFeatureFlip && isBusinessAccount ?
+          <Tab tabId={'drafts'}>Drafts</Tab> :
+            shouldRedirectTabId('drafts')
         }
         <Tab tabId={'settings'}>Settings</Tab>
         <FeatureLoader supportedFeatures={'b4b_calendar'}>
@@ -77,7 +100,7 @@ const TabNavigation = ({
             </Button>
         </div>
       }
-      {shouldShowNestedSettingsTab &&
+      {shouldShowNestedSettingsTab ?
         <Tabs
           selectedTabId={selectedChildTab}
           onTabClick={onChildTabClick}
@@ -85,7 +108,8 @@ const TabNavigation = ({
         >
           <Tab tabId={'general-settings'}>General</Tab>
           <Tab tabId={'posting-schedule'}>Posting Schedule</Tab>
-        </Tabs>
+        </Tabs> :
+        shouldRedirectChildTabId()
       }
     </div>
   );


### PR DESCRIPTION
### Purpose
Redirect user to queue if they do not have access to routes
https://buffer.atlassian.net/browse/PUB-946

Example: For a free user, they will not see the Drafts tab in the navigation. However, if they visit the drafts route, they will still have access to it. 
### Notes
I added the logic to the tabs package since we were already checking permissions there. It could also make sense to add the logic to the profile-page package.
### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
