### PR TITLE
[PUB-1164] Adding new Past Reminders tab for Instagram profiles

### DIFF
--- a/packages/composer-popover/components/ComposerWrapper/index.jsx
+++ b/packages/composer-popover/components/ComposerWrapper/index.jsx
@@ -36,6 +36,12 @@ export default connect(
             post: state.sent.byProfileId[selectedProfileId].posts[postId],
           };
           break;
+        case 'pastReminders':
+          options = {
+            editMode: state.pastReminders.editMode,
+            post: state.pastReminders.byProfileId[selectedProfileId].posts[postId],
+          };
+          break;
         default:
           return;
       }

--- a/packages/composer-popover/index.js
+++ b/packages/composer-popover/index.js
@@ -27,7 +27,7 @@ ComposerPopover.propTypes = {
   onSave: PropTypes.func.isRequired,
   transparentOverlay: PropTypes.bool,
   preserveComposerStateOnClose: PropTypes.bool,
-  type: PropTypes.oneOf(['queue', 'drafts', 'sent']),
+  type: PropTypes.oneOf(['queue', 'drafts', 'sent', 'pastReminders']),
 };
 
 ComposerPopover.defaultProps = {

--- a/packages/past-reminders/README.md
+++ b/packages/past-reminders/README.md
@@ -1,0 +1,1 @@
+# @bufferapp/publish-past-reminders

--- a/packages/past-reminders/components/PastRemindersList/index.jsx
+++ b/packages/past-reminders/components/PastRemindersList/index.jsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  PostLists,
+  EmptyState,
+  LockedProfileNotification,
+} from '@bufferapp/publish-shared-components';
+import {
+  Divider,
+  Text,
+  LoadingAnimation,
+} from '@bufferapp/components';
+import ComposerPopover from '@bufferapp/publish-composer-popover';
+
+const headerStyle = {
+  marginBottom: '1.5rem',
+  width: '100%',
+};
+
+const loadingContainerStyle = {
+  width: '100%',
+  height: '100%',
+  textAlign: 'center',
+  paddingTop: '5rem',
+};
+
+const topBarContainerStyle = {
+  display: 'flex',
+};
+
+const composerStyle = {
+  marginBottom: '1.5rem',
+  flexGrow: '1',
+};
+
+const PastRemindersList = ({
+  header,
+  subHeader,
+  total,
+  loading,
+  postLists,
+  onEditClick,
+  onShareAgainClick,
+  onImageClick,
+  onImageClickNext,
+  onImageClickPrev,
+  onImageClose,
+  onComposerCreateSuccess,
+  showComposer,
+  editMode,
+  isManager,
+  isLockedProfile,
+  onClickUpgradeToPro,
+}) => {
+  if (loading) {
+    return (
+      <div style={loadingContainerStyle}>
+        <LoadingAnimation />
+      </div>
+    );
+  }
+
+  if (isLockedProfile) {
+    return (
+      <LockedProfileNotification onClickUpgradeToPro={onClickUpgradeToPro} />
+    );
+  }
+
+  if (total < 1) {
+    return (
+      <EmptyState
+        title="You haven’t published any posts with this account in the past 30 days!"
+        subtitle="Once a post has gone live via Buffer, you can track its performance here to learn what works best with your audience!"
+        heroImg="https://s3.amazonaws.com/buffer-publish/images/empty-sent2x.png"
+        heroImgSize={{ width: '270px', height: '150px' }}
+      />
+    );
+  }
+  return (
+    <div>
+      <div style={headerStyle}>
+        <Text color={'black'}>{header}</Text>
+        <div>
+          <Text color={'black'}>{subHeader}</Text>
+        </div>
+        <Divider />
+      </div>
+      <div style={topBarContainerStyle}>
+        <div style={composerStyle}>
+          {showComposer && !editMode &&
+            <ComposerPopover
+              onSave={onComposerCreateSuccess}
+              type={'pastReminders'}
+            />
+          }
+        </div>
+      </div>
+      {showComposer && editMode &&
+        <ComposerPopover
+          onSave={onComposerCreateSuccess}
+          type={'pastReminders'}
+        />
+      }
+      <PostLists
+        postLists={postLists}
+        onEditClick={onEditClick}
+        onShareAgainClick={onShareAgainClick}
+        onImageClick={onImageClick}
+        onImageClickNext={onImageClickNext}
+        onImageClickPrev={onImageClickPrev}
+        onImageClose={onImageClose}
+        isManager={isManager}
+        isSent={false}
+        isPastReminder
+      />
+    </div>
+  );
+};
+
+PastRemindersList.propTypes = {
+  header: PropTypes.string,
+  subHeader: PropTypes.string,
+  loading: PropTypes.bool,
+  moreToLoad: PropTypes.bool, // eslint-disable-line
+  page: PropTypes.number, // eslint-disable-line
+  postLists: PropTypes.arrayOf(
+    PropTypes.shape({
+      listHeader: PropTypes.string,
+      posts: PropTypes.arrayOf(
+        PropTypes.shape({
+          text: PropTypes.string,
+        }),
+      ),
+    }),
+  ),
+  total: PropTypes.number,
+  showComposer: PropTypes.bool,
+  editMode: PropTypes.bool,
+  onComposerCreateSuccess: PropTypes.func.isRequired,
+  onEditClick: PropTypes.func.isRequired,
+  onShareAgainClick: PropTypes.func,
+  onImageClick: PropTypes.func,
+  onImageClickNext: PropTypes.func,
+  onImageClickPrev: PropTypes.func,
+  onImageClose: PropTypes.func,
+  isManager: PropTypes.bool,
+  isLockedProfile: PropTypes.bool,
+  onClickUpgradeToPro: PropTypes.func.isRequired,
+};
+
+PastRemindersList.defaultProps = {
+  header: null,
+  subHeader: null,
+  loading: true,
+  moreToLoad: false,
+  page: 1,
+  postLists: [],
+  total: 0,
+  showComposer: false,
+  editMode: false,
+  isManager: true,
+  isLockedProfile: false,
+  onEditClick: () => {},
+  onShareAgainClick: () => {},
+  onImageClick: () => {},
+  onImageClickNext: () => {},
+  onImageClickPrev: () => {},
+  onImageClose: () => {},
+};
+
+export default PastRemindersList;

--- a/packages/past-reminders/components/PastRemindersList/postData.js
+++ b/packages/past-reminders/components/PastRemindersList/postData.js
@@ -1,0 +1,83 @@
+export const postLists = [
+  {
+    listHeader: 'Today',
+    posts: [
+      {
+        id: '590a365d749c2018007b23c6',
+        isConfirmingDelete: false,
+        isDeleting: false,
+        isWorking: false,
+        imageUrls: [],
+        links: [],
+        linkAttachment: {},
+        postDetails: {
+          postAction: 'This post is scheduled for May 2nd',
+          isRetweet: false,
+        },
+        retweetCommentLinks: [],
+        sent: false,
+        text: 'New thing',
+        type: 'text',
+      },
+      {
+        id: '590a3693749c200e007b23c7',
+        isConfirmingDelete: false,
+        isDeleting: false,
+        isWorking: false,
+        imageUrls: [],
+        links: [],
+        linkAttachment: {},
+        postDetails: {
+          postAction: 'This post is scheduled for May 2nd',
+          isRetweet: false,
+        },
+        retweetCommentLinks: [],
+        sent: true,
+        text: 'Another thing, that is also new',
+        type: 'text',
+      },
+    ],
+  },
+  {
+    listHeader: 'Tuesday May 3rd',
+    posts: [
+      {
+        id: '590a365d749c2018007b23c6',
+        isConfirmingDelete: false,
+        isDeleting: false,
+        isWorking: false,
+        imageUrls: [],
+        links: [],
+        linkAttachment: {},
+        postDetails: {
+          postAction: 'This post is scheduled for May 3rd',
+          isRetweet: false,
+        },
+        retweetCommentLinks: [],
+        sent: true,
+        text: 'New thing',
+        type: 'text',
+      },
+      {
+        id: '590a3693749c200e007b23c7',
+        isConfirmingDelete: false,
+        isDeleting: false,
+        isWorking: false,
+        imageUrls: [],
+        links: [],
+        linkAttachment: {},
+        postDetails: {
+          postAction: 'This post is scheduled for May 3rd',
+          isRetweet: false,
+        },
+        retweetCommentLinks: [],
+        sent: true,
+        text: 'Another thing, that is also new',
+        type: 'text',
+      },
+    ],
+  },
+];
+
+export const header = 'Recent past reminders';
+export const subHeader = 'Here you can manage posts that may still require posting from your mobile';

--- a/packages/past-reminders/components/PastRemindersList/story.jsx
+++ b/packages/past-reminders/components/PastRemindersList/story.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { checkA11y } from 'storybook-addon-a11y';
+import PastReminders from './index';
+import {
+  header,
+  postLists,
+} from './postData';
+
+storiesOf('PastRemindersPastReminders', module)
+  .addDecorator(checkA11y)
+  .add('default', () => (
+    <PastReminders
+      total={0}
+      header={header}
+      postLists={postLists}
+    />
+  ));

--- a/packages/past-reminders/index.js
+++ b/packages/past-reminders/index.js
@@ -1,0 +1,96 @@
+// component vs. container https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0
+import { connect } from 'react-redux';
+// load the presentational component
+import { actions as modalsActions } from '@bufferapp/publish-modals';
+import { actions } from './reducer';
+import PastRemindersList from './components/PastRemindersList';
+
+const formatPostLists = (posts) => {
+  const postLists = [];
+  let day;
+  let newList;
+  const orderedPosts = (posts && typeof posts === 'object') ?
+    Object.values(posts).sort((a, b) => b.due_at - a.due_at) : [];
+
+  orderedPosts.forEach((post) => {
+    if (post.day !== day) {
+      day = post.day;
+      newList = { listHeader: day, posts: [post] };
+      postLists.push(newList);
+    } else { // if same day add to posts array of current list
+      newList.posts.push(post);
+    }
+  });
+  return postLists;
+};
+
+// default export = container
+export default connect(
+  (state, ownProps) => {
+    const profileId = ownProps.profileId;
+    const currentProfile = state.pastReminders.byProfileId[profileId];
+    if (currentProfile) {
+      return {
+        header: currentProfile.header,
+        subHeader: currentProfile.subHeader,
+        loading: currentProfile.loading,
+        loadingMore: currentProfile.loadingMore,
+        moreToLoad: currentProfile.moreToLoad,
+        page: currentProfile.page,
+        postLists: formatPostLists(currentProfile.posts),
+        total: currentProfile.total,
+        showComposer: state.pastReminders.showComposer,
+        editMode: state.pastReminders.editMode,
+        isManager: state.profileSidebar.selectedProfile.isManager,
+        isLockedProfile: state.profileSidebar.isLockedProfile,
+      };
+    }
+    return {};
+  },
+  (dispatch, ownProps) => ({
+    onShareAgainClick: ({ post }) => {
+      dispatch(actions.handleShareAgainClick({
+        post,
+        profileId: ownProps.profileId,
+      }));
+    },
+    onComposerCreateSuccess: () => {
+      dispatch(actions.handleComposerCreateSuccess());
+    },
+    onImageClick: (post) => {
+      dispatch(actions.handleImageClick({
+        post: post.post,
+        profileId: ownProps.profileId,
+      }));
+    },
+    onImageClose: (post) => {
+      dispatch(actions.handleImageClose({
+        post: post.post,
+        profileId: ownProps.profileId,
+      }));
+    },
+    onImageClickNext: (post) => {
+      dispatch(actions.handleImageClickNext({
+        post: post.post,
+        profileId: ownProps.profileId,
+      }));
+    },
+    onImageClickPrev: (post) => {
+      dispatch(actions.handleImageClickPrev({
+        post: post.post,
+        profileId: ownProps.profileId,
+      }));
+    },
+    onClickUpgradeToPro: () => {
+      dispatch(modalsActions.showUpgradeModal({ source: 'locked_profile' }));
+    },
+  }),
+)(PastRemindersList);
+
+// export reducer, actions and action types
+export reducer, { actions, actionTypes } from './reducer';
+export middleware from './middleware';
+/*
+a consumer of a package should be able to use the package in the following way:
+import Example, { actions, actionTypes, middleware, reducer } from '@bufferapp/publish-example';
+*/

--- a/packages/past-reminders/index.test.jsx
+++ b/packages/past-reminders/index.test.jsx
@@ -19,7 +19,7 @@ const storeFake = state => ({
 describe('PastReminder', () => {
   it('should render', () => {
     const store = storeFake({
-      sent: {
+      pastReminders: {
         byProfileId: {
           abc: {
             loading: true,

--- a/packages/past-reminders/index.test.jsx
+++ b/packages/past-reminders/index.test.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import PastReminder, {
+  reducer,
+  actions,
+  actionTypes,
+  middleware,
+} from './index';
+import PastRemindersList from './components/PastRemindersList';
+
+const storeFake = state => ({
+  default: () => {},
+  subscribe: () => {},
+  dispatch: () => {},
+  getState: () => ({ ...state }),
+});
+
+describe('PastReminder', () => {
+  it('should render', () => {
+    const store = storeFake({
+      sent: {
+        byProfileId: {
+          abc: {
+            loading: true,
+            loadingMore: false,
+            moreToLoad: false,
+            page: 1,
+            posts: [],
+            total: 0,
+          },
+        },
+      },
+      appSidebar: {
+        user: {
+          is_business_user: false,
+        },
+      },
+      profileSidebar: {
+        selectedProfile: {
+          isManager: true,
+        },
+      },
+    });
+    const wrapper = mount(
+      <Provider store={store}>
+        <PastReminder
+          profileId="abc"
+          onShareAgainClick={jest.fn()}
+        />
+      </Provider>,
+    );
+    expect(wrapper.find(PastRemindersList).length)
+      .toBe(1);
+  });
+
+  it('should export reducer', () => {
+    expect(reducer)
+      .toBeDefined();
+  });
+
+  it('should export actions', () => {
+    expect(actions)
+      .toBeDefined();
+  });
+
+  it('should export actionTypes', () => {
+    expect(actionTypes)
+      .toBeDefined();
+  });
+
+  it('should export middleware', () => {
+    expect(middleware)
+      .toBeDefined();
+  });
+});

--- a/packages/past-reminders/middleware.js
+++ b/packages/past-reminders/middleware.js
@@ -1,0 +1,19 @@
+import { actionTypes } from '@bufferapp/publish-profile-sidebar';
+import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
+
+export default ({ dispatch }) => next => (action) => { // eslint-disable-line no-unused-vars
+  next(action);
+  switch (action.type) {
+    case actionTypes.SELECT_PROFILE:
+      dispatch(dataFetchActions.fetch({
+        name: 'pastReminders',
+        args: {
+          profileId: action.profile.id,
+          isFetchingMore: false,
+        },
+      }));
+      break;
+    default:
+      break;
+  }
+};

--- a/packages/past-reminders/middleware.test.js
+++ b/packages/past-reminders/middleware.test.js
@@ -1,0 +1,8 @@
+import middleware from './middleware';
+
+describe('middleware', () => {
+  it('should export middleware', () => {
+    expect(middleware)
+      .toBeDefined();
+  });
+});

--- a/packages/past-reminders/package.json
+++ b/packages/past-reminders/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@bufferapp/publish-past-reminders",
+  "version": "2.0.0",
+  "description": "Past Reminders package",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint . --ignore-pattern coverage node_modules"
+  },
+  "author": "mariale.uribe@gmail.com",
+  "dependencies": {
+    "@bufferapp/async-data-fetch": "1.9.4",
+    "@bufferapp/publish-profile-sidebar": "2.0.0",
+    "@bufferapp/publish-pusher-sync": "2.0.0",
+    "@bufferapp/publish-queue": "2.0.0",
+    "@bufferapp/publish-shared-components": "2.0.0",
+    "@bufferapp/publish-composer-popover": "2.0.0"
+  },
+  "devDependencies": {
+    "eslint": "3.19.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/past-reminders/reducer.js
+++ b/packages/past-reminders/reducer.js
@@ -1,0 +1,244 @@
+import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
+import { actionTypes as profileSidebarActionTypes } from '@bufferapp/publish-profile-sidebar';
+import { actionTypes as queueActionTypes } from '@bufferapp/publish-queue';
+import keyWrapper from '@bufferapp/keywrapper';
+import {
+  header,
+  subHeader,
+} from './components/PastRemindersList/postData';
+
+export const actionTypes = keyWrapper('PAST_REMINDERS', {
+  OPEN_COMPOSER: 0,
+  HIDE_COMPOSER: 0,
+  POST_IMAGE_CLICKED: 0,
+  POST_IMAGE_CLICKED_NEXT: 0,
+  POST_IMAGE_CLICKED_PREV: 0,
+  POST_IMAGE_CLOSED: 0,
+});
+
+export const initialState = {
+  byProfileId: {},
+  showComposer: false,
+  editMode: false,
+  editingPostId: '',
+  environment: 'production',
+};
+
+export const profileInitialState = {
+  header,
+  subHeader,
+  loading: true,
+  loadingMore: false,
+  moreToLoad: false,
+  page: 1,
+  posts: {},
+  total: 0,
+};
+
+const handlePosts = (action, currentPosts) => {
+  let posts = action.result.updates;
+  if (action.args.isFetchingMore) {
+    posts = { ...currentPosts, ...posts };
+  }
+  return posts;
+};
+
+const increasePageCount = (page) => {
+  page += 1;
+  return page;
+};
+
+const determineIfMoreToLoad = (action, currentPosts) => {
+  const currentPostCount = Object.keys(currentPosts).length;
+  const resultUpdatesCount = Object.keys(action.result.updates).length;
+  return (action.result.total > (currentPostCount + resultUpdatesCount));
+};
+
+const getProfileId = (action) => {
+  if (action.profileId) { return action.profileId; }
+  if (action.args) { return action.args.profileId; }
+  if (action.profile) { return action.profile.id; }
+};
+
+const getPostUpdateId = (action) => {
+  if (action.updateId) { return action.updateId; }
+  if (action.args) { return action.args.updateId; }
+  if (action.post) { return action.post.id; }
+};
+
+const postReducer = (state, action) => {
+  switch (action.type) {
+    case actionTypes.POST_IMAGE_CLICKED:
+      return {
+        ...state,
+        isLightboxOpen: true,
+        currentImage: 0,
+      };
+    case actionTypes.POST_IMAGE_CLOSED:
+      return {
+        ...state,
+        isLightboxOpen: false,
+      };
+    case actionTypes.POST_IMAGE_CLICKED_NEXT:
+      return {
+        ...state,
+        currentImage: state.currentImage + 1,
+      };
+    case actionTypes.POST_IMAGE_CLICKED_PREV:
+      return {
+        ...state,
+        currentImage: state.currentImage - 1,
+      };
+    default:
+      return state;
+  }
+};
+
+const postsReducer = (state, action) => {
+  switch (action.type) {
+    case queueActionTypes.POST_SENT:
+      return {
+        ...state,
+        [getPostUpdateId(action)]: action.post,
+      };
+    case actionTypes.POST_IMAGE_CLICKED:
+    case actionTypes.POST_IMAGE_CLOSED:
+    case actionTypes.POST_IMAGE_CLICKED_NEXT:
+    case actionTypes.POST_IMAGE_CLICKED_PREV: {
+      return {
+        ...state,
+        [getPostUpdateId(action)]: postReducer(state[getPostUpdateId(action)], action),
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+const profileReducer = (state = profileInitialState, action) => {
+  switch (action.type) {
+    case profileSidebarActionTypes.SELECT_PROFILE:
+      return profileInitialState;
+    case `pastReminders_${dataFetchActionTypes.FETCH_START}`:
+      return {
+        ...state,
+        loading: !action.args.isFetchingMore,
+        loadingMore: action.args.isFetchingMore,
+      };
+    case `pastReminders_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      return {
+        ...state,
+        loading: false,
+        loadingMore: false,
+        moreToLoad: determineIfMoreToLoad(action, state.posts),
+        page: increasePageCount(state.page),
+        posts: handlePosts(action, state.posts),
+        total: action.result.total,
+      };
+    case `pastReminders_${dataFetchActionTypes.FETCH_FAIL}`:
+      return {
+        ...state,
+        loading: false,
+      };
+    case queueActionTypes.POST_COUNT_UPDATED:
+      return {
+        ...state,
+        total: action.counts.sent,
+      };
+    case queueActionTypes.POST_SENT:
+    case actionTypes.POST_IMAGE_CLICKED:
+    case actionTypes.POST_IMAGE_CLOSED:
+    case actionTypes.POST_IMAGE_CLICKED_NEXT:
+    case actionTypes.POST_IMAGE_CLICKED_PREV:
+      return {
+        ...state,
+        posts: postsReducer(state.posts, action),
+      };
+    default:
+      return state;
+  }
+};
+
+export default (state = initialState, action) => {
+  let profileId;
+  switch (action.type) {
+    case profileSidebarActionTypes.SELECT_PROFILE:
+    case `pastReminders_${dataFetchActionTypes.FETCH_START}`:
+    case `pastReminders_${dataFetchActionTypes.FETCH_SUCCESS}`:
+    case `pastReminders_${dataFetchActionTypes.FETCH_FAIL}`:
+    case queueActionTypes.POST_SENT:
+    case queueActionTypes.POST_COUNT_UPDATED:
+    case actionTypes.POST_IMAGE_CLICKED:
+    case actionTypes.POST_IMAGE_CLOSED:
+    case actionTypes.POST_IMAGE_CLICKED_NEXT:
+    case actionTypes.POST_IMAGE_CLICKED_PREV:
+      profileId = getProfileId(action);
+      if (profileId) {
+        return {
+          byProfileId: {
+            ...state.byProfileId,
+            [profileId]: profileReducer(state.byProfileId[profileId], action),
+          },
+        };
+      }
+      return state;
+    case actionTypes.OPEN_COMPOSER:
+      return {
+        ...state,
+        showComposer: true,
+        editMode: action.editMode,
+        editingPostId: action.updateId,
+      };
+    case actionTypes.HIDE_COMPOSER:
+      return {
+        ...state,
+        showComposer: false,
+        editMode: false,
+      };
+    default:
+      return state;
+  }
+};
+
+export const actions = {
+  handleShareAgainClick: ({ post, profileId }) => {
+    return {
+      type: actionTypes.OPEN_COMPOSER,
+      updateId: post.id,
+      editMode: false,
+      post: {
+        ...post,
+        scheduled_at: null,
+        due_at: null,
+      },
+      profileId,
+    };
+  },
+  handleComposerCreateSuccess: () => ({
+    type: actionTypes.HIDE_COMPOSER,
+  }),
+  handleImageClick: ({ post, profileId }) => ({
+    type: actionTypes.POST_IMAGE_CLICKED,
+    updateId: post.id,
+    post,
+    profileId,
+  }),
+  handleImageClickNext: ({ post, profileId }) => ({
+    type: actionTypes.POST_IMAGE_CLICKED_NEXT,
+    updateId: post.id,
+    post,
+    profileId,
+  }),
+  handleImageClickPrev: ({ post, profileId }) => ({
+    type: actionTypes.POST_IMAGE_CLICKED_PREV,
+    updateId: post.id,
+    post,
+    profileId,
+  }),
+  handleImageClose: ({ post, profileId }) => ({
+    type: actionTypes.POST_IMAGE_CLOSED,
+    updateId: post.id,
+    post,
+    profileId,
+  }),
+};

--- a/packages/past-reminders/reducer.test.js
+++ b/packages/past-reminders/reducer.test.js
@@ -1,0 +1,177 @@
+import deepFreeze from 'deep-freeze';
+import reducer, { initialState, profileInitialState, actionTypes } from './reducer';
+import {
+  header,
+} from './components/PastRemindersList/postData';
+
+const profileId = '123456';
+
+describe('reducer', () => {
+  it('should initialize default state', () => {
+    const stateAfter = initialState;
+    const action = {
+      type: 'INIT',
+    };
+    deepFreeze(action);
+    expect(reducer(undefined, action))
+      .toEqual(stateAfter);
+  });
+
+  it('should handle sentPosts_FETCH_START action type', () => {
+    const stateAfter = {
+      byProfileId: {
+        [profileId]: {
+          header,
+          loading: true,
+          loadingMore: false,
+          moreToLoad: false,
+          page: 1,
+          posts: {},
+          total: 0,
+        },
+      },
+    };
+    const action = {
+      profileId,
+      type: 'sentPosts_FETCH_START',
+      args: {
+        isFetchingMore: false,
+      },
+    };
+    deepFreeze(action);
+    expect(reducer(undefined, action))
+      .toEqual(stateAfter);
+  });
+
+  it('should handle sentPosts_FETCH_SUCCESS action type', () => {
+    const post = { id: 'foo', text: 'i love buffer' };
+    const stateAfter = {
+      byProfileId: {
+        [profileId]: {
+          header,
+          loading: false,
+          loadingMore: false,
+          moreToLoad: false,
+          page: 2,
+          posts: [post],
+          total: 1,
+        },
+      },
+    };
+    const action = {
+      profileId,
+      type: 'sentPosts_FETCH_SUCCESS',
+      result: {
+        updates: [post],
+        total: 1,
+      },
+      args: {
+        isFetchingMore: false,
+      },
+    };
+    deepFreeze(action);
+    expect(reducer(undefined, action))
+      .toEqual(stateAfter);
+  });
+
+  it('should handle sentPosts_FETCH_FAIL action type', () => {
+    const stateAfter = {
+      byProfileId: {
+        [profileId]: {
+          header,
+          loading: false,
+          loadingMore: false,
+          moreToLoad: false,
+          page: 1,
+          posts: {},
+          total: 0,
+        },
+      },
+    };
+    const action = {
+      profileId,
+      type: 'sentPosts_FETCH_FAIL',
+    };
+    deepFreeze(action);
+    expect(reducer(undefined, action))
+      .toEqual(stateAfter);
+  });
+
+  it('should handle OPEN_COMPOSER action type', () => {
+    const stateComposerHidden = Object.assign(
+      initialState,
+      { showComposer: false },
+    );
+
+    const action = {
+      profileId,
+      type: 'OPEN_COMPOSER',
+    };
+
+    expect(reducer(stateComposerHidden, action))
+      .toEqual(Object.assign(initialState, { showComposer: true }));
+  });
+
+  it('should handle HIDE_COMPOSER action type', () => {
+    const stateComposerVisible = Object.assign(
+      initialState,
+      { showComposer: true },
+    );
+
+    const action = {
+      profileId,
+      type: 'HIDE_COMPOSER',
+    };
+
+    expect(reducer(stateComposerVisible, action))
+      .toEqual(Object.assign(initialState, { showComposer: false }));
+  });
+
+  it('should handle POST_IMAGE_CLICKED action type', () => {
+    const post = { id: '12345', text: 'i heart buffer' };
+    const postAfter = { ...post, isLightboxOpen: true, currentImage: 0 };
+    const stateBefore = {
+      byProfileId: {
+        [profileId]: Object.assign(profileInitialState, { posts: { 12345: post } }),
+      },
+    };
+    const stateAfter = {
+      byProfileId: {
+        [profileId]: Object.assign(profileInitialState, { posts: { 12345: postAfter } }),
+      },
+    };
+    const action = {
+      type: actionTypes.POST_IMAGE_CLICKED,
+      profileId,
+      post: postAfter,
+      updateId: postAfter.id,
+    };
+    deepFreeze(action);
+    expect(reducer(stateBefore, action))
+      .toEqual(stateAfter);
+  });
+
+  it('should handle POST_IMAGE_CLOSED action type', () => {
+    const post = { id: '12345', text: 'i heart buffer' };
+    const postAfter = { ...post, isLightboxOpen: false };
+    const stateBefore = {
+      byProfileId: {
+        [profileId]: Object.assign(profileInitialState, { posts: { 12345: post } }),
+      },
+    };
+    const stateAfter = {
+      byProfileId: {
+        [profileId]: Object.assign(profileInitialState, { posts: { 12345: postAfter } }),
+      },
+    };
+    const action = {
+      type: actionTypes.POST_IMAGE_CLOSED,
+      profileId,
+      post: postAfter,
+      updateId: postAfter.id,
+    };
+    deepFreeze(action);
+    expect(reducer(stateBefore, action))
+      .toEqual(stateAfter);
+  });
+});

--- a/packages/past-reminders/reducer.test.js
+++ b/packages/past-reminders/reducer.test.js
@@ -2,6 +2,7 @@ import deepFreeze from 'deep-freeze';
 import reducer, { initialState, profileInitialState, actionTypes } from './reducer';
 import {
   header,
+  subHeader,
 } from './components/PastRemindersList/postData';
 
 const profileId = '123456';
@@ -17,11 +18,12 @@ describe('reducer', () => {
       .toEqual(stateAfter);
   });
 
-  it('should handle sentPosts_FETCH_START action type', () => {
+  it('should handle pastReminders_FETCH_START action type', () => {
     const stateAfter = {
       byProfileId: {
         [profileId]: {
           header,
+          subHeader,
           loading: true,
           loadingMore: false,
           moreToLoad: false,
@@ -33,7 +35,7 @@ describe('reducer', () => {
     };
     const action = {
       profileId,
-      type: 'sentPosts_FETCH_START',
+      type: 'pastReminders_FETCH_START',
       args: {
         isFetchingMore: false,
       },
@@ -43,12 +45,13 @@ describe('reducer', () => {
       .toEqual(stateAfter);
   });
 
-  it('should handle sentPosts_FETCH_SUCCESS action type', () => {
+  it('should handle pastReminders_FETCH_SUCCESS action type', () => {
     const post = { id: 'foo', text: 'i love buffer' };
     const stateAfter = {
       byProfileId: {
         [profileId]: {
           header,
+          subHeader,
           loading: false,
           loadingMore: false,
           moreToLoad: false,
@@ -60,7 +63,7 @@ describe('reducer', () => {
     };
     const action = {
       profileId,
-      type: 'sentPosts_FETCH_SUCCESS',
+      type: 'pastReminders_FETCH_SUCCESS',
       result: {
         updates: [post],
         total: 1,
@@ -74,11 +77,12 @@ describe('reducer', () => {
       .toEqual(stateAfter);
   });
 
-  it('should handle sentPosts_FETCH_FAIL action type', () => {
+  it('should handle pastReminders_FETCH_FAIL action type', () => {
     const stateAfter = {
       byProfileId: {
         [profileId]: {
           header,
+          subHeader,
           loading: false,
           loadingMore: false,
           moreToLoad: false,
@@ -90,7 +94,7 @@ describe('reducer', () => {
     };
     const action = {
       profileId,
-      type: 'sentPosts_FETCH_FAIL',
+      type: 'pastReminders_FETCH_FAIL',
     };
     deepFreeze(action);
     expect(reducer(undefined, action))

--- a/packages/profile-page/components/ProfilePage/index.jsx
+++ b/packages/profile-page/components/ProfilePage/index.jsx
@@ -5,6 +5,7 @@ import { Redirect } from 'react-router';
 
 import QueuedPosts from '@bufferapp/publish-queue';
 import SentPosts from '@bufferapp/publish-sent';
+import PastReminders from '@bufferapp/publish-past-reminders';
 import DraftList from '@bufferapp/publish-drafts';
 import PostingSchedule from '@bufferapp/publish-posting-schedule';
 import GeneralSettings from '@bufferapp/publish-general-settings';
@@ -53,6 +54,12 @@ const TabContent = ({ tabId, profileId, childTabId }) => {
     case 'sent':
       return (
         <SentPosts
+          profileId={profileId}
+        />
+      );
+    case 'pastReminders':
+      return (
+        <PastReminders
           profileId={profileId}
         />
       );

--- a/packages/profile-page/components/ProfilePage/story.jsx
+++ b/packages/profile-page/components/ProfilePage/story.jsx
@@ -49,4 +49,15 @@ storiesOf('ProfilePage', module)
       }}
       history={stubbedHistory}
     />
+  ))
+  .add('should render pastReminders', () => (
+    <ProfilePage
+      match={{
+        params: {
+          profileId: 'someProfileId',
+          tabId: 'pastReminders',
+        },
+      }}
+      history={stubbedHistory}
+    />
   ));

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -3,6 +3,7 @@ const { rpc } = require('@bufferapp/buffer-rpc');
 const profilesMethod = require('./profiles');
 const queuedPostsMethod = require('./queuedPosts');
 const sentPostsMethod = require('./sentPosts');
+const pastRemindersMethod = require('./pastReminders');
 const draftPostsMethod = require('./draftPosts');
 const userMethod = require('./user');
 const deletePostMethod = require('./deletePost');
@@ -55,6 +56,7 @@ module.exports = rpc(
   profilesMethod,
   queuedPostsMethod,
   sentPostsMethod,
+  pastRemindersMethod,
   draftPostsMethod,
   userMethod,
   deletePostMethod,

--- a/packages/server/rpc/pastReminders/index.js
+++ b/packages/server/rpc/pastReminders/index.js
@@ -1,0 +1,29 @@
+const { postParser } = require('@bufferapp/publish-parsers');
+const { buildPostMap } = require('@bufferapp/publish-formatters');
+const { method } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+module.exports = method(
+  'pastReminders',
+  'fetch past reminders',
+  ({ profileId, page }, { session }) =>
+    rp({
+      uri: `${process.env.API_ADDR}/1/profiles/${profileId}/notifications.json`,
+      method: 'GET',
+      strictSSL: !(process.env.NODE_ENV === 'development'),
+      qs: {
+        access_token: session.publish.accessToken,
+        page,
+        count: 20,
+      },
+    })
+      .then(result => JSON.parse(result))
+      .then((parsedResult) => {
+        const updates = parsedResult.notifications.map(postParser);
+        const mappedUpdates = buildPostMap(updates);
+        return {
+          total: parsedResult.total,
+          updates: mappedUpdates,
+        };
+      }),
+);

--- a/packages/shared-components/ImagePost/index.jsx
+++ b/packages/shared-components/ImagePost/index.jsx
@@ -70,6 +70,7 @@ const ImagePost = ({
   serviceLink,
   isSent,
   isManager,
+  isPastReminder,
 }) => {
   const children = (
     <div style={postContentStyle}>
@@ -137,6 +138,7 @@ const ImagePost = ({
       serviceLink={serviceLink}
       isSent={isSent}
       isManager={isManager}
+      isPastReminder={isPastReminder}
     >
       {children}
     </Post>
@@ -163,6 +165,7 @@ ImagePost.propTypes = {
   onImageClose: PropTypes.func,
   isSent: PropTypes.bool,
   isManager: PropTypes.bool,
+  isPastReminder: PropTypes.bool,
 };
 
 ImagePost.defaultProps = ImagePost.defaultProps;

--- a/packages/shared-components/LinkPost/index.jsx
+++ b/packages/shared-components/LinkPost/index.jsx
@@ -67,6 +67,7 @@ const LinkPost = ({
   serviceLink,
   isSent,
   isManager,
+  isPastReminder,
 }) => {
   const children = (
     <div style={postContentStyle}>
@@ -149,6 +150,7 @@ const LinkPost = ({
       serviceLink={serviceLink}
       isSent={isSent}
       isManager={isManager}
+      isPastReminder={isPastReminder}
     >
       {children}
     </Post>
@@ -174,6 +176,7 @@ LinkPost.propTypes = {
   text: PropTypes.string.isRequired,
   isSent: PropTypes.bool,
   isManager: PropTypes.bool,
+  isPastReminder: PropTypes.bool,
 };
 
 LinkPost.defaultProps = Post.defaultProps;

--- a/packages/shared-components/MultipleImagesPost/index.jsx
+++ b/packages/shared-components/MultipleImagesPost/index.jsx
@@ -54,6 +54,7 @@ const MultipleImagesPost = ({
   serviceLink,
   isSent,
   isManager,
+  isPastReminder,
 }) => {
   const images = imageUrls.map(url => ({ src: `${url}` }));
   const children = (
@@ -118,6 +119,7 @@ const MultipleImagesPost = ({
       serviceLink={serviceLink}
       isSent={isSent}
       isManager={isManager}
+      isPastReminder={isPastReminder}
     >
       {children}
     </Post>
@@ -144,6 +146,7 @@ MultipleImagesPost.propTypes = {
   currentImage: PropTypes.number,
   isSent: PropTypes.bool,
   isManager: PropTypes.bool,
+  isPastReminder: PropTypes.bool,
 };
 
 MultipleImagesPost.defaultProps = Post.defaultProps;

--- a/packages/shared-components/Post/InstagramPostMetaBar/index.jsx
+++ b/packages/shared-components/Post/InstagramPostMetaBar/index.jsx
@@ -6,6 +6,7 @@ const InstagramPostMetaBar = ({
   dragging,
   locationName,
   isSent,
+  isPastReminder,
 }) => {
   const leftContent = { title: 'Location:', text: locationName };
   return (
@@ -13,6 +14,7 @@ const InstagramPostMetaBar = ({
       dragging={dragging}
       leftContent={leftContent}
       isSent={isSent}
+      isPastReminder={isPastReminder}
     />
   );
 };
@@ -21,6 +23,7 @@ InstagramPostMetaBar.propTypes = {
   locationName: PropTypes.string,
   dragging: PropTypes.bool,
   isSent: PropTypes.bool,
+  isPastReminder: PropTypes.bool,
 };
 
 export default InstagramPostMetaBar;

--- a/packages/shared-components/Post/RenderPostMetaBar/index.jsx
+++ b/packages/shared-components/Post/RenderPostMetaBar/index.jsx
@@ -11,6 +11,7 @@ const RenderPostMetaBar = ({
   subprofiles,
   dragging,
   isSent,
+  isPastReminder,
 }) => {
   if (profileService === 'instagram' && locationName) {
     return (
@@ -18,6 +19,7 @@ const RenderPostMetaBar = ({
         dragging={dragging}
         locationName={locationName}
         isSent={isSent}
+        isPastReminder={isPastReminder}
       />
     );
   } else if (profileService === 'pinterest' && subprofileID) {
@@ -49,6 +51,7 @@ RenderPostMetaBar.propTypes = {
   ),
   dragging: PropTypes.bool,
   isSent: PropTypes.bool,
+  isPastReminder: PropTypes.bool,
 };
 
 export default RenderPostMetaBar;

--- a/packages/shared-components/Post/index.jsx
+++ b/packages/shared-components/Post/index.jsx
@@ -140,6 +140,7 @@ const Post = ({
   serviceLink,
   isSent,
   isManager,
+  isPastReminder,
 }) =>
   (<div style={getPostContainerStyle({ dragging, hovering })}>
     <div style={postStyle}>
@@ -172,6 +173,7 @@ const Post = ({
           subprofileID={subprofileID}
           subprofiles={subprofiles}
           isSent={isSent}
+          isPastReminder={isPastReminder}
         />
         <PostFooter
           isManager={isManager}
@@ -188,6 +190,7 @@ const Post = ({
           onRequeueClick={onRequeueClick}
           serviceLink={serviceLink}
           isSent={isSent}
+          isPastReminder={isPastReminder}
         />
         <FeatureLoader
           supportedFeatures={'post_stats'}
@@ -239,6 +242,7 @@ Post.commonPropTypes = {
   onDropPost: PropTypes.func,
   serviceLink: PropTypes.string,
   isSent: PropTypes.bool,
+  isPastReminder: PropTypes.bool,
 };
 
 Post.propTypes = {
@@ -253,6 +257,7 @@ Post.defaultProps = {
   fixed: false,
   isSent: false,
   isManager: true,
+  isPastReminder: true,
 };
 
 export default Post;

--- a/packages/shared-components/PostList/index.jsx
+++ b/packages/shared-components/PostList/index.jsx
@@ -52,6 +52,7 @@ const renderPost = ({
   onImageClose,
   onDropPost,
   isSent,
+  isPastReminder,
 }) => {
   const postWithEventHandlers = {
     ...post,
@@ -67,6 +68,7 @@ const renderPost = ({
     onImageClose: () => onImageClose({ post }),
     onDropPost,
     isSent,
+    isPastReminder,
   };
   let PostComponent = postTypeComponentMap.get(post.type);
   PostComponent = PostComponent || TextPost;
@@ -92,6 +94,7 @@ const PostList = ({
   onShareAgainClick,
   isSent,
   isManager,
+  isPastReminder,
 }) =>
   <div>
     <div style={listHeaderStyle}>
@@ -119,6 +122,7 @@ const PostList = ({
               onDropPost,
               onShareAgainClick,
               isSent,
+              isPastReminder,
             })
           }
           {isManager &&
@@ -160,6 +164,7 @@ PostList.propTypes = {
   onShareAgainClick: PropTypes.func,
   isSent: PropTypes.bool,
   isManager: PropTypes.bool,
+  isPastReminder: PropTypes.bool,
 };
 
 PostList.defaultProps = {

--- a/packages/shared-components/PostLists/index.jsx
+++ b/packages/shared-components/PostLists/index.jsx
@@ -29,6 +29,7 @@ const renderPostList = ({
   onShareAgainClick,
   isSent,
   isManager,
+  isPastReminder,
 }) =>
   <div style={postListStyle}>
     <PostList
@@ -49,6 +50,7 @@ const renderPostList = ({
       onShareAgainClick={onShareAgainClick}
       isSent={isSent}
       isManager={isManager}
+      isPastReminder={isPastReminder}
     />
   </div>;
 
@@ -70,6 +72,7 @@ const PostLists = ({
   onShareAgainClick,
   isSent,
   isManager,
+  isPastReminder,
 }) =>
   <List
     items={postLists.map((postList, index) =>
@@ -90,6 +93,7 @@ const PostLists = ({
         onShareAgainClick,
         isSent,
         isManager,
+        isPastReminder,
       }),
     )}
     fillContainer
@@ -120,6 +124,7 @@ PostLists.propTypes = {
   onShareAgainClick: PropTypes.func,
   isSent: PropTypes.bool,
   isManager: PropTypes.bool,
+  isPastReminder: PropTypes.bool,
 };
 
 PostLists.defaultProps = {

--- a/packages/shared-components/TextPost/index.jsx
+++ b/packages/shared-components/TextPost/index.jsx
@@ -44,6 +44,7 @@ const TextPost = ({
   serviceLink,
   isSent,
   isManager,
+  isPastReminder,
 }) => {
   const children = (
     <div style={postContentStyle}>
@@ -93,6 +94,7 @@ const TextPost = ({
       serviceLink={serviceLink}
       isSent={isSent}
       isManager={isManager}
+      isPastReminder={isPastReminder}
     >
       {children}
     </Post>
@@ -120,6 +122,7 @@ TextPost.propTypes = {
   text: PropTypes.string.isRequired,
   isSent: PropTypes.bool,
   isManager: PropTypes.bool,
+  isPastReminder: PropTypes.bool,
 };
 
 TextPost.defaultProps = Post.defaultProps;

--- a/packages/shared-components/VideoPost/index.jsx
+++ b/packages/shared-components/VideoPost/index.jsx
@@ -34,6 +34,7 @@ const VideoPost = ({
   serviceLink,
   isSent,
   isManager,
+  isPastReminder,
 }) =>
   <ImagePost
     isConfirmingDelete={isConfirmingDelete}
@@ -68,6 +69,7 @@ const VideoPost = ({
     serviceLink={serviceLink}
     isSent={isSent}
     isManager={isManager}
+    isPastReminder={isPastReminder}
   />;
 
 VideoPost.propTypes = ImagePost.propTypes;

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -4,6 +4,7 @@ import createHistory from 'history/createBrowserHistory';
 import { createMiddleware as createBufferMetricsMiddleware } from '@bufferapp/buffermetrics/redux';
 import { middleware as queueMiddleware } from '@bufferapp/publish-queue';
 import { middleware as sentMiddleware } from '@bufferapp/publish-sent';
+import { middleware as pastRemindersMiddleware } from '@bufferapp/publish-past-reminders';
 import { middleware as draftsMiddleware } from '@bufferapp/publish-drafts';
 import { middleware as postingScheduleSettingsMiddleware } from '@bufferapp/publish-posting-schedule';
 import { middleware as generalSettingsMiddleware } from '@bufferapp/publish-general-settings';
@@ -87,6 +88,7 @@ const configureStore = (initialstate) => {
         productFeatureMiddleware,
         queueMiddleware,
         sentMiddleware,
+        pastRemindersMiddleware,
         postingScheduleSettingsMiddleware,
         generalSettingsMiddleware,
         pusherSyncMiddleware,

--- a/packages/store/reducers.js
+++ b/packages/store/reducers.js
@@ -4,6 +4,7 @@ import { routerReducer } from 'react-router-redux';
 import { reducer as tabsReducer } from '@bufferapp/publish-tabs';
 import { reducer as queueReducer } from '@bufferapp/publish-queue';
 import { reducer as sentReducer } from '@bufferapp/publish-sent';
+import { reducer as pastRemindersReducer } from '@bufferapp/publish-past-reminders';
 import { reducer as draftsReducer } from '@bufferapp/publish-drafts';
 import { reducer as postingScheduleReducer } from '@bufferapp/publish-posting-schedule';
 import { reducer as generalSettingsReducer } from '@bufferapp/publish-general-settings';
@@ -46,6 +47,7 @@ export default combineReducers({
   router: routerReducer,
   queue: queueReducer,
   sent: sentReducer,
+  pastReminders: pastRemindersReducer,
   i18n: i18nReducer,
   tabs: tabsReducer,
   profileSidebar: profileSidebarReducer,

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -31,6 +31,7 @@ const TabNavigation = ({
   profileId,
   isLockedProfile,
   isInstagramProfile,
+  hasPastRemindersFeatureFlip,
 }) => {
   const selectedChildTab = selectedChildTabId || 'general-settings';
   return (
@@ -43,7 +44,9 @@ const TabNavigation = ({
       >
         <Tab tabId={'queue'}>Queue</Tab>
         <Tab tabId={'sent'}>Sent Posts</Tab>
-        {isInstagramProfile && <Tab tabId={'pastReminders'}>Past Reminders</Tab>}
+        {isInstagramProfile && hasPastRemindersFeatureFlip &&
+          <Tab tabId={'pastReminders'}>Past Reminders</Tab>
+        }
         {isBusinessAccount && <Tab tabId={'analytics'}>Analytics</Tab>}
         {isBusinessAccount && isManager &&
           <Tab tabId={'awaitingApproval'}>Awaiting Approval</Tab>
@@ -100,6 +103,7 @@ TabNavigation.defaultProps = {
   profileId: null,
   isLockedProfile: false,
   isInstagramProfile: false,
+  hasPastRemindersFeatureFlip: false,
 };
 
 TabNavigation.propTypes = {
@@ -115,6 +119,7 @@ TabNavigation.propTypes = {
   profileId: PropTypes.string,
   isLockedProfile: PropTypes.bool,
   isInstagramProfile: PropTypes.bool,
+  hasPastRemindersFeatureFlip: PropTypes.bool,
 };
 
 export default TabNavigation;

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -30,6 +30,7 @@ const TabNavigation = ({
   showUpgradeModal,
   profileId,
   isLockedProfile,
+  isInstagramProfile,
 }) => {
   const selectedChildTab = selectedChildTabId || 'general-settings';
   return (
@@ -42,6 +43,7 @@ const TabNavigation = ({
       >
         <Tab tabId={'queue'}>Queue</Tab>
         <Tab tabId={'sent'}>Sent Posts</Tab>
+        {isInstagramProfile && <Tab tabId={'pastReminders'}>Past Reminders</Tab>}
         {isBusinessAccount && <Tab tabId={'analytics'}>Analytics</Tab>}
         {isBusinessAccount && isManager &&
           <Tab tabId={'awaitingApproval'}>Awaiting Approval</Tab>
@@ -97,6 +99,7 @@ TabNavigation.defaultProps = {
   selectedChildTabId: null,
   profileId: null,
   isLockedProfile: false,
+  isInstagramProfile: false,
 };
 
 TabNavigation.propTypes = {
@@ -111,6 +114,7 @@ TabNavigation.propTypes = {
   shouldShowNestedSettingsTab: PropTypes.bool,
   profileId: PropTypes.string,
   isLockedProfile: PropTypes.bool,
+  isInstagramProfile: PropTypes.bool,
 };
 
 export default TabNavigation;

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -17,6 +17,7 @@ export default connect(
     shouldShowNestedSettingsTab: ownProps.tabId === 'settings',
     profileId: ownProps.profileId,
     isLockedProfile: state.profileSidebar.isLockedProfile,
+    isInstagramProfile: state.generalSettings.isInstagramProfile,
   }),
   (dispatch, ownProps) => ({
     onTabClick: tabId => dispatch(push(generateProfilePageRoute({

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -18,6 +18,7 @@ export default connect(
     profileId: ownProps.profileId,
     isLockedProfile: state.profileSidebar.isLockedProfile,
     isInstagramProfile: state.generalSettings.isInstagramProfile,
+    hasPastRemindersFeatureFlip: state.appSidebar.user.features ? state.appSidebar.user.features.includes('past_reminders_in_new_publish') : false,
   }),
   (dispatch, ownProps) => ({
     onTabClick: tabId => dispatch(push(generateProfilePageRoute({


### PR DESCRIPTION
### Purpose
Adding new Past Reminders tab for Instagram profiles and basic functionality to view past reminders.

Related to task [PUB-1164](https://buffer.atlassian.net/browse/PUB-1164)