### PR TITLE
Raise the memory limit to avoid pod restarts

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,7 +8,7 @@ image:
 resources:
   limits:
     cpu: 1000m
-    memory: 150Mi
+    memory: 512Mi
   requests:
     cpu: 100m
     memory: 50Mi


### PR DESCRIPTION
### Purpose
This PR should prevent the pod restarts by raising the memory limit

Details: https://buffer.slack.com/archives/C151RRDL1/p1549932022055800

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
