### PR TITLE
Show analytics and drafts tab for team members

### DIFF
--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -47,14 +47,16 @@ const TabNavigation = ({
         {isInstagramProfile &&
           <Tab tabId={'pastReminders'}>Past Reminders</Tab>
         }
-        {!features.isFreeUser() && <Tab tabId={'analytics'}>Analytics</Tab>}
+        {(!features.isFreeUser() || isBusinessAccount) &&
+          <Tab tabId={'analytics'}>Analytics</Tab>
+        }
         {isBusinessAccount && isManager &&
           <Tab tabId={'awaitingApproval'}>Awaiting Approval</Tab>
         }
         {isBusinessAccount && !isManager &&
           <Tab tabId={'pendingApproval'}>Pending Approval</Tab>
         }
-        {!features.isFreeUser() &&
+        {(!features.isFreeUser() || isBusinessAccount) &&
           <Tab tabId={'drafts'}>Drafts</Tab>
         }
         <FeatureLoader supportedFeatures={'b4b_calendar'}>

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -47,15 +47,19 @@ const TabNavigation = ({
         {isInstagramProfile &&
           <Tab tabId={'pastReminders'}>Past Reminders</Tab>
         }
+        {/* Pro and up users or Team Members */}
         {(!features.isFreeUser() || isBusinessAccount) &&
           <Tab tabId={'analytics'}>Analytics</Tab>
         }
+        {/* Team Members who are Managers */}
         {isBusinessAccount && isManager &&
           <Tab tabId={'awaitingApproval'}>Awaiting Approval</Tab>
         }
+        {/* Team Members who are Contributors */}
         {isBusinessAccount && !isManager &&
           <Tab tabId={'pendingApproval'}>Pending Approval</Tab>
         }
+        {/* Pro and up users or Team Members */}
         {(!features.isFreeUser() || isBusinessAccount) &&
           <Tab tabId={'drafts'}>Drafts</Tab>
         }

--- a/packages/tabs/components/TabNavigation/story.jsx
+++ b/packages/tabs/components/TabNavigation/story.jsx
@@ -5,8 +5,8 @@ import {
 import {
   action,
 } from '@storybook/addon-actions';
-import TabNavigation from './index';
 import { Provider } from 'react-redux';
+import TabNavigation from './index';
 
 const storeFake = state => ({
   default: () => {},
@@ -48,5 +48,50 @@ storiesOf('TabNavigation', module)
       onChildTabClick={action('child-tab-click')}
       showUpgradeModal={action('show-upgrade-modal')}
       shouldShowUpgradeCta
+      onUpgradeButtonClick={action('on-upgrade-button-click')}
     />
-  ));
+  ))
+  .add('isInstagramProfile', () => (
+    <TabNavigation
+      selectedTabId={'queue'}
+      onTabClick={action('tab-click')}
+      isBusinessAccount={false}
+      isManager={false}
+      isInstagramProfile
+      shouldShowNestedSettingsTab
+      selectedChildTabId={'general-settings'}
+      onChildTabClick={action('child-tab-click')}
+      showUpgradeModal={action('show-upgrade-modal')}
+      shouldShowUpgradeCta
+      onUpgradeButtonClick={action('on-upgrade-button-click')}
+    />
+  ))
+  .add('isContributor', () => (
+    <TabNavigation
+      selectedTabId={'queue'}
+      onTabClick={action('tab-click')}
+      isBusinessAccount
+      isManager={false}
+      shouldShowNestedSettingsTab
+      selectedChildTabId={'general-settings'}
+      onChildTabClick={action('child-tab-click')}
+      showUpgradeModal={action('show-upgrade-modal')}
+      shouldShowUpgradeCta={false}
+      onUpgradeButtonClick={action('on-upgrade-button-click')}
+    />
+  ))
+  .add('isManager, isBusinessAccount', () => (
+    <TabNavigation
+      selectedTabId={'queue'}
+      onTabClick={action('tab-click')}
+      isBusinessAccount
+      isManager
+      shouldShowNestedSettingsTab
+      selectedChildTabId={'general-settings'}
+      onChildTabClick={action('child-tab-click')}
+      showUpgradeModal={action('show-upgrade-modal')}
+      shouldShowUpgradeCta={false}
+      onUpgradeButtonClick={action('on-upgrade-button-click')}
+    />
+  ))
+  ;

--- a/packages/tabs/components/TabNavigation/story.jsx
+++ b/packages/tabs/components/TabNavigation/story.jsx
@@ -93,5 +93,4 @@ storiesOf('TabNavigation', module)
       shouldShowUpgradeCta={false}
       onUpgradeButtonClick={action('on-upgrade-button-click')}
     />
-  ))
-  ;
+  ));


### PR DESCRIPTION
### Purpose
Make sure both Contributors and Managers of Business Profiles (Teams) see drafts and analytics tabs.
[PUB-1250](https://buffer.atlassian.net/browse/PUB-1250)
[PUB-1251](https://buffer.atlassian.net/browse/PUB-1250)

### Notes
There was a regression caused by this [PR](https://github.com/bufferapp/buffer-publish/commit/d3441e740125c6076afe1883c27a3a6c9f5a542b#diff-bbd13035738703c150624fc45a666579):
`isBusinessAccount` condition was replaced by `!features.isFreeUser()`. I believe the intention of the change was to include Pro Users. However, since `isBusinessAccount` is related to a specific profile (a Free User who is part of a team has profiles that are `isBusinessAccount`) and not the Business Plan, Team Members were excluded with the change.
I've added a couple of stories on Storybook so in the future it's easier to spot Tabs changes 😄 