### PR TITLE
Bump publish-parsers package to 1.13.4

### DIFF
--- a/packages/pusher-sync/package.json
+++ b/packages/pusher-sync/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@bufferapp/publish-profile-sidebar": "2.0.0",
     "@bufferapp/publish-queue": "2.0.0",
-    "@bufferapp/publish-parsers": "1.13.3",
+    "@bufferapp/publish-parsers": "1.13.4",
     "pusher-js": "4.1.0"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,7 +13,7 @@
     "@bufferapp/logger": "0.7.0",
     "@bufferapp/micro-rpc": "0.1.7",
     "@bufferapp/publish-formatters": "1.9.30",
-    "@bufferapp/publish-parsers": "1.13.3",
+    "@bufferapp/publish-parsers": "1.13.4",
     "@bufferapp/session-manager": "0.7.1",
     "@bufferapp/shutdown-helper": "0.2.0",
     "@bugsnag/js": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,10 +568,10 @@
     moment "2.19.3"
     moment-timezone "0.5.13"
 
-"@bufferapp/publish-parsers@1.13.3":
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/@bufferapp/publish-parsers/-/publish-parsers-1.13.3.tgz#c13b2c17b46f6056c8b6f3e0ba0f2ae20f3063cd"
-  integrity sha512-iz6/NlhQtR/lmYqzWkrisatPHtH7PkAfQzbEZNWWGBmYxN4HtHVMVCXSJdW73MsmFnumWk7aZCPMEyihf68EUg==
+"@bufferapp/publish-parsers@1.13.4":
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/@bufferapp/publish-parsers/-/publish-parsers-1.13.4.tgz#ce72126900178db823715c5fa5bc3694cea500c8"
+  integrity sha512-pEOFOqYUqkOLXbHZxvc+SWtxUiyfpNdCzv546XyUfC70w3Pv8exNyzr0a+vZDA4hIOTkwbrcph5Oz3hK8Emj+A==
   dependencies:
     "@bufferapp/publish-formatters" "1.9.29"
     twitter-text "3.0.0"


### PR DESCRIPTION
### Purpose
User is seeing their New Publish dashboard crashing to a white screen when clicking on "Sent Posts". When checking the console, an error appears for "RangeError: Maximum call stack size exceeded."
Fixed by filtering facebook links with incorrect indices in publish-parsers package
https://buffer.atlassian.net/browse/PUB-1015
### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
