### PR TITLE
Removing past reminders feature flip

### DIFF
--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -32,7 +32,6 @@ const TabNavigation = ({
   profileId,
   isLockedProfile,
   isInstagramProfile,
-  hasPastRemindersFeatureFlip,
 }) => {
   const selectedChildTab = selectedChildTabId || 'general-settings';
   return (
@@ -45,7 +44,7 @@ const TabNavigation = ({
       >
         <Tab tabId={'queue'}>Queue</Tab>
         <Tab tabId={'sent'}>Sent Posts</Tab>
-        {isInstagramProfile && hasPastRemindersFeatureFlip &&
+        {isInstagramProfile &&
           <Tab tabId={'pastReminders'}>Past Reminders</Tab>
         }
         {!features.isFreeUser() && <Tab tabId={'analytics'}>Analytics</Tab>}
@@ -117,7 +116,6 @@ TabNavigation.defaultProps = {
   profileId: null,
   isLockedProfile: false,
   isInstagramProfile: false,
-  hasPastRemindersFeatureFlip: false,
   isBusinessAccount: false,
 };
 
@@ -135,7 +133,6 @@ TabNavigation.propTypes = {
   profileId: PropTypes.string,
   isLockedProfile: PropTypes.bool,
   isInstagramProfile: PropTypes.bool,
-  hasPastRemindersFeatureFlip: PropTypes.bool,
 };
 
 export default WithFeatureLoader(TabNavigation);

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -19,7 +19,6 @@ export default connect(
     profileId: ownProps.profileId,
     isLockedProfile: state.profileSidebar.isLockedProfile,
     isInstagramProfile: state.generalSettings.isInstagramProfile,
-    hasPastRemindersFeatureFlip: state.appSidebar.user.features ? state.appSidebar.user.features.includes('past_reminders_in_new_publish') : false,
   }),
   (dispatch, ownProps) => ({
     onTabClick: (tabId) => {


### PR DESCRIPTION
### Purpose
Removing past reminders feature flip from the code so it's accessible to all users.

### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
