### PR TITLE
Move /health-check before the validateSessionMiddleware

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -171,6 +171,8 @@ app.post('/ajax/buffermetrics',
   composerAjaxBuffemetrics,
 );
 
+app.get('/health-check', controller.healthCheck);
+
 // make sure we have a valid session
 app.use(
   validateSessionMiddleware({
@@ -178,8 +180,6 @@ app.use(
     requiredSessionKeys: ['publish.accessToken', 'global.userId'],
   }),
 );
-
-app.get('/health-check', controller.healthCheck);
 
 // Pusher Auth
 app.post(


### PR DESCRIPTION
### Purpose

There is a fair amount of unnecessary requests to the `buffer-login` services generated from the publish `health-check` route.

This route was registered after the `validateSessionMiddleware` which redirects to `login.buffer.com` if the session is not valid, which is always the case for the healthcheck.
