### PR TITLE
[PUB-1136] Updating schedule time for queue posts.

### DIFF
--- a/packages/queue/middleware.js
+++ b/packages/queue/middleware.js
@@ -25,6 +25,7 @@ export default ({ dispatch, getState }) => next => (action) => {
         },
       }));
       break;
+    case `updateSchedule_${dataFetchActionTypes.FETCH_SUCCESS}`:
     case `updatePausedSchedules_${dataFetchActionTypes.FETCH_SUCCESS}`:
     case `toggleInstagramReminders_${dataFetchActionTypes.FETCH_SUCCESS}`:
       dispatch(dataFetchActions.fetch({

--- a/packages/queue/middleware.test.js
+++ b/packages/queue/middleware.test.js
@@ -70,6 +70,26 @@ describe('middleware', () => {
       }));
   });
 
+  it('should fetch queuedPosts if updateSchedule is successful', () => {
+    const action = {
+      type: `updateSchedule_${dataFetchActionTypes.FETCH_SUCCESS}`,
+      args: {
+        profileId: 'id1',
+      },
+    };
+    middleware({ dispatch })(next)(action);
+    expect(next)
+      .toBeCalledWith(action);
+    expect(dispatch)
+      .toBeCalledWith(dataFetchActions.fetch({
+        name: 'queuedPosts',
+        args: {
+          profileId: action.args.profileId,
+          isFetchingMore: false,
+        },
+      }));
+  });
+
   it('should trigger a notification for COMPOSER_EVENT in case of success', () => {
     const action = {
       type: 'COMPOSER_EVENT',


### PR DESCRIPTION
### Purpose
When a user updates the schedule time on Settings, it doesn't automatically update the posts time in the queue, until page reload.

https://buffer.atlassian.net/browse/PUB-1136

### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
