### PR TITLE
[PUB-1115] Allow a user to drag and reorder their sidebar profiles

### DIFF
--- a/packages/profile-sidebar/components/ProfileDragWrapper/index.jsx
+++ b/packages/profile-sidebar/components/ProfileDragWrapper/index.jsx
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import flow from 'lodash.flow';
+import { DragSource, DropTarget, DropTargetConnector } from 'react-dnd';
+import ProfileListItem from '../ProfileListItem';
+
+const profileSource = {
+  beginDrag(props, monitor, component) {
+    return {
+      id: props.id,
+      index: props.index,
+      width: component.containerNode.offsetWidth,
+    };
+  },
+};
+
+const profileTarget = {
+  drop(props, monitor, component) {
+    component.decoratedComponentInstance.containerNode.blur();
+    props.onDropProfile({ commit: true });
+  },
+  hover(props, monitor, component) {
+    const { index: dragIndex } = monitor.getItem();
+    const { index: hoverIndex, onDropProfile } = props;
+
+    // Don't replace profile with itself...
+    if (dragIndex === hoverIndex) {
+      return;
+    }
+
+    // Determine rectangle on screen
+    const node = component.decoratedComponentInstance.containerNode;
+    const hoverBoundingRect = node.getBoundingClientRect();
+
+    // Get vertical middle
+    const hoverThird = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 3;
+
+    // Determine mouse position
+    const clientOffset = monitor.getClientOffset();
+
+    // Get pixels to the top
+    const hoverClientY = clientOffset.y - hoverBoundingRect.top;
+
+    // Only perform the move when the mouse has crossed half of the items height
+    // When dragging downwards, only move when the cursor is below 50%
+    // When dragging upwards, only move when the cursor is above 50%
+
+    // Dragging downwards
+    if (dragIndex < hoverIndex && hoverClientY < hoverThird) {
+      return;
+    }
+
+    // Dragging upwards
+    if (dragIndex > hoverIndex && hoverClientY > hoverThird) {
+      return;
+    }
+
+    // Drop!
+    onDropProfile({ dragIndex, hoverIndex });
+
+    // We need to directly mutate the monitor state here
+    // to ensure the currently dragged item index is updated.
+    monitor.getItem().index = hoverIndex;
+  },
+};
+
+class ProfileDragWrapper extends Component {
+
+  render() {
+    const {
+      isDragging,
+      connectDragSource,
+      connectDropTarget,
+    } = this.props;
+    const profileProps = this.props;
+
+    return connectDragSource(
+      connectDropTarget(
+        <div
+          aria-dropeffect="move"
+          ref={(node) => { this.containerNode = node; }}
+          draggable
+          tabIndex={0}
+        >
+          <ProfileListItem
+            {...profileProps}
+          />
+        </div>,
+      ),
+    );
+  }
+}
+
+ProfileDragWrapper.propTypes = {
+  connectDragSource: PropTypes.func.isRequired,
+  connectDropTarget: PropTypes.func.isRequired,
+  id: PropTypes.string.isRequired, // eslint-disable-line
+  isDragging: PropTypes.bool.isRequired,
+};
+
+export default flow(
+  DragSource('profile', profileSource, (connect: DropTargetConnector, monitor) => ({
+    connectDragSource: connect.dragSource(),
+    isDragging: monitor.isDragging(),
+  })),
+  DropTarget('profile', profileTarget, connect => ({
+    connectDropTarget: connect.dropTarget(),
+  })),
+)(ProfileDragWrapper);

--- a/packages/profile-sidebar/components/ProfileDragWrapper/index.jsx
+++ b/packages/profile-sidebar/components/ProfileDragWrapper/index.jsx
@@ -69,7 +69,6 @@ class ProfileDragWrapper extends Component {
 
   render() {
     const {
-      isDragging,
       connectDragSource,
       connectDropTarget,
     } = this.props;
@@ -96,13 +95,11 @@ ProfileDragWrapper.propTypes = {
   connectDragSource: PropTypes.func.isRequired,
   connectDropTarget: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired, // eslint-disable-line
-  isDragging: PropTypes.bool.isRequired,
 };
 
 export default flow(
-  DragSource('profile', profileSource, (connect: DropTargetConnector, monitor) => ({
+  DragSource('profile', profileSource, (connect: DropTargetConnector) => ({
     connectDragSource: connect.dragSource(),
-    isDragging: monitor.isDragging(),
   })),
   DropTarget('profile', profileTarget, connect => ({
     connectDropTarget: connect.dropTarget(),

--- a/packages/profile-sidebar/components/ProfileDragWrapper/index.jsx
+++ b/packages/profile-sidebar/components/ProfileDragWrapper/index.jsx
@@ -34,7 +34,7 @@ const profileTarget = {
     const hoverBoundingRect = node.getBoundingClientRect();
 
     // Get vertical middle
-    const hoverThird = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 3;
+    const hoverThird = (hoverBoundingRect.bottom - hoverBoundingRect.top);
 
     // Determine mouse position
     const clientOffset = monitor.getClientOffset();

--- a/packages/profile-sidebar/components/ProfileDragWrapper/index.jsx
+++ b/packages/profile-sidebar/components/ProfileDragWrapper/index.jsx
@@ -22,7 +22,7 @@ const profileTarget = {
   },
   hover(props, monitor, component) {
     const { index: dragIndex } = monitor.getItem();
-    const { index: hoverIndex, onDropProfile } = props;
+    const { index: hoverIndex, onDropProfile, profileLimit } = props;
 
     // Don't replace profile with itself...
     if (dragIndex === hoverIndex) {
@@ -57,7 +57,7 @@ const profileTarget = {
     }
 
     // Drop!
-    onDropProfile({ dragIndex, hoverIndex });
+    onDropProfile({ dragIndex, hoverIndex, profileLimit });
 
     // We need to directly mutate the monitor state here
     // to ensure the currently dragged item index is updated.

--- a/packages/profile-sidebar/components/ProfileList/index.jsx
+++ b/packages/profile-sidebar/components/ProfileList/index.jsx
@@ -4,16 +4,18 @@ import {
   List,
 } from '@bufferapp/components';
 import ProfileListItem from '../ProfileListItem';
+import ProfileDragWrapper from '../ProfileDragWrapper';
 
 const ProfileList = ({
   profiles,
   selectedProfileId,
   onProfileClick,
+  onDropProfile,
   showProfilesDisconnectedModal,
-}) =>
+}) => (
   <List
-    items={profiles.map(profile =>
-      <ProfileListItem
+    items={profiles.map((profile, index) =>
+      <ProfileDragWrapper
         avatarUrl={profile.avatarUrl}
         type={profile.type}
         handle={profile.handle}
@@ -22,13 +24,18 @@ const ProfileList = ({
         locked={profile.disabled}
         disconnected={profile.isDisconnected}
         onClick={() => onProfileClick(profile)}
+        onDropProfile={onDropProfile}
         showProfilesDisconnectedModal={showProfilesDisconnectedModal}
+        id={profile.id}
+        index={index}
       />,
     )}
-  />;
+  />
+);
 
 ProfileList.propTypes = {
   onProfileClick: PropTypes.func.isRequired,
+  onDropProfile: PropTypes.func.isRequired,
   profiles: PropTypes.arrayOf(
     PropTypes.shape(ProfileListItem.propTypes),
   ),

--- a/packages/profile-sidebar/components/ProfileList/index.jsx
+++ b/packages/profile-sidebar/components/ProfileList/index.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   List,
+  Divider,
 } from '@bufferapp/components';
 import ProfileListItem from '../ProfileListItem';
 import ProfileDragWrapper from '../ProfileDragWrapper';
+import ProfileLockedHeader from '../ProfileLockedHeader';
 
 const ProfileList = ({
   profiles,
@@ -12,26 +14,43 @@ const ProfileList = ({
   onProfileClick,
   onDropProfile,
   showProfilesDisconnectedModal,
-}) => (
-  <List
-    items={profiles.map((profile, index) =>
-      <ProfileDragWrapper
-        avatarUrl={profile.avatarUrl}
-        type={profile.type}
-        handle={profile.handle}
-        notifications={profile.pendingCount}
-        selected={profile.id === selectedProfileId}
-        locked={profile.disabled}
-        disconnected={profile.isDisconnected}
-        onClick={() => onProfileClick(profile)}
-        onDropProfile={onDropProfile}
-        showProfilesDisconnectedModal={showProfilesDisconnectedModal}
-        id={profile.id}
-        index={index}
-      />,
-    )}
-  />
-);
+  profileLimit,
+  translations,
+}) => {
+  const lockedProfiles = profiles.length > profileLimit;
+  return (
+    <List
+      items={profiles.map((profile, index) =>
+        <div>
+          {lockedProfiles && (index === profileLimit) &&
+            <div>
+              <ProfileLockedHeader
+                translations={translations}
+                profileLimit={profileLimit}
+              />
+              <Divider />
+            </div>
+          }
+          <ProfileDragWrapper
+            avatarUrl={profile.avatarUrl}
+            type={profile.type}
+            handle={profile.handle}
+            notifications={profile.pendingCount}
+            selected={profile.id === selectedProfileId}
+            locked={profile.disabled}
+            disconnected={profile.isDisconnected}
+            onClick={() => onProfileClick(profile)}
+            profileLimit={profileLimit}
+            onDropProfile={onDropProfile}
+            showProfilesDisconnectedModal={showProfilesDisconnectedModal}
+            id={profile.id}
+            index={index}
+          />
+        </div>,
+      )}
+    />
+  );
+};
 
 ProfileList.propTypes = {
   onProfileClick: PropTypes.func.isRequired,
@@ -41,6 +60,12 @@ ProfileList.propTypes = {
   ),
   selectedProfileId: PropTypes.string,
   showProfilesDisconnectedModal: PropTypes.func.isRequired,
+  profileLimit: PropTypes.number.isRequired,
+  translations: PropTypes.shape({
+    connectButton: PropTypes.string,
+    lockedList: PropTypes.string,
+    lockedListTooltip: PropTypes.string,
+  }).isRequired,
 };
 
 ProfileList.defaultProps = {

--- a/packages/profile-sidebar/components/ProfileList/story.jsx
+++ b/packages/profile-sidebar/components/ProfileList/story.jsx
@@ -1,12 +1,26 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { checkA11y } from 'storybook-addon-a11y';
+import TestBackend from 'react-dnd-test-backend';
+import { DragDropContext } from 'react-dnd';
 import ProfileList from './index';
 import profiles from '../../mockData/profiles';
+/* eslint-disable react/prop-types */
+class _TestContextContainer extends Component { // eslint-disable-line
+  render() {
+    return (
+      <div>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+const TestContextContainer = DragDropContext(TestBackend)(_TestContextContainer);
 
 storiesOf('ProfileList', module)
   .addDecorator(checkA11y)
+  .addDecorator(getStory => <TestContextContainer>{getStory()}</TestContextContainer>)
   .add('should display a list of profiles', () => (
     <ProfileList
       profiles={profiles}

--- a/packages/profile-sidebar/components/ProfileListItem/index.jsx
+++ b/packages/profile-sidebar/components/ProfileListItem/index.jsx
@@ -71,57 +71,55 @@ const ProfileListItem = ({
   };
 
   return (
-    <div>
-      <Link
-        href={'#'}
-        onClick={e => {
-          e.preventDefault();
-          handleClick();
-        }}
-        unstyled
+    <Link
+      href={'#'}
+      onClick={e => {
+        e.preventDefault();
+        handleClick();
+      }}
+      unstyled
+    >
+      <div
+        style={calculateStyles(
+          {
+            default: {
+              display: 'flex',
+              alignItems: 'center',
+              padding: '0.5rem',
+              justifyContent: 'space-between',
+              lineHeight: 1,
+            },
+            selected: {
+              background: curiousBlueUltraLight,
+              borderRadius: '4px',
+            },
+          },
+          {
+            selected,
+          },
+        )}
       >
-        <div
-          style={calculateStyles(
-            {
-              default: {
-                display: 'flex',
-                alignItems: 'center',
-                padding: '0.5rem',
-                justifyContent: 'space-between',
-                lineHeight: 1,
-              },
-              selected: {
-                background: curiousBlueUltraLight,
-                borderRadius: '4px',
-              },
-            },
-            {
-              selected,
-            },
-          )}
-        >
-          <div style={profileBadgeWrapperStyle}>
-            <div style={{ marginRight: '16px' }}>
-              <ProfileBadge avatarUrl={avatarUrl} type={type} />
-            </div>
-            <SensitiveData>
-              <Text size={'small'} color={selected ? 'black' : 'shuttleGray'}>
-                {handle}
-              </Text>
-            </SensitiveData>
+        <div style={profileBadgeWrapperStyle}>
+          <div style={{ marginRight: '16px' }}>
+            <ProfileBadge avatarUrl={avatarUrl} type={type} />
           </div>
-          {locked ? (
-            <LockIcon />
-          ) : disconnected ? (
-            <NewDisconnectedIcon
-              showProfilesDisconnectedModal={showProfilesDisconnectedModal}
-            />
-          ) : (
-            <Notifications notifications={notifications} />
-          )}
+          <SensitiveData>
+            <Text size={'small'} color={selected ? 'black' : 'shuttleGray'}>
+              {handle}
+            </Text>
+          </SensitiveData>
         </div>
-      </Link>
-    </div>
+        {locked ? (
+          <LockIcon />
+        ) : disconnected ? (
+          <NewDisconnectedIcon
+            showProfilesDisconnectedModal={showProfilesDisconnectedModal}
+          />
+        ) : (
+          <Notifications notifications={notifications} />
+        )}
+      </div>
+    </Link>
   );
 };
 

--- a/packages/profile-sidebar/components/ProfileListItem/index.jsx
+++ b/packages/profile-sidebar/components/ProfileListItem/index.jsx
@@ -69,56 +69,59 @@ const ProfileListItem = ({
     const queueTab = document.querySelector('#tabs a');
     if (queueTab) queueTab.focus();
   };
+
   return (
-    <Link
-      href={'#'}
-      onClick={e => {
-        e.preventDefault();
-        handleClick();
-      }}
-      unstyled
-    >
-      <div
-        style={calculateStyles(
-          {
-            default: {
-              display: 'flex',
-              alignItems: 'center',
-              padding: '0.5rem',
-              justifyContent: 'space-between',
-              lineHeight: 1,
-            },
-            selected: {
-              background: curiousBlueUltraLight,
-              borderRadius: '4px',
-            },
-          },
-          {
-            selected,
-          },
-        )}
+    <div>
+      <Link
+        href={'#'}
+        onClick={e => {
+          e.preventDefault();
+          handleClick();
+        }}
+        unstyled
       >
-        <div style={profileBadgeWrapperStyle}>
-          <div style={{ marginRight: '16px' }}>
-            <ProfileBadge avatarUrl={avatarUrl} type={type} />
+        <div
+          style={calculateStyles(
+            {
+              default: {
+                display: 'flex',
+                alignItems: 'center',
+                padding: '0.5rem',
+                justifyContent: 'space-between',
+                lineHeight: 1,
+              },
+              selected: {
+                background: curiousBlueUltraLight,
+                borderRadius: '4px',
+              },
+            },
+            {
+              selected,
+            },
+          )}
+        >
+          <div style={profileBadgeWrapperStyle}>
+            <div style={{ marginRight: '16px' }}>
+              <ProfileBadge avatarUrl={avatarUrl} type={type} />
+            </div>
+            <SensitiveData>
+              <Text size={'small'} color={selected ? 'black' : 'shuttleGray'}>
+                {handle}
+              </Text>
+            </SensitiveData>
           </div>
-          <SensitiveData>
-            <Text size={'small'} color={selected ? 'black' : 'shuttleGray'}>
-              {handle}
-            </Text>
-          </SensitiveData>
+          {locked ? (
+            <LockIcon />
+          ) : disconnected ? (
+            <NewDisconnectedIcon
+              showProfilesDisconnectedModal={showProfilesDisconnectedModal}
+            />
+          ) : (
+            <Notifications notifications={notifications} />
+          )}
         </div>
-        {locked ? (
-          <LockIcon />
-        ) : disconnected ? (
-          <NewDisconnectedIcon
-            showProfilesDisconnectedModal={showProfilesDisconnectedModal}
-          />
-        ) : (
-          <Notifications notifications={notifications} />
-        )}
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 };
 

--- a/packages/profile-sidebar/components/ProfileLockedHeader/index.jsx
+++ b/packages/profile-sidebar/components/ProfileLockedHeader/index.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Text, QuestionIcon, IconArrowPopover } from '@bufferapp/components';
+
+const lockedAccountHeaderStyle = {
+  margin: '1rem 0 0.5rem 0',
+  display: 'flex',
+  alignItems: 'center',
+  flexDirection: 'row',
+};
+
+const ProfileLockedHeader = ({ translations, profileLimit }) => (
+  <div style={lockedAccountHeaderStyle}>
+    <Text size={'small'}>{translations.lockedList}</Text>
+    <div style={{ position: 'absolute', marginLeft: '13rem' }}>
+      <IconArrowPopover
+        icon={<QuestionIcon />}
+        position="above"
+        shadow
+        oneLine={false}
+        width="320px"
+        label={translations.lockedList}
+      >
+        <div style={{ padding: '.5rem .25rem' }}>
+          {translations.lockedListTooltip1 +
+            profileLimit +
+            translations.lockedListTooltip2}
+        </div>
+      </IconArrowPopover>
+    </div>
+  </div>
+);
+
+ProfileLockedHeader.propTypes = {
+  translations: PropTypes.shape({
+    connectButton: PropTypes.string,
+    lockedList: PropTypes.string,
+    lockedListTooltip: PropTypes.string,
+  }).isRequired,
+  profileLimit: PropTypes.number.isRequired,
+};
+
+export default ProfileLockedHeader;

--- a/packages/profile-sidebar/components/ProfileLockedHeader/story.jsx
+++ b/packages/profile-sidebar/components/ProfileLockedHeader/story.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { checkA11y } from 'storybook-addon-a11y';
+import ProfileLockedHeader from './index';
+
+const translations = {
+  lockedList: 'Locked Social Accounts',
+  lockedListTooltip1: 'Sorry, your current plan lets you access 3 accounts',
+  lockedListTooltip2: `social accounts at the same time (and any business accounts you’re a
+    team member on as long as the owner is on a Business Plan). We’ll keep these other ones
+    safe and sound until you’re ready to upgrade!`,
+};
+
+storiesOf('ProfileLockedHeader', module)
+  .addDecorator(checkA11y)
+  .add('default', () => (
+    <ProfileLockedHeader
+      profileLimit={3}
+      translations={translations}
+    />
+  ));

--- a/packages/profile-sidebar/components/ProfileSidebar/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/index.jsx
@@ -40,8 +40,6 @@ const buttonDividerStyle = {
 
 };
 
-const DefaultFallbackType = <Text size={'large'}>Free</Text>;
-
 const productTitle = (
   <div>
     <span style={productTitleStyle}>

--- a/packages/profile-sidebar/components/ProfileSidebar/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/index.jsx
@@ -4,8 +4,6 @@ import {
   Text,
   Button,
   Divider,
-  QuestionIcon,
-  IconArrowPopover,
 } from '@bufferapp/components';
 import FeatureLoader from '@bufferapp/product-features';
 import { offWhite, mystic } from '@bufferapp/components/style/color';
@@ -36,38 +34,9 @@ const profileListStyle = {
   overflowY: 'scroll',
 };
 
-const lockedAccountHeaderStyle = {
-  margin: '1rem 0 0.5rem 0',
-  display: 'flex',
-  alignItems: 'center',
-  flexDirection: 'row',
-};
-
 const buttonDividerStyle = {
   marginBottom: '1rem',
 };
-
-const renderLockedHeader = ({ translations, profileLimit }) => (
-  <div style={lockedAccountHeaderStyle}>
-    <Text size={'small'}>{translations.lockedList}</Text>
-    <div style={{ position: 'absolute', marginLeft: '13rem' }}>
-      <IconArrowPopover
-        icon={<QuestionIcon />}
-        position="above"
-        shadow
-        oneLine={false}
-        width="320px"
-        label={translations.lockedList}
-      >
-        <div style={{ padding: '.5rem .25rem' }}>
-          {translations.lockedListTooltip1 +
-            profileLimit +
-            translations.lockedListTooltip2}
-        </div>
-      </IconArrowPopover>
-    </div>
-  </div>
-);
 
 const DefaultFallbackType = <Text size={'large'}>Free</Text>;
 
@@ -99,7 +68,6 @@ const ProfileSidebar = ({
   loading,
   selectedProfileId,
   profiles,
-  lockedProfiles,
   translations,
   onProfileClick,
   onDropProfile,
@@ -117,16 +85,8 @@ const ProfileSidebar = ({
         onProfileClick={onProfileClick}
         onDropProfile={onDropProfile}
         showProfilesDisconnectedModal={showProfilesDisconnectedModal}
-      />
-      {lockedProfiles.length > 0 &&
-        renderLockedHeader({ translations, profileLimit })}
-      {lockedProfiles.length > 0 && <Divider />}
-      <ProfileList
-        selectedProfileId={selectedProfileId}
-        profiles={lockedProfiles}
-        onProfileClick={onProfileClick}
-        onDropProfile={onDropProfile}
-        showProfilesDisconnectedModal={showProfilesDisconnectedModal}
+        profileLimit={profileLimit}
+        translations={translations}
       />
     </div>
     <div>
@@ -152,12 +112,7 @@ ProfileSidebar.propTypes = {
   onConnectSocialAccountClick: PropTypes.func.isRequired,
   selectedProfileId: ProfileList.propTypes.selectedProfileId,
   profiles: PropTypes.arrayOf(PropTypes.shape(ProfileListItem.propTypes)),
-  lockedProfiles: PropTypes.arrayOf(PropTypes.shape(ProfileListItem.propTypes)),
-  translations: PropTypes.shape({
-    connectButton: PropTypes.string,
-    lockedList: PropTypes.string,
-    lockedListTooltip: PropTypes.string,
-  }).isRequired,
+  translations: ProfileList.propTypes.translations,
   profileLimit: PropTypes.number,
   onDropProfile: PropTypes.func,
   showProfilesDisconnectedModal: PropTypes.func.isRequired,

--- a/packages/profile-sidebar/components/ProfileSidebar/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/index.jsx
@@ -122,7 +122,6 @@ ProfileSidebar.defaultProps = {
   onProfileClick: ProfileList.defaultProps.onProfileClick,
   selectedProfileId: ProfileList.defaultProps.selectedProfileId,
   profiles: [],
-  lockedProfiles: [],
 };
 
 export default ProfileSidebar;

--- a/packages/profile-sidebar/components/ProfileSidebar/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/index.jsx
@@ -102,6 +102,7 @@ const ProfileSidebar = ({
   lockedProfiles,
   translations,
   onProfileClick,
+  onDropProfile,
   onConnectSocialAccountClick,
   profileLimit,
   showProfilesDisconnectedModal,
@@ -114,6 +115,7 @@ const ProfileSidebar = ({
         selectedProfileId={selectedProfileId}
         profiles={profiles}
         onProfileClick={onProfileClick}
+        onDropProfile={onDropProfile}
         showProfilesDisconnectedModal={showProfilesDisconnectedModal}
       />
       {lockedProfiles.length > 0 &&
@@ -123,6 +125,7 @@ const ProfileSidebar = ({
         selectedProfileId={selectedProfileId}
         profiles={lockedProfiles}
         onProfileClick={onProfileClick}
+        onDropProfile={onDropProfile}
         showProfilesDisconnectedModal={showProfilesDisconnectedModal}
       />
     </div>
@@ -156,6 +159,7 @@ ProfileSidebar.propTypes = {
     lockedListTooltip: PropTypes.string,
   }).isRequired,
   profileLimit: PropTypes.number,
+  onDropProfile: PropTypes.func,
   showProfilesDisconnectedModal: PropTypes.func.isRequired,
 };
 

--- a/packages/profile-sidebar/components/ProfileSidebar/story.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/story.jsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
+import TestBackend from 'react-dnd-test-backend';
+import { DragDropContext } from 'react-dnd';
 import createStore from '@bufferapp/publish-store';
 import { action } from '@storybook/addon-actions';
 import { Provider } from 'react-redux';
@@ -19,13 +21,26 @@ const translations = {
   lockedListTooltip2: ' social accounts at the same time (and any business accounts you’re a team member on as long as the owner is on a Business Plan). We’ll keep these other ones safe and sound until you’re ready to upgrade!',
 };
 
+/* eslint-disable react/prop-types */
+class _TestContextContainer extends Component { // eslint-disable-line
+  render() {
+    return (
+      <div>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+const TestContextContainer = DragDropContext(TestBackend)(_TestContextContainer);
+
 storiesOf('ProfileSidebar', module)
   .addDecorator(checkA11y)
   .addDecorator(getStory =>
     <Provider store={store}>
-        {getStory()}
+      {getStory()}
     </Provider>,
   )
+  .addDecorator(getStory => <TestContextContainer>{getStory()}</TestContextContainer>)
   .add('should display a list of profiles', () => (
     <ProfileSidebar
       selectedProfileId={'1234'}

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -36,9 +36,10 @@ export default connect(
         }
       }
     },
-    onDropProfile: ({ commit, dragIndex, hoverIndex }) => {
+    onDropProfile: ({ commit, profileLimit, dragIndex, hoverIndex }) => {
       dispatch(actions.onDropProfile({
         commit,
+        profileLimit,
         dragIndex,
         hoverIndex,
       }));

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -36,6 +36,13 @@ export default connect(
         }
       }
     },
+    onDropProfile: ({ commit, dragIndex, hoverIndex }) => {
+      dispatch(actions.onDropProfile({
+        commit,
+        dragIndex,
+        hoverIndex,
+      }));
+    },
     onConnectSocialAccountClick: () => {
       dispatch(actions.handleConnectSocialAccountClick());
     },

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -13,7 +13,6 @@ export default connect(
     selectedProfile: state.profileSidebar.selectedProfile,
     selectedProfileId: ownProps.profileId,
     profiles: state.profileSidebar.profiles,
-    lockedProfiles: state.profileSidebar.lockedProfiles,
     translations: state.i18n.translations['profile-sidebar'],
     profileLimit: state.appSidebar.user.profile_limit,
   }),

--- a/packages/profile-sidebar/middleware.js
+++ b/packages/profile-sidebar/middleware.js
@@ -114,6 +114,20 @@ export default ({ dispatch, getState }) => next => (action) => {
         }));
       }
       break;
+    case actionTypes.PROFILE_DROPPED: {
+      if (action.commit) {
+        const state = getState();
+        const profiles = state.profileSidebar.profiles;
+        const orderedIds = profiles.map(profile => profile.id);
+        dispatch(dataFetchActions.fetch({
+          name: 'reorderProfiles',
+          args: {
+            order: orderedIds,
+          },
+        }));
+      }
+      break;
+    }
     default:
       break;
   }

--- a/packages/profile-sidebar/middleware.js
+++ b/packages/profile-sidebar/middleware.js
@@ -44,9 +44,8 @@ export default ({ dispatch, getState }) => next => (action) => {
         path,
       });
       const profiles = getState().profileSidebar.profiles;
-      const lockedProfiles = getState().profileSidebar.lockedProfiles;
       if (params && params.profileId) {
-        const profile = [...profiles, ...lockedProfiles].find(p => p.id === params.profileId);
+        const profile = [...profiles].find(p => p.id === params.profileId);
 
         dispatch(actions.selectProfile({
           profile,

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -36,10 +36,17 @@ const moveProfileInArray = (arr, from, to) => {
 };
 
 const handleProfileDropped = (profiles, action) => {
-  const reorderedProfiles = moveProfileInArray(profiles, action.dragIndex, action.hoverIndex);
+  const { profileLimit, hoverIndex, dragIndex } = action;
+  const reorderedProfiles = moveProfileInArray(profiles, dragIndex, hoverIndex);
+  // add profiles after limit as disabled
+  if (reorderedProfiles.length > profileLimit) {
+    reorderedProfiles.map((profile, index) => {
+      profile.disabled = index >= profileLimit;
+      return profile;
+    });
+  }
   return reorderedProfiles;
 };
-
 
 const profilesReducer = (state = [], action) => {
   switch (action.type) {

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -8,6 +8,7 @@ export const actionTypes = keyWrapper('PROFILE_SIDEBAR', {
   PROFILE_PAUSED: 0,
   PUSHER_PROFILE_PAUSED_STATE: 0,
   CONNECT_SOCIAL_ACCOUNT: 0,
+  PROFILE_DROPPED: 0,
 });
 
 const initialState = {
@@ -19,6 +20,26 @@ const initialState = {
   isLockedProfile: false,
   isBusinessAccount: false,
 };
+
+const moveProfileInArray = (arr, from, to) => {
+  const clone = [...arr];
+
+  // Support passing `from` and `to` in non-sequential order (e.g., 4 and 1).
+  const fromIndex = from < to ? from : to;
+  const toIndex = to > from ? to : from;
+
+  // Generate the new array
+  Array.prototype.splice.call(clone, toIndex, 0,
+    Array.prototype.splice.call(clone, fromIndex, 1)[0],
+  );
+  return clone;
+};
+
+const handleProfileDropped = (profiles, action) => {
+  const reorderedProfiles = moveProfileInArray(profiles, action.dragIndex, action.hoverIndex);
+  return reorderedProfiles;
+};
+
 
 const profilesReducer = (state = [], action) => {
   switch (action.type) {
@@ -88,6 +109,15 @@ export default (state = initialState, action) => {
         isLockedProfile: action.profile ? action.profile.disabled : false,
       };
     }
+    case actionTypes.PROFILE_DROPPED: {
+      if (!action.commit) {
+        return {
+          ...state,
+          profiles: handleProfileDropped(state.profiles, action),
+        };
+      }
+      return state;
+    }
     case actionTypes.PROFILE_PAUSED:
     case actionTypes.PROFILE_UNPAUSED:
     case actionTypes.PUSHER_PROFILE_PAUSED_STATE:
@@ -119,5 +149,11 @@ export const actions = {
   }),
   handleConnectSocialAccountClick: () => ({
     type: actionTypes.CONNECT_SOCIAL_ACCOUNT,
+  }),
+  onDropProfile: ({ commit, dragIndex, hoverIndex }) => ({
+    type: actionTypes.PROFILE_DROPPED,
+    commit,
+    dragIndex,
+    hoverIndex,
   }),
 };

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -13,7 +13,6 @@ export const actionTypes = keyWrapper('PROFILE_SIDEBAR', {
 
 const initialState = {
   profiles: [],
-  lockedProfiles: [],
   selectedProfileId: '',
   loading: false,
   selectedProfile: {},
@@ -100,10 +99,7 @@ export default (state = initialState, action) => {
       return {
         ...state,
         loading: false,
-        profiles: action.result
-          .filter(profile => !profile.disabled),
-        lockedProfiles: action.result
-          .filter(profile => profile.disabled),
+        profiles: action.result,
       };
     }
     case actionTypes.SELECT_PROFILE: {
@@ -111,7 +107,6 @@ export default (state = initialState, action) => {
         ...state,
         selectedProfileId: action.profileId,
         profiles: profilesReducer(state.profiles, action),
-        lockedProfiles: profilesReducer(state.lockedProfiles, action),
         selectedProfile: action.profile,
         isLockedProfile: action.profile ? action.profile.disabled : false,
       };
@@ -132,7 +127,6 @@ export default (state = initialState, action) => {
       return {
         ...state,
         profiles: profilesReducer(state.profiles, action),
-        lockedProfiles: profilesReducer(state.lockedProfiles, action),
       };
     }
     default:
@@ -157,10 +151,11 @@ export const actions = {
   handleConnectSocialAccountClick: () => ({
     type: actionTypes.CONNECT_SOCIAL_ACCOUNT,
   }),
-  onDropProfile: ({ commit, dragIndex, hoverIndex }) => ({
+  onDropProfile: ({ commit, dragIndex, hoverIndex, profileLimit }) => ({
     type: actionTypes.PROFILE_DROPPED,
     commit,
     dragIndex,
     hoverIndex,
+    profileLimit,
   }),
 };

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -11,7 +11,7 @@ export const actionTypes = keyWrapper('PROFILE_SIDEBAR', {
   PROFILE_DROPPED: 0,
 });
 
-const initialState = {
+export const initialState = {
   profiles: [],
   selectedProfileId: '',
   loading: false,

--- a/packages/profile-sidebar/reducer.test.js
+++ b/packages/profile-sidebar/reducer.test.js
@@ -1,5 +1,5 @@
 import deepFreeze from 'deep-freeze';
-import reducer, { actions, actionTypes } from './reducer';
+import reducer, { actions, actionTypes, initialState } from './reducer';
 
 import profiles from './mockData/profiles';
 
@@ -29,5 +29,41 @@ describe('reducer', () => {
         profileId: profile.id,
         profile,
       });
+  });
+  it('should generate a profile dropped action', () => {
+    const props = { dragIndex: 1, hoverIndex: 0 };
+    expect(actions.onDropProfile(props))
+      .toEqual({
+        type: actionTypes.PROFILE_DROPPED,
+        dragIndex: props.dragIndex,
+        hoverIndex: props.hoverIndex,
+      });
+  });
+
+  it('should reorder profiles with PROFILE_DROPPED', () => {
+    const dragIndex = 0;
+    const hoverIndex = 1;
+    const stateBefore = {
+      ...initialState,
+      profiles,
+    };
+
+    const profilesAfter = profiles.slice();
+    [profilesAfter[dragIndex], profilesAfter[hoverIndex]] = [profilesAfter[hoverIndex], profilesAfter[dragIndex]];
+
+    const stateAfter = {
+      ...initialState,
+      profiles: profilesAfter,
+    };
+
+    const action = {
+      type: actionTypes.PROFILE_DROPPED,
+      dragIndex,
+      hoverIndex,
+    };
+
+    deepFreeze(action);
+    expect(reducer(stateBefore, action))
+      .toEqual(stateAfter);
   });
 });

--- a/packages/profile-sidebar/reducer.test.js
+++ b/packages/profile-sidebar/reducer.test.js
@@ -7,7 +7,6 @@ describe('reducer', () => {
   it('should initialize default state', () => {
     const stateAfter = {
       profiles: [],
-      lockedProfiles: [],
       loading: false,
       selectedProfileId: '',
       selectedProfile: {},

--- a/packages/profile-sidebar/reducer.test.js
+++ b/packages/profile-sidebar/reducer.test.js
@@ -1,8 +1,8 @@
 import deepFreeze from 'deep-freeze';
-import reducer, { actions, actionTypes, initialState } from './reducer';
-import { actions as queueActions } from '@bufferapp/publish-queue';
 
 import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
+import { actions as queueActions } from '@bufferapp/publish-queue';
+import reducer, { actions, actionTypes, initialState as profileInitialState } from './reducer';
 import profiles from './mockData/profiles';
 
 describe('reducer', () => {
@@ -50,7 +50,7 @@ describe('reducer', () => {
     const dragIndex = 0;
     const hoverIndex = 1;
     const stateBefore = {
-      ...initialState,
+      ...profileInitialState,
       profiles,
     };
 
@@ -58,7 +58,7 @@ describe('reducer', () => {
     [profilesAfter[dragIndex], profilesAfter[hoverIndex]] = [profilesAfter[hoverIndex], profilesAfter[dragIndex]];
 
     const stateAfter = {
-      ...initialState,
+      ...profileInitialState,
       profiles: profilesAfter,
     };
 
@@ -81,22 +81,13 @@ describe('reducer', () => {
     expect(loading).toBe(true);
   });
 
-  it('should load non-locked profiles', () => {
+  it('should load all profiles', () => {
     const action = {
       type: `profiles_${dataFetchActionTypes.FETCH_SUCCESS}`,
       result: profiles,
     };
     const { profiles: profilesInStore } = reducer(undefined, action);
-    expect(profilesInStore).toEqual([profiles[0]]);
-  });
-
-  it('should load locked profiles', () => {
-    const action = {
-      type: `profiles_${dataFetchActionTypes.FETCH_SUCCESS}`,
-      result: profiles,
-    };
-    const { lockedProfiles } = reducer(undefined, action);
-    expect(lockedProfiles).toEqual([profiles[1]]);
+    expect(profilesInStore).toEqual(profiles);
   });
 
   it('should correctly set flags for connected accounts', () => {

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -14,6 +14,7 @@ const updateScheduleMethod = require('./updateSchedule');
 const getTimezonesMethod = require('./getTimezones');
 const updateTimezoneMethod = require('./updateTimezone');
 const reorderPostsMethod = require('./reorderPosts');
+const reorderProfilesMethod = require('./reorderProfiles');
 const pauseQueueMethod = require('./pauseQueue');
 const requeuePost = require('./requeuePost');
 const updatePausedSchedules = require('./updatePausedSchedules');
@@ -65,6 +66,7 @@ module.exports = rpc(
   getTimezonesMethod,
   updateTimezoneMethod,
   reorderPostsMethod,
+  reorderProfilesMethod,
   pauseQueueMethod,
   requeuePost,
   updatePausedSchedules,

--- a/packages/server/rpc/reorderProfiles/index.js
+++ b/packages/server/rpc/reorderProfiles/index.js
@@ -1,0 +1,29 @@
+const { method } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+module.exports = method(
+  'reorderProfiles',
+  'reorder profiles',
+  async ({ profileId, order }, { session }) => {
+    let result;
+    try {
+      result = await rp({
+        uri: `${process.env.API_ADDR}/1/profiles/reorder.json`,
+        method: 'POST',
+        strictSSL: !(process.env.NODE_ENV === 'development'),
+        form: {
+          access_token: session.publish.accessToken,
+          order,
+        },
+      });
+    } catch (err) {
+      if (err.error) {
+        const { message } = JSON.parse(err.error);
+        throw new Error(message);
+      }
+      throw err;
+    }
+    result = JSON.parse(result);
+    return Promise.resolve(result);
+  },
+);

--- a/packages/server/rpc/reorderProfiles/index.js
+++ b/packages/server/rpc/reorderProfiles/index.js
@@ -4,7 +4,7 @@ const rp = require('request-promise');
 module.exports = method(
   'reorderProfiles',
   'reorder profiles',
-  async ({ profileId, order }, { session }) => {
+  async ({ order }, { session }) => {
     let result;
     try {
       result = await rp({


### PR DESCRIPTION
### Purpose
Give the option for users to drag and reorder their sidebar profiles
https://buffer.atlassian.net/browse/PUB-1115
### Notes
Refactored locked and unlocked profiles into one list so that drag and drop would work for all. 
### Review
@hamstu Currently getting a storybook error when running tests for `Could not find the drag and drop manager in the context of DragSource(ProfileDragWrapper)`. Will look more into it. Curious if you ran into this error when you were working on queue drag and drop
#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
