### PR TITLE
Add `/ajax/buffermetrics` endpoint

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -21,9 +21,12 @@ const maintenanceHandler = require('./maintenanceHandler');
 const { sendFavicon } = require('./lib/favicon');
 const { getBugsnagClient, getBugsnagScript } = require('./lib/bugsnag');
 const serialize = require('serialize-javascript');
+const multer = require('multer');
 
 const app = express();
 const server = http.createServer(app);
+const multiBodyParser = multer();
+const composerAjaxBuffemetrics = require('./lib/composerAjaxBuffermetrics');
 
 // Favicon
 app.get(
@@ -155,6 +158,17 @@ app.use(
     debug: !isProduction,
     trackVisits: true,
   }),
+);
+
+/**
+ * The composer expects this URL to exist and accept
+ * metrics data. It does on buffer-web, but not here
+ * in publish, so we create it here.
+ */
+app.post('/ajax/buffermetrics',
+  // needed to parse the multipart FormData
+  multiBodyParser.fields([]),
+  composerAjaxBuffemetrics,
 );
 
 // make sure we have a valid session

--- a/packages/server/lib/composerAjaxBuffermetrics.js
+++ b/packages/server/lib/composerAjaxBuffermetrics.js
@@ -1,0 +1,25 @@
+module.exports = (req, res) => {
+  const { values } = req.body;
+
+  values.forEach((event) => {
+    const scopes = event.value;
+    const metadata = event.extra_data;
+    const indexOfMc = scopes.indexOf('multiple-composers');
+
+    if (indexOfMc) {
+      // We can only send one action with our new metrics
+      // so we'll concat anything after the mc part
+      let action = scopes.splice(indexOfMc + 1);
+      action = action.join('-');
+
+      req.buffermetrics.trackAction({
+        application: 'publish',
+        location: 'composer',
+        action,
+        metadata,
+      });
+    }
+  });
+
+  res.send('success');
+};

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,6 +25,7 @@
     "micro-rpc-client": "0.1.4",
     "moment": "2.22.2",
     "moment-timezone": "0.5.23",
+    "multer": "^1.4.1",
     "node-dogstatsd": "0.0.6",
     "pusher": "1.5.1",
     "request": "2.81.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,6 +1461,11 @@ aphrodite@^0.5.0:
     asap "^2.0.3"
     inline-style-prefixer "^2.0.0"
 
+append-field@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-field/-/append-field-1.0.0.tgz#1e3440e915f0b1203d23748e78edd7b9b5b43e56"
+  integrity sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=
+
 append-transform@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
@@ -3336,6 +3341,14 @@ bunyan@1.8.1:
     mv "~2"
     safe-json-stringify "~1"
 
+busboy@^0.2.11:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.2.14.tgz#6c2a622efcf47c57bbbe1e2a9c37ad36c7925453"
+  integrity sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=
+  dependencies:
+    dicer "0.2.5"
+    readable-stream "1.1.x"
+
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -4536,6 +4549,14 @@ detect-port-alt@1.1.6:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+dicer@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
+  integrity sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=
+  dependencies:
+    readable-stream "1.1.x"
+    streamsearch "0.1.2"
 
 diff@^3.2.0:
   version "3.5.0"
@@ -8964,6 +8985,20 @@ msgpack-lite@*:
     int64-buffer "^0.1.9"
     isarray "^1.0.0"
 
+multer@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/multer/-/multer-1.4.1.tgz#24b12a416a22fec2ade810539184bf138720159e"
+  integrity sha512-zzOLNRxzszwd+61JFuAo0fxdQfvku12aNJgnla0AQ+hHxFmfc/B7jBVuPr5Rmvu46Jze/iJrFpSOsD7afO8SDw==
+  dependencies:
+    append-field "^1.0.0"
+    busboy "^0.2.11"
+    concat-stream "^1.5.2"
+    mkdirp "^0.5.1"
+    object-assign "^4.1.1"
+    on-finished "^2.3.0"
+    type-is "^1.6.4"
+    xtend "^4.0.0"
+
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -11158,6 +11193,16 @@ readable-stream@1.1:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
+readable-stream@1.1.x:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readable-stream@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.0.6.tgz#351302e4c68b5abd6a2ed55376a7f9a25be3057a"
@@ -12381,6 +12426,11 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
+streamsearch@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+  integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -12913,7 +12963,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.15, type-is@~1.6.16:
+type-is@^1.6.4, type-is@~1.6.15, type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
   integrity sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==


### PR DESCRIPTION
### Purpose

The composer expects an `/ajax/buffermetrics` endpoint to post tracking to. This doesn't exist on the publish server so it throws 404 errors in the console and we're losing out on any tracking from the composer.

![image](https://user-images.githubusercontent.com/809093/51060155-86fb9d00-15a3-11e9-8e05-9df357b86b17.png)

This PR adds this endpoint our server and properly sends this data along to buffermetrics.

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
