### PR TITLE
[PUB-1239] Fixing sidebar styling position when user scrolls on Firefox.

### DIFF
--- a/packages/preferences/components/Preferences/index.jsx
+++ b/packages/preferences/components/Preferences/index.jsx
@@ -69,6 +69,10 @@ const Preferences = ({
         flexBasis: '16rem',
         width: '16rem',
         minWidth: '16rem',
+        position: 'sticky',
+        bottom: 0,
+        top: 0,
+        height: '100vh',
       }}
     >
       <ProfileSidebar />

--- a/packages/profile-page/components/ProfilePage/index.jsx
+++ b/packages/profile-page/components/ProfilePage/index.jsx
@@ -24,6 +24,10 @@ const profileSideBarStyle = {
   flexBasis: '16rem',
   width: '16rem',
   minWidth: '16rem',
+  position: 'sticky',
+  bottom: 0,
+  top: 0,
+  height: '100vh',
 };
 
 const contentStyle = {

--- a/packages/server/index.html
+++ b/packages/server/index.html
@@ -20,6 +20,13 @@
     #root {
       height: 100%;
       margin: 0;
+      display: flex;
+      min-height: 100vh;
+      flex-direction: column;
+    }
+
+    #root > div {
+      flex: 1;
     }
 
     ::-webkit-scrollbar {


### PR DESCRIPTION
### Purpose
Fixing sidebar styling position when user scrolls on Firefox, specifically the profile sidebar component.

### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
