### PR TITLE
Upgrade Composer to v2.6.6

### DIFF
--- a/packages/composer-popover/package.json
+++ b/packages/composer-popover/package.json
@@ -8,7 +8,7 @@
   },
   "author": "ana@buffer.com",
   "dependencies": {
-    "@bufferapp/composer": "2.5.0"
+    "@bufferapp/composer": "2.6.6"
   },
   "devDependencies": {
     "eslint": "3.19.0"

--- a/packages/pusher-sync/package.json
+++ b/packages/pusher-sync/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@bufferapp/publish-profile-sidebar": "2.0.0",
     "@bufferapp/publish-queue": "2.0.0",
-    "@bufferapp/publish-parsers": "1.10.1",
+    "@bufferapp/publish-parsers": "1.11.0",
     "pusher-js": "4.1.0"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,7 +13,7 @@
     "@bufferapp/logger": "0.7.0",
     "@bufferapp/micro-rpc": "0.1.7",
     "@bufferapp/publish-formatters": "1.9.29",
-    "@bufferapp/publish-parsers": "1.10.1",
+    "@bufferapp/publish-parsers": "1.11.0",
     "@bufferapp/session-manager": "0.7.1",
     "@bufferapp/shutdown-helper": "0.2.0",
     "@bugsnag/js": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -352,10 +352,10 @@
     react-autocomplete "1.7.2"
     react-day-picker "6.2.1"
 
-"@bufferapp/composer@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-2.5.0.tgz#fbc0ce4633761e0e08013cf39bf78152c84cbd13"
-  integrity sha512-0sIj3n00RHmSw1F6Lk4bnQ1TclNm1bsi+1VdUUol/mSEiv3nCX6KcU5HWhDirttfPKnTBR2lN1IofTuhI4VhHw==
+"@bufferapp/composer@2.6.6":
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-2.6.6.tgz#5a3975191ff2a9f75e48a8ba979ebac3ddb307d3"
+  integrity sha512-PRkvj1KVBJXs7iLEho9pulhzMlkohu6Z4VrZl8FR8beTsyPfSx+kQD18ncdKMcgVNeMMIhyPhvOv2nc7se4Orw==
   dependencies:
     "@bufferapp/buffer-js-api" "0.3.0"
     "@bufferapp/buffer-js-metrics" "0.2.0"


### PR DESCRIPTION
This PR includes an updated version of the composer and also the user parser.

* Composer: See the [CHANGELOG](https://github.com/bufferapp/buffer-composer/blob/master/CHANGELOG.md) for details. It's almost entirely to support IG direct video.
* Parsers: See [this commit](https://github.com/bufferapp/buffer-js-publish-parsers/commit/ecb6720efee786934fef665939afbdf30b18a123)