### PR TITLE
Ensure settings is always the last tab in the nav bar.

### DIFF
--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -57,12 +57,12 @@ const TabNavigation = ({
         {!features.isFreeUser() &&
           <Tab tabId={'drafts'}>Drafts</Tab>
         }
-        <Tab tabId={'settings'}>Settings</Tab>
         <FeatureLoader supportedFeatures={'b4b_calendar'}>
           <Tab tabId={'b4bCalendar'} onClick={() => openCalendarWindow(profileId)}>
             Calendar
           </Tab>
         </FeatureLoader>
+        <Tab tabId={'settings'}>Settings</Tab>
       </Tabs>
       {shouldShowUpgradeCta &&
         <div style={upgradeCtaStyle}>


### PR DESCRIPTION
### Purpose
 - Ensure that "Settings" always appear last in the navbar. Sometimes it would appear before calendar (for Pro + B4B customers)

### Notes
<img width="730" alt="screen shot 2019-02-28 at 11 48 06 am" src="https://user-images.githubusercontent.com/1670168/53593991-bf087080-3b4e-11e9-87fd-4ef94be1bc28.png">


### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
