### PR TITLE
Changes name of mini calendar in UI.

### DIFF
--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -144,7 +144,7 @@ const QueuedPosts = ({
               secondary
               onClick={onCalendarToggleClick}
             >
-              {showCalendar ? 'Hide Calendar' : 'Show Calendar'}
+              {showCalendar ? 'Hide Overview' : 'Show Overview'}
             </Button>
           </div>
 


### PR DESCRIPTION
### Purpose
Changes the name of the mini calendar in the UI to "Show Overview" to avoid confusion with large iframe calendar. 

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.publish.buffer.com :smile:_
