### PR TITLE
Add new error key for connection error messages

### DIFF
--- a/packages/notifications-provider/utils/notifications.json
+++ b/packages/notifications-provider/utils/notifications.json
@@ -7,6 +7,7 @@
   },
   "error": {
     "bitly-connect": "{{__variable__}}",
-    "bitly-disconnect": "{{__variable__}}"
+    "bitly-disconnect": "{{__variable__}}",
+    "connection": "{{__variable__}}"
   }
 }


### PR DESCRIPTION
### Purpose
This should cover all the connection error messages passed from buffer-web.

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
