### PR TITLE
[PUB-1181] Styling adjustment for UI bug on the queue with long posts.

### DIFF
--- a/packages/queue/components/QueueItems/index.jsx
+++ b/packages/queue/components/QueueItems/index.jsx
@@ -73,7 +73,6 @@ const renderPost = ({
   const defaultStyle = {
     default: {
       marginBottom: '2rem',
-      maxHeight: '100vh',
       transition: `all ${transitionAnimationTime} ${transitionAnimationType}`,
     },
     hidden: {


### PR DESCRIPTION
### Purpose
On the queue tab, when there is a very long post, it overlaps the other posts below it.

### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
