### PR TITLE
[Hotfix] Temporarily pause tracking for composer

### DIFF
--- a/packages/server/lib/composerAjaxBuffermetrics.js
+++ b/packages/server/lib/composerAjaxBuffermetrics.js
@@ -1,25 +1,31 @@
 module.exports = (req, res) => {
-  const { values } = req.body;
-
-  values.forEach((event) => {
-    const scopes = event.value;
-    const metadata = event.extra_data;
-    const indexOfMc = scopes.indexOf('multiple-composers');
-
-    if (indexOfMc) {
-      // We can only send one action with our new metrics
-      // so we'll concat anything after the mc part
-      let action = scopes.splice(indexOfMc + 1);
-      action = action.join('-');
-
-      req.buffermetrics.trackAction({
-        application: 'publish',
-        location: 'composer',
-        action,
-        metadata,
-      });
-    }
-  });
-
+  /**
+   * Sending success for now until we fix issues with the
+   * tracking code below.
+   */
   res.send('success');
+
+  // const { values } = req.body;
+
+  // values.forEach((event) => {
+  //   const scopes = event.value;
+  //   const metadata = event.extra_data;
+  //   const indexOfMc = scopes.indexOf('multiple-composers');
+
+  //   if (indexOfMc) {
+  //     // We can only send one action with our new metrics
+  //     // so we'll concat anything after the mc part
+  //     let action = scopes.splice(indexOfMc + 1);
+  //     action = action.join('-');
+
+  //     req.buffermetrics.trackAction({
+  //       application: 'publish',
+  //       location: 'composer',
+  //       action,
+  //       metadata,
+  //     });
+  //   }
+  // });
+
+  // res.send('success');
 };


### PR DESCRIPTION
### Purpose

Based on chat and Zoom with @michael-erasmus I'm going to pause the composer tracking for now until we can fix some of the issues.

### Notes

Issues appear to be:

* The `action` is coming through as null in the pipelie
* The user id is not getting sent

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
