### PR TITLE
Upgrade Composer to v2.6.17

### DIFF
--- a/packages/composer-popover/package.json
+++ b/packages/composer-popover/package.json
@@ -8,7 +8,7 @@
   },
   "author": "ana@buffer.com",
   "dependencies": {
-    "@bufferapp/composer": "2.6.16"
+    "@bufferapp/composer": "2.6.17"
   },
   "devDependencies": {
     "eslint": "3.19.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -315,10 +315,10 @@
     react-autocomplete "1.7.2"
     react-day-picker "6.2.1"
 
-"@bufferapp/composer@2.6.16":
-  version "2.6.16"
-  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-2.6.16.tgz#01c8f131f7dad36d6fc5d23d52c032889de03626"
-  integrity sha512-lz+KzmokBZhAS8up64O3HH0UwlSNUroQYRX1ufrOLVCnGqW7aKoXIqwJs5jFVN6hIkRNOiRwajmvu4yOWgSZVg==
+"@bufferapp/composer@2.6.17":
+  version "2.6.17"
+  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-2.6.17.tgz#3681b4ae03bfca5cc2abeac8d25f1da07756cd3a"
+  integrity sha512-iuLPHWKqKJuWyPNOT/dUp3MWT4+9YCkUPKmFLDh0tRKbciIKIuJrVSk8t/Jwm4qQqRHSljhinvW4NIojMMMxDg==
   dependencies:
     "@bufferapp/buffer-js-api" "0.3.0"
     "@bufferapp/buffer-js-metrics" "0.2.0"


### PR DESCRIPTION
This composer change allows team members of business plans to have access to Instagram Cover. There's also a change that hides the edit cover button if a user doesn't have direct posting enabled.
https://buffer.atlassian.net/browse/PUB-1171