### PR TITLE
Reseting due_at and scheduled_at dates on re-buffer

### DIFF
--- a/packages/past-reminders/reducer.js
+++ b/packages/past-reminders/reducer.js
@@ -206,7 +206,7 @@ export const actions = {
       type: actionTypes.OPEN_COMPOSER,
       updateId: post.id,
       editMode: false,
-      post: Object.assign(post, { due_at: null }),
+      post: Object.assign(post, { due_at: null, scheduled_at: null }),
       profileId,
     };
   },

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -204,11 +204,7 @@ export const actions = {
       type: actionTypes.OPEN_COMPOSER,
       updateId: post.id,
       editMode: false,
-      post: {
-        ...post,
-        scheduled_at: null,
-        due_at: null,
-      },
+      post: Object.assign(post, { due_at: null, scheduled_at: null }),
       profileId,
     };
   },


### PR DESCRIPTION
### Purpose
Reseting due_at and scheduled_at dates to prevent displaying a previous date when re-buffering a post.
