### PR TITLE
[PUB-1169] Show upgrade path CTA banner in Sent Posts

### DIFF
--- a/packages/pusher-sync/package.json
+++ b/packages/pusher-sync/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@bufferapp/publish-profile-sidebar": "2.0.0",
     "@bufferapp/publish-queue": "2.0.0",
-    "@bufferapp/publish-parsers": "1.12.5",
+    "@bufferapp/publish-parsers": "1.13.0",
     "pusher-js": "4.1.0"
   }
 }

--- a/packages/sent/components/SentPosts/index.jsx
+++ b/packages/sent/components/SentPosts/index.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import FeatureLoader from '@bufferapp/product-features';
 import {
   PostLists,
   EmptyState,
   LockedProfileNotification,
+  BusinessTrialOrUpgradeBanner,
 } from '@bufferapp/publish-shared-components';
 import {
   Divider,
@@ -49,6 +51,7 @@ const SentPosts = ({
   isManager,
   isLockedProfile,
   onClickUpgradeToPro,
+  canStartBusinessTrial,
 }) => {
   if (loading) {
     return (
@@ -64,18 +67,45 @@ const SentPosts = ({
     );
   }
 
+  const bannerCopy = canStartBusinessTrial ?
+  { cta: 'Learn About Buffer for Business',
+    subtext: 'TRY IT FREE FOR 14 DAYS',
+    link: 'https://buffer.com/business' } :
+  { cta: 'Upgrade to Buffer for Business',
+    link: 'https://buffer.com/app/account/receipts?content_only=true',
+  };
+
   if (total < 1) {
     return (
-      <EmptyState
-        title="You haven’t published any posts with this account in the past 30 days!"
-        subtitle="Once a post has gone live via Buffer, you can track its performance here to learn what works best with your audience!"
-        heroImg="https://s3.amazonaws.com/buffer-publish/images/empty-sent2x.png"
-        heroImgSize={{ width: '270px', height: '150px' }}
-      />
+      <div>
+        <FeatureLoader supportedPlans={'pro'}>
+          <BusinessTrialOrUpgradeBanner
+            body={'Get in-depth post analytics by upgrading to Buffer for Business.'}
+            cta={bannerCopy.cta}
+            subtext={bannerCopy.subtext}
+            onCtaClick={() => { window.location.assign(bannerCopy.link); }}
+          />
+        </FeatureLoader>
+        <EmptyState
+          title="You haven’t published any posts with this account in the past 30 days!"
+          subtitle="Once a post has gone live via Buffer, you can track its performance here to learn what works best with your audience!"
+          heroImg="https://s3.amazonaws.com/buffer-publish/images/empty-sent2x.png"
+          heroImgSize={{ width: '270px', height: '150px' }}
+        />
+      </div>
     );
   }
+
   return (
     <div>
+      <FeatureLoader supportedPlans={'pro'}>
+        <BusinessTrialOrUpgradeBanner
+          body={'Get in-depth post analytics by upgrading to Buffer for Business.'}
+          cta={bannerCopy.cta}
+          subtext={bannerCopy.subtext}
+          onCtaClick={() => { window.location.assign(bannerCopy.link); }}
+        />
+      </FeatureLoader>
       <div style={headerStyle}>
         <Text color={'black'}>{header}</Text>
         <Divider />
@@ -139,6 +169,7 @@ SentPosts.propTypes = {
   isManager: PropTypes.bool,
   isLockedProfile: PropTypes.bool,
   onClickUpgradeToPro: PropTypes.func.isRequired,
+  canStartBusinessTrial: PropTypes.bool.isRequired,
 };
 
 SentPosts.defaultProps = {

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -42,6 +42,7 @@ export default connect(
         editMode: state.sent.editMode,
         isManager: state.profileSidebar.selectedProfile.isManager,
         isLockedProfile: state.profileSidebar.isLockedProfile,
+        canStartBusinessTrial: state.appSidebar.user.canStartBusinessTrial,
       };
     }
     return {};

--- a/packages/sent/package.json
+++ b/packages/sent/package.json
@@ -13,7 +13,8 @@
     "@bufferapp/publish-pusher-sync": "2.0.0",
     "@bufferapp/publish-queue": "2.0.0",
     "@bufferapp/publish-shared-components": "2.0.0",
-    "@bufferapp/publish-composer-popover": "2.0.0"
+    "@bufferapp/publish-composer-popover": "2.0.0",
+    "@bufferapp/product-features": "2.0.0"
   },
   "devDependencies": {
     "eslint": "3.19.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,7 +13,7 @@
     "@bufferapp/logger": "0.7.0",
     "@bufferapp/micro-rpc": "0.1.7",
     "@bufferapp/publish-formatters": "1.9.30",
-    "@bufferapp/publish-parsers": "1.12.5",
+    "@bufferapp/publish-parsers": "1.13.0",
     "@bufferapp/session-manager": "0.7.1",
     "@bufferapp/shutdown-helper": "0.2.0",
     "@bugsnag/js": "^5.0.1",

--- a/packages/shared-components/BDSButton/index.jsx
+++ b/packages/shared-components/BDSButton/index.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const bdsButtonStyle = {
+  base: {
+    background: '#2C4BFF',
+    borderRadius: '4px',
+    border: 'none',
+    color: '#fff',
+    padding: '16px',
+    fontWeight: 500,
+    fontSize: '14px',
+    fontFamily: 'Roboto',
+    cursor: 'pointer',
+    transition: 'all 0.1s ease-out',
+    outline: 'none',
+  },
+  hover: {
+    background: 'rgb(31, 53, 179)',
+  },
+  loading: {
+    pointerEvents: 'none',
+    color: 'rgb(119, 121, 122)',
+    background: 'rgb(224, 224, 224)',
+  },
+};
+const getBdsButtonStyle = (hover, loading) => {
+  let style = bdsButtonStyle.base;
+  if (hover) {
+    style = { ...style, ...bdsButtonStyle.hover };
+  }
+  if (loading) {
+    style = { ...style, ...bdsButtonStyle.loading };
+  }
+  return style;
+};
+
+class BDSButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hover: false, loading: false };
+    this.handleOnClick = this.handleOnClick.bind(this);
+  }
+
+  handleOnClick() {
+    const { onClick } = this.props;
+    if (onClick) {
+      onClick();
+      this.setState({ loading: true });
+    }
+  }
+
+  render() {
+    const { children } = this.props;
+    const { hover, loading } = this.state;
+    return (
+      <button
+        onClick={this.handleOnClick}
+        onMouseOver={() => this.setState({ hover: true })}
+        onMouseOut={() => this.setState({ hover: false })}
+        style={getBdsButtonStyle(hover, loading)}
+      >
+        {children}
+      </button>
+    );
+  }
+}
+
+BDSButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default BDSButton;

--- a/packages/shared-components/BDSButton/story.jsx
+++ b/packages/shared-components/BDSButton/story.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import {
+  storiesOf,
+} from '@storybook/react';
+import { checkA11y } from 'storybook-addon-a11y';
+import BDSButton from './index';
+
+const cta = 'Learn About Buffer for Business';
+
+storiesOf('BDSButton', module)
+  .addDecorator(checkA11y)
+  .add('default', () => (
+    <BDSButton onCtaClick={() => {}}> {cta} </BDSButton>
+  ));

--- a/packages/shared-components/BusinessTrialOrUpgradeBanner/index.jsx
+++ b/packages/shared-components/BusinessTrialOrUpgradeBanner/index.jsx
@@ -20,6 +20,7 @@ const bodyStyle = {
   fontFamily: 'Roboto',
   fontSize: '16px',
   fontWeight: '500',
+  color: '#121E66',
 };
 
 const btnWrapperStyle = {
@@ -49,7 +50,8 @@ const BusinessTrialOrUpgradeBanner = ({ body, cta, subtext, onCtaClick }) => (
         <BDSButton onClick={onCtaClick}>{cta}</BDSButton>
       </div>
     </div>
-    {subtext && <div style={subtextStyle}>{subtext}</div>}
+    {subtext &&
+      <div style={subtextStyle}>{subtext}</div>}
   </div>
 );
 

--- a/packages/shared-components/BusinessTrialOrUpgradeBanner/index.jsx
+++ b/packages/shared-components/BusinessTrialOrUpgradeBanner/index.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import BDSButton from '../BDSButton';
+
+const svgUrl = 'https://s3.amazonaws.com/buffer-publish/images/analytics-cta-banner-background.svg';
+
+const bannerStyle = {
+  top: '155px',
+  height: '105px',
+  background: `url(${svgUrl}) no-repeat`,
+  display: 'flex',
+  alignItems: 'center',
+  marginLeft: '-5px',
+  marginRight: '-5px',
+  marginBottom: '15px',
+};
+
+const bodyStyle = {
+  paddingLeft: '45px',
+  fontFamily: 'Roboto',
+  fontSize: '16px',
+  fontWeight: '500',
+};
+
+const btnWrapperStyle = {
+  marginLeft: 'auto',
+  paddingRight: '45px',
+};
+
+const subtextStyle = {
+  fontFamily: 'Roboto',
+  fontWeight: 'bold',
+  lineHeight: '20px',
+  fontSize: '10px',
+  color: '#636363',
+  position: 'relative',
+  float: 'right',
+  top: '-42px',
+  left: '-97px',
+};
+
+const BusinessTrialOrUpgradeBanner = ({ body, cta, subtext, onCtaClick }) => (
+  <div>
+    <div style={bannerStyle}>
+      <div style={bodyStyle}>
+        {body}
+      </div>
+      <div style={btnWrapperStyle}>
+        <BDSButton onClick={onCtaClick}>{cta}</BDSButton>
+      </div>
+    </div>
+    {subtext && <div style={subtextStyle}>{subtext}</div>}
+  </div>
+);
+
+BusinessTrialOrUpgradeBanner.propTypes = {
+  body: PropTypes.string.isRequired,
+  cta: PropTypes.string.isRequired,
+  subtext: PropTypes.string,
+  onCtaClick: PropTypes.func.isRequired,
+};
+
+BusinessTrialOrUpgradeBanner.defaultProps = {
+  subtext: null,
+};
+
+export default BusinessTrialOrUpgradeBanner;

--- a/packages/shared-components/BusinessTrialOrUpgradeBanner/story.jsx
+++ b/packages/shared-components/BusinessTrialOrUpgradeBanner/story.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {
+  storiesOf,
+} from '@storybook/react';
+import { checkA11y } from 'storybook-addon-a11y';
+import BufferTrialOrUpgradeBanner from './index';
+
+const canStartBusinessTrialCopy = {
+  cta: 'Learn About Buffer for Business',
+  subtext: 'TRY IT FREE FOR 14 DAYS',
+};
+
+storiesOf('BusinessTrialOrUpgradeBanner', module)
+  .addDecorator(checkA11y)
+  .add('Can start business trial', () => (
+    <BufferTrialOrUpgradeBanner
+      body={'Get in-depth post analytics by upgrading to Buffer for Business.'}
+      cta={canStartBusinessTrialCopy.cta}
+      subtext={canStartBusinessTrialCopy.subtext}
+      onCtaClick={() => {}}
+    />
+  ))
+  .add('Unable to start business trial', () => (
+    <BufferTrialOrUpgradeBanner
+      body={'Get in-depth post analytics by upgrading to Buffer for Business.'}
+      cta={'Upgrade to Buffer for Business'}
+      onCtaClick={() => {}}
+    />
+));

--- a/packages/shared-components/index.js
+++ b/packages/shared-components/index.js
@@ -23,3 +23,5 @@ export Tab from './Tab';
 export Tabs from './Tabs';
 export TextPost from './TextPost';
 export VideoPost from './VideoPost';
+export BusinessTrialOrUpgradeBanner from './BusinessTrialOrUpgradeBanner';
+export BDSButton from './BDSButton';

--- a/yarn.lock
+++ b/yarn.lock
@@ -516,10 +516,10 @@
     moment "2.19.3"
     moment-timezone "0.5.13"
 
-"@bufferapp/publish-parsers@1.12.5":
-  version "1.12.5"
-  resolved "https://registry.yarnpkg.com/@bufferapp/publish-parsers/-/publish-parsers-1.12.5.tgz#ee0cac2fb64c3cbb41d947e4ed64d68a5745fc76"
-  integrity sha512-yNQflAL1oxGuEMDCf9/ye4FGcP/K3cpz8AtyfAglNcofsr2jyWLvq8/mJxC6rPrdyp4pUUgHcUg40GuL6SNypw==
+"@bufferapp/publish-parsers@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@bufferapp/publish-parsers/-/publish-parsers-1.13.0.tgz#678622253505e54c18ba5d7e003e1430c8c580d7"
+  integrity sha512-fQ9tWgY1VkClzB1DHm+Ofl4edRsbXPq5+ANKmpS2SkuNZ1uoboSVJ6GDYRApb/T/kebn0H/DQ0hC1tfYocsWfw==
   dependencies:
     "@bufferapp/publish-formatters" "1.9.29"
     twitter-text "3.0.0"


### PR DESCRIPTION
### Purpose
Show analytics upgrade path CTA banner in Sent Posts tab
https://buffer.atlassian.net/browse/PUB-1169
### Notes

<img width="956" alt="screen shot 2019-02-20 at 11 36 22 am" src="https://user-images.githubusercontent.com/3019212/53111985-dbc7f700-3503-11e9-9060-8b7772295642.png">
<img width="984" alt="screen shot 2019-02-20 at 11 30 40 am" src="https://user-images.githubusercontent.com/3019212/53111990-e08cab00-3503-11e9-9e99-eaf80f8bd0b7.png">

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
