### PR TITLE
[PUB-1027] Clearing default scheduled time when sharing a post again (re-buffer).

### DIFF
--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -199,13 +199,17 @@ export default (state = initialState, action) => {
 };
 
 export const actions = {
-  handleShareAgainClick: ({ post, profileId }) => ({
-    type: actionTypes.OPEN_COMPOSER,
-    updateId: post.id,
-    editMode: false,
-    post,
-    profileId,
-  }),
+  handleShareAgainClick: ({ post, profileId }) => {
+    post.scheduled_at = null;
+    post.due_at = null;
+    return {
+      type: actionTypes.OPEN_COMPOSER,
+      updateId: post.id,
+      editMode: false,
+      post,
+      profileId,
+    };
+  },
   handleComposerCreateSuccess: () => ({
     type: actionTypes.HIDE_COMPOSER,
   }),

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -200,13 +200,15 @@ export default (state = initialState, action) => {
 
 export const actions = {
   handleShareAgainClick: ({ post, profileId }) => {
-    post.scheduled_at = null;
-    post.due_at = null;
     return {
       type: actionTypes.OPEN_COMPOSER,
       updateId: post.id,
       editMode: false,
-      post,
+      post: {
+        ...post,
+        scheduled_at: null,
+        due_at: null,
+      },
       profileId,
     };
   },


### PR DESCRIPTION
### Purpose
Clearing default scheduled date and time when sharing a post again (re-buffer), because currently it marks as is set in a past date.
