### PR TITLE
Fix IG modal flashing wrong content

### DIFF
--- a/packages/queue/reducer.js
+++ b/packages/queue/reducer.js
@@ -190,6 +190,12 @@ const handlePostDropped = (posts, action) => {
 
   return newPostsMap;
 };
+const handleInstagramLoading = (action) => {
+  if (action.args.recheck && action.result.is_business) {
+    return true;
+  }
+  return false;
+};
 
 /**
  * handlePostsReordered()
@@ -467,7 +473,7 @@ export default (state = initialState, action) => {
       return {
         ...state,
         isBusinessOnInstagram: action.result.is_business,
-        isInstagramLoading: false,
+        isInstagramLoading: handleInstagramLoading(action),
       };
     case `checkInstagramBusiness_${dataFetchActionTypes.FETCH_FAIL}`:
       return {
@@ -475,6 +481,7 @@ export default (state = initialState, action) => {
         isBusinessOnInstagram: false,
         isInstagramLoading: false,
       };
+
     case actionTypes.OPEN_COMPOSER:
       return {
         ...state,


### PR DESCRIPTION
### Purpose
When the user does not have a IG Business Profile but converts to it with the modal opened, this fix prevents to render content after the request is successful, 1s before redirecting the user.