### PR TITLE
Raise the replica count to reduce the impact of application memory leak

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,6 +1,6 @@
 name: buffer-publish # Override to be the name of the application
 track: stable # stable | canary
-replicaCount: 5
+replicaCount: 10
 image:
   repository: bufferapp/buffer-publish # Override with the docker image
   tag: latest # this will be overriden by the build process


### PR DESCRIPTION
### Purpose
Raise the number of pods to 10, so when restart happens in every 2 hours our users wont feel that much of an impact.

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
