### PR TITLE
Receive post error as an object with link from api

### DIFF
--- a/packages/pusher-sync/package.json
+++ b/packages/pusher-sync/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@bufferapp/publish-profile-sidebar": "2.0.0",
     "@bufferapp/publish-queue": "2.0.0",
-    "@bufferapp/publish-parsers": "1.12.0",
+    "@bufferapp/publish-parsers": "1.12.2",
     "pusher-js": "4.1.0"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,7 +13,7 @@
     "@bufferapp/logger": "0.7.0",
     "@bufferapp/micro-rpc": "0.1.7",
     "@bufferapp/publish-formatters": "1.9.29",
-    "@bufferapp/publish-parsers": "1.12.0",
+    "@bufferapp/publish-parsers": "1.12.2",
     "@bufferapp/session-manager": "0.7.1",
     "@bufferapp/shutdown-helper": "0.2.0",
     "@bugsnag/js": "^5.0.1",

--- a/packages/server/rpc/sharePostNow/index.js
+++ b/packages/server/rpc/sharePostNow/index.js
@@ -1,4 +1,4 @@
-const { method } = require('@bufferapp/buffer-rpc');
+const { method, createError } = require('@bufferapp/buffer-rpc');
 const rp = require('request-promise');
 
 module.exports = method(
@@ -18,7 +18,9 @@ module.exports = method(
     } catch (err) {
       if (err.error) {
         const { message } = JSON.parse(err.error);
-        throw new Error(message);
+        throw createError({
+          message: message.text,
+        });
       }
       throw err;
     }

--- a/packages/server/rpc/sharePostNow/index.js
+++ b/packages/server/rpc/sharePostNow/index.js
@@ -1,6 +1,11 @@
 const { method, createError } = require('@bufferapp/buffer-rpc');
 const rp = require('request-promise');
 
+const getMessage = (message) => {
+  const isObject = typeof message === 'object' && message !== null;
+  return isObject ? message.text : message;
+};
+
 module.exports = method(
   'sharePostNow',
   'share post now',
@@ -19,7 +24,7 @@ module.exports = method(
       if (err.error) {
         const { message } = JSON.parse(err.error);
         throw createError({
-          message: message.text,
+          message: getMessage(message),
         });
       }
       throw err;

--- a/packages/shared-components/Post/index.jsx
+++ b/packages/shared-components/Post/index.jsx
@@ -149,10 +149,11 @@ const Post = ({
         draggingPlaceholder={dragging && !fixed}
         noBorder={dragging && fixed}
       >
-        {postDetails.error && postDetails.error.length > 0 &&
+        {postDetails && postDetails.error && postDetails.error.length > 0 &&
           <PostErrorBanner
             dragging={dragging}
             error={postDetails.error}
+            errorLink={postDetails.errorLink}
           />
         }
         {renderContent({

--- a/packages/shared-components/PostErrorBanner/index.jsx
+++ b/packages/shared-components/PostErrorBanner/index.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Text } from '@bufferapp/components';
+import { Text, Link } from '@bufferapp/components';
 import { white } from '@bufferapp/components/style/color';
 
-const errorBannerWrapper = dragging => ({
+const errorWrapperStyle = dragging => ({
   backgroundColor: '#E0364F', // get color name from new design system when rolled out
   padding: '8px 16px',
   color: white,
@@ -16,29 +16,61 @@ const errorBannerWrapper = dragging => ({
   opacity: dragging ? 0 : 1,
 });
 
-const createMarkup = error => (
-  { __html: error }
+const errorMessageStyle = link => ({
+  marginRight: link ? '24px' : 'auto',
+});
+
+const errorButtonStyle = {
+  whiteSpace: 'nowrap',
+  backgroundColor: '#9D2637',
+  padding: '0 8px',
+  height: '32px',
+  display: 'flex',
+  alignItems: 'center',
+  borderRadius: '4px',
+  marginLeft: 'auto',
+  cursor: 'pointer',
+};
+
+// using new design system styles, replace btn when system gets rolled out
+const renderButton = link => (
+  <div style={errorButtonStyle}>
+    <Link
+      newTab
+      unstyled
+      href={link}
+    >
+      <Text
+        size={'mini'}
+        weight={'medium'}
+        color={'white'}
+      >
+        Learn More
+      </Text>
+    </Link>
+  </div>
 );
 
-// Need to add <a> style because can't directly get to <a> in error html string
-const PostErrorBanner = ({ dragging, error }) => (
-  <div id="errorBanner" style={errorBannerWrapper(dragging)}>
-    <style>{`
-      #errorBanner a { color: ${white}; }
-    `}
-    </style>
-    <Text
-      size={'mini'}
-      weight={'medium'}
-      color={'white'}
-    >
-      <div dangerouslySetInnerHTML={createMarkup(error)} />
-    </Text>
+const PostErrorBanner = ({ dragging, error, errorLink }) => (
+  <div style={errorWrapperStyle(dragging)}>
+    <div style={errorMessageStyle(errorLink)}>
+      <Text
+        size={'mini'}
+        weight={'medium'}
+        color={'white'}
+      >
+        { error.message }
+      </Text>
+    </div>
+    {errorLink &&
+      renderButton(errorLink)
+    }
   </div>
 );
 
 PostErrorBanner.propTypes = {
   error: PropTypes.string,
+  errorLink: PropTypes.string,
   dragging: PropTypes.bool,
 };
 

--- a/packages/shared-components/PostErrorBanner/index.jsx
+++ b/packages/shared-components/PostErrorBanner/index.jsx
@@ -59,7 +59,7 @@ const PostErrorBanner = ({ dragging, error, errorLink }) => (
         weight={'medium'}
         color={'white'}
       >
-        { error.message }
+        { error }
       </Text>
     </div>
     {errorLink &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -506,10 +506,10 @@
     moment "2.19.3"
     moment-timezone "0.5.13"
 
-"@bufferapp/publish-parsers@1.12.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/@bufferapp/publish-parsers/-/publish-parsers-1.12.0.tgz#24739a369e920cc34f77f988916ffacfa39ec9b2"
-  integrity sha512-cDNlw7Pv9QDRu/xZm+yAgJKYxdBCIZNC8y0VDGYmi5XqUTB+AGJ22m6+uFGjvI8RqZzvPFroNXM/V/7T06uUig==
+"@bufferapp/publish-parsers@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@bufferapp/publish-parsers/-/publish-parsers-1.12.2.tgz#f8ffdcd4919f2e21f94bf6d2ede2f0cc11a59f85"
+  integrity sha512-lQYUmylC3se0Iy6i8HCoJyQiNT4Ow9pARbl06yxEdk+ZuDWHG5n+xtYpWFboHcxw6I4iXUr8znwO20fxssJEUg==
   dependencies:
     "@bufferapp/publish-formatters" "1.9.29"
     twitter-text "3.0.0"


### PR DESCRIPTION
### Purpose
To allow links to be separate from error messages, the post errors are getting sent from api as an object with text and link fields. This way, messages with links will not show up in the top right notification and the link will be used as a Learn More button in the queue card. 
### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
