### PR TITLE
Handle forEach error if orderedPosts is not an array

### DIFF
--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -8,7 +8,9 @@ const formatPostLists = (posts) => {
   const postLists = [];
   let day;
   let newList;
-  const orderedPosts = Object.values(posts).sort((a, b) => b.due_at - a.due_at);
+  const orderedPosts = (posts && typeof posts === 'object') ?
+    Object.values(posts).sort((a, b) => b.due_at - a.due_at) : [];
+
   orderedPosts.forEach((post) => {
     if (post.day !== day) {
       day = post.day;


### PR DESCRIPTION
### Purpose
Handle error for forEach if orderedPosts is not an array
https://app.bugsnag.com/buffer/buffer-publish/errors/5c2cccf7851927001c792b0d?filters[event.since][0]=30d&filters[error.status][0]=open
### Notes
Noticed this error in bugsnag after merging the imageClick PR for sent posts this morning. `TypeError · e.forEach is not a function` I wasn't able to replicate the error while impersonating the users, but I'm assuming orderedPosts must be undefined or not an array.  
### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
