### PR TITLE
Update composer version to hide Group buttons in New Publish

### DIFF
--- a/packages/composer-popover/package.json
+++ b/packages/composer-popover/package.json
@@ -8,7 +8,7 @@
   },
   "author": "ana@buffer.com",
   "dependencies": {
-    "@bufferapp/composer": "2.6.17"
+    "@bufferapp/composer": "2.6.19"
   },
   "devDependencies": {
     "eslint": "3.19.0"

--- a/packages/drafts/reducer.test.js
+++ b/packages/drafts/reducer.test.js
@@ -207,7 +207,7 @@ describe('reducer', () => {
       .toEqual(stateAfter);
   });
 
-  // DRAFT_APPROVED
+  // DRAFT_APPROVED.
   it('should handle DRAFT_APPROVED action type', () => {
     const draft = { id: '12345', text: 'i love buffer so much' };
     const stateAfter = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,10 +345,10 @@
     react-autocomplete "1.7.2"
     react-day-picker "6.2.1"
 
-"@bufferapp/composer@2.6.17":
-  version "2.6.17"
-  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-2.6.17.tgz#3681b4ae03bfca5cc2abeac8d25f1da07756cd3a"
-  integrity sha512-iuLPHWKqKJuWyPNOT/dUp3MWT4+9YCkUPKmFLDh0tRKbciIKIuJrVSk8t/Jwm4qQqRHSljhinvW4NIojMMMxDg==
+"@bufferapp/composer@2.6.19":
+  version "2.6.19"
+  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-2.6.19.tgz#0f37b7eecce1bb5a1013e92dd9af19f9d065e25c"
+  integrity sha512-ZEwZI4DVoD+KHjXlsJOg9rLaOCCOixEhXjkXIsDigOJGyrkkDebXouKkLDtntVdWCl9kfynJnSIm5KCopGikwA==
   dependencies:
     "@bufferapp/buffer-js-api" "0.3.0"
     "@bufferapp/buffer-js-metrics" "0.2.0"


### PR DESCRIPTION
### Purpose
Update composer version to 2.6.19 to hide Edit Group and Create Group buttons in New Publish
### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
