### PR TITLE
Small tweaks to handle errors and styling in PostMetaBar

### DIFF
--- a/packages/shared-components/Post/InstagramPostMetaBar/index.jsx
+++ b/packages/shared-components/Post/InstagramPostMetaBar/index.jsx
@@ -5,12 +5,14 @@ import PostMetaBar from '../../PostMetaBar';
 const InstagramPostMetaBar = ({
   dragging,
   locationName,
+  isSent,
 }) => {
   const leftContent = { title: 'Location:', text: locationName };
   return (
     <PostMetaBar
       dragging={dragging}
       leftContent={leftContent}
+      isSent={isSent}
     />
   );
 };
@@ -18,6 +20,7 @@ const InstagramPostMetaBar = ({
 InstagramPostMetaBar.propTypes = {
   locationName: PropTypes.string,
   dragging: PropTypes.bool,
+  isSent: PropTypes.bool,
 };
 
 export default InstagramPostMetaBar;

--- a/packages/shared-components/Post/PinterestPostMetaBar/index.jsx
+++ b/packages/shared-components/Post/PinterestPostMetaBar/index.jsx
@@ -8,6 +8,7 @@ const PinterestPostMetaBar = ({
   sourceUrl,
   boardName,
   boardAvatarUrl,
+  isSent,
 }) => {
   const leftContent = { title: 'Pinned to:', text: boardName, avatarUrl: boardAvatarUrl };
   const rightContent = sourceUrl ? { title: 'Source:', text: getFormattedSourceUrl(sourceUrl) } : null;
@@ -17,6 +18,7 @@ const PinterestPostMetaBar = ({
       dragging={dragging}
       leftContent={leftContent}
       rightContent={rightContent}
+      isSent={isSent}
     />
   );
 };
@@ -26,6 +28,7 @@ PinterestPostMetaBar.propTypes = {
   sourceUrl: PropTypes.string,
   boardName: PropTypes.string,
   boardAvatarUrl: PropTypes.string,
+  isSent: PropTypes.bool,
 };
 
 export default PinterestPostMetaBar;

--- a/packages/shared-components/Post/RenderPostMetaBar/index.jsx
+++ b/packages/shared-components/Post/RenderPostMetaBar/index.jsx
@@ -10,23 +10,26 @@ const RenderPostMetaBar = ({
   subprofileID,
   subprofiles,
   dragging,
+  isSent,
 }) => {
-  if (profileService === 'instagram' && locationName !== null) {
+  if (profileService === 'instagram' && locationName) {
     return (
       <InstagramPostMetaBar
         dragging={dragging}
         locationName={locationName}
+        isSent={isSent}
       />
     );
-  } else if (profileService === 'pinterest' && subprofileID !== null) {
+  } else if (profileService === 'pinterest' && subprofileID) {
     /*  having a subprofileID is required, sourceUrl is not */
     const subprofile = subprofiles.find((profile => profile.id === subprofileID));
     return (
       <PinterestPostMetaBar
         dragging={dragging}
-        boardName={subprofile.name}
-        boardAvatarUrl={subprofile.avatar}
+        boardName={subprofile ? subprofile.name : null}
+        boardAvatarUrl={subprofile ? subprofile.avatar : null}
         sourceUrl={sourceUrl}
+        isSent={isSent}
       />
     );
   }

--- a/packages/shared-components/Post/RenderPostMetaBar/index.jsx
+++ b/packages/shared-components/Post/RenderPostMetaBar/index.jsx
@@ -44,6 +44,7 @@ RenderPostMetaBar.propTypes = {
     }),
   ),
   dragging: PropTypes.bool,
+  isSent: PropTypes.bool,
 };
 
 export default RenderPostMetaBar;

--- a/packages/shared-components/Post/RenderPostMetaBar/index.jsx
+++ b/packages/shared-components/Post/RenderPostMetaBar/index.jsx
@@ -22,7 +22,8 @@ const RenderPostMetaBar = ({
     );
   } else if (profileService === 'pinterest' && subprofileID) {
     /*  having a subprofileID is required, sourceUrl is not */
-    const subprofile = subprofiles.find((profile => profile.id === subprofileID));
+    const subprofile = subprofiles ?
+      subprofiles.find((profile => profile.id === subprofileID)) : null;
     return (
       <PinterestPostMetaBar
         dragging={dragging}

--- a/packages/shared-components/Post/index.jsx
+++ b/packages/shared-components/Post/index.jsx
@@ -161,6 +161,7 @@ const Post = ({
           sourceUrl={sourceUrl}
           subprofileID={subprofileID}
           subprofiles={subprofiles}
+          isSent={isSent}
         />
         <PostFooter
           isDeleting={isDeleting}

--- a/packages/shared-components/PostMetaBar/index.jsx
+++ b/packages/shared-components/PostMetaBar/index.jsx
@@ -5,14 +5,14 @@ import { mystic, offWhite } from '@bufferapp/components/style/color';
 import { borderWidth } from '@bufferapp/components/style/border';
 import { Text, Image } from '@bufferapp/components';
 
-const getPostMetaBarStyle = dragging => ({
+const getPostMetaBarStyle = (dragging, isSent) => ({
   display: 'flex',
   padding: '0.5rem 1rem',
   backgroundColor: offWhite,
   borderTop: `${borderWidth} solid ${mystic}`,
   borderBottom: `${borderWidth} solid ${mystic}`,
   opacity: dragging ? 0 : 1,
-  marginBottom: 10,
+  marginBottom: isSent ? 0 : 10,
 });
 
 const getImageWrapperStyle = avatarUrl => ({
@@ -53,8 +53,8 @@ const renderLeftContent = leftContent => (
   </span>
 );
 
-const PostMetaBar = ({ leftContent, rightContent, dragging }) => (
-  <div style={getPostMetaBarStyle(dragging)}>
+const PostMetaBar = ({ leftContent, rightContent, dragging, isSent }) => (
+  <div style={getPostMetaBarStyle(dragging, isSent)}>
     {renderLeftContent(leftContent)}
     {rightContent &&
       <span>
@@ -71,6 +71,7 @@ const PostMetaBar = ({ leftContent, rightContent, dragging }) => (
 
 PostMetaBar.propTypes = {
   dragging: PropTypes.bool,
+  isSent: PropTypes.bool,
   leftContent: PropTypes.shape({
     title: PropTypes.string,
     text: PropTypes.string,


### PR DESCRIPTION
### Purpose
Added a couple of small tweaks for the PostMetaBar component.
- Add a change to handle subprofiles & subprofile being undefined.  
- Check if a post is sent or in the queue, and assign bottom-margin based on it
- Check if locationBar is true instead of null (to catch undefined)

https://buffer.slack.com/archives/C151RRDL1/p1545424352041200
### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
