### PR TITLE
[PUB-1246] Contributors should see Link Shortening Settings disabled

### DIFF
--- a/packages/general-settings/components/GeneralSettings/index.jsx
+++ b/packages/general-settings/components/GeneralSettings/index.jsx
@@ -88,6 +88,7 @@ const GeneralSettings = ({
       />
       <Divider />
       <GoogleAnalytics
+        isContributor={isContributor}
         onShowGACustomizationFormClick={onShowGACustomizationFormClick}
         showGACustomizationForm={showGACustomizationForm}
         googleAnalyticsIsEnabled={googleAnalyticsIsEnabled}

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -80,6 +80,7 @@ const GoogleAnalytics = ({
   onChangeUtmSource,
   utmMedium,
   onChangeUtmMedium,
+  isContributor,
   }) => (
     <div style={googleAnalyticsWrapperStyle}>
       <div style={headerTextWrapperStyle}>
@@ -117,6 +118,7 @@ const GoogleAnalytics = ({
         </div>
         <div style={switchStyle}>
           <Toggle
+            disabled={isContributor}
             onText={'Enabled'}
             offText={'Disabled'}
             on={googleAnalyticsIsEnabled}
@@ -232,6 +234,7 @@ GoogleAnalytics.propTypes = {
   utmCampaign: PropTypes.string,
   utmSource: PropTypes.string,
   utmMedium: PropTypes.string,
+  isContributor: PropTypes.bool.isRequired,
 };
 
 export default reduxForm({

--- a/packages/general-settings/components/GoogleAnalytics/story.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/story.jsx
@@ -37,6 +37,7 @@ storiesOf('GoogleAnalytics', module)
   .addDecorator(UpgradeModalDecorator)
   .add('default', () => (
     <GoogleAnalytics
+      isContributor={false}
       googleAnalyticsIsEnabled={false}
       showGACustomizationForm={false}
       onShowGACustomizationFormClick={action('onShowGACustomizationFormClick')}
@@ -50,8 +51,9 @@ storiesOf('GoogleAnalytics', module)
       onSaveGATrackingSettingsClick={action('onSaveGATrackingSettingsClick')}
     />
   ))
-  .add('google analytics is enabled', () => (
+  .add('is enabled', () => (
     <GoogleAnalytics
+      isContributor={false}
       googleAnalyticsIsEnabled
       showGACustomizationForm={false}
       onShowGACustomizationFormClick={action('onShowGACustomizationFormClick')}
@@ -67,8 +69,25 @@ storiesOf('GoogleAnalytics', module)
   ))
   .add('the customisation form is shown', () => (
     <GoogleAnalytics
+      isContributor={false}
       googleAnalyticsIsEnabled
       showGACustomizationForm
+      onShowGACustomizationFormClick={action('onShowGACustomizationFormClick')}
+      onToggleGoogleAnalyticsClick={action('onToggleGoogleAnalyticsClick')}
+      onChangeUtmCampaign={action('onChangeUtmCampaign')}
+      onChangeUtmSource={action('onChangeUtmSource')}
+      onChangeUtmMedium={action('onChangeUtmMedium')}
+      utmCampaign={'buffer'}
+      utmSource={'source'}
+      utmMedium={'medium'}
+      onSaveGATrackingSettingsClick={action('onSaveGATrackingSettingsClick')}
+    />
+  ))
+  .add('is disabled for Contributors', () => (
+    <GoogleAnalytics
+      isContributor
+      googleAnalyticsIsEnabled
+      showGACustomizationForm={false}
       onShowGACustomizationFormClick={action('onShowGACustomizationFormClick')}
       onToggleGoogleAnalyticsClick={action('onToggleGoogleAnalyticsClick')}
       onChangeUtmCampaign={action('onChangeUtmCampaign')}

--- a/packages/general-settings/components/LinkShortening/LinkShorteningWrapper.jsx
+++ b/packages/general-settings/components/LinkShortening/LinkShorteningWrapper.jsx
@@ -24,6 +24,10 @@ const wrapperSidebarStyle = {
   minWidth: '175px',
 };
 
+const optionOnlyStyle = {
+  alignSelf: 'center',
+};
+
 const loadingContainerStyle = {
   ...wrapperSidebarStyle,
   paddingTop: '1.5rem',
@@ -49,6 +53,7 @@ const LinkShorteningWrapper = ({
     onConnectBitlyURLClick,
     onDisconnectBitlyURLClick,
     isBitlyConnected,
+    isContributor,
   }) => {
   const selectedValue = selectedShortener || (linkList && linkList.filter(ll => ll.selected));
 
@@ -79,7 +84,8 @@ const LinkShorteningWrapper = ({
         <div
           style={{
             ...wrapperSidebarStyle,
-            ...(showConnectBitly ? bitlyWrapperSidebarStyle : {}),
+            ...bitlyWrapperSidebarStyle,
+            ...((!showConnectBitly || isFreeUser) ? optionOnlyStyle : ''),
           }}
         >
           <div>
@@ -88,6 +94,7 @@ const LinkShorteningWrapper = ({
               onChange={onOptionSelect}
               value={selectedValue && selectedValue[0].value}
               size={'small'}
+              disabled={isContributor}
             />
           </div>
           <ConnectBitlyToggler
@@ -140,6 +147,7 @@ LinkShorteningWrapper.propTypes = {
   showConnectBitly: PropTypes.bool,
   isBitlyConnected: PropTypes.bool,
   isFreeUser: PropTypes.func.isRequired,
+  isContributor: PropTypes.bool.isRequired,
 };
 
 export default LinkShorteningWrapper;

--- a/packages/general-settings/components/LinkShortening/index.jsx
+++ b/packages/general-settings/components/LinkShortening/index.jsx
@@ -73,6 +73,7 @@ const LinkShortening = ({
       onDisconnectBitlyURLClick={onDisconnectBitlyURLClick}
       showConnectBitly={!isContributor}
       isBitlyConnected={isBitlyConnected}
+      isContributor={isContributor}
     >
       <div style={textWrapperStyle}>
         <Text size="small">

--- a/packages/general-settings/components/LinkShortening/story.jsx
+++ b/packages/general-settings/components/LinkShortening/story.jsx
@@ -61,4 +61,15 @@ storiesOf('LinkShortener', module)
       features={features}
       profileService="pinterest"
     />
+  ))
+  .add('Options disabled if isContributor', () => (
+    <LinkShortener
+      features={features}
+      onConnectBitlyURLClick={() => {}}
+      onDisconnectBitlyURLClick={() => {}}
+      linkShorteners={linkList}
+      onOptionSelect={() => {}}
+      loading={false}
+      isContributor
+    />
   ));


### PR DESCRIPTION
### Purpose
Contributors should see Link Shortening settings disable, and not be able to perform any action.

- Disable Link shortening select for Contributors
- Align Link shortening select when connect bit.ly button is not displayed (Contributors and Free plan)
- Disable Google Analytics toggle for Contributors

### Notes
[PUB-1246](https://buffer.atlassian.net/browse/PUB-1246)