### PR TITLE
[PUB-1239] Fixes top menu scrolling on FF instead of staying visible

### DIFF
--- a/packages/app-switcher/components/AppSwitcher/index.jsx
+++ b/packages/app-switcher/components/AppSwitcher/index.jsx
@@ -19,7 +19,7 @@ const getContainerStyle = hidden => ({
   right: '16px',
   width: '260px',
   display: hidden ? 'none' : '',
-  zIndex: 2,
+  zIndex: 10,
 });
 
 const cardInnerStyle = {

--- a/packages/app-switcher/components/AppSwitcher/index.jsx
+++ b/packages/app-switcher/components/AppSwitcher/index.jsx
@@ -19,6 +19,7 @@ const getContainerStyle = hidden => ({
   right: '16px',
   width: '260px',
   display: hidden ? 'none' : '',
+  zIndex: 2,
 });
 
 const cardInnerStyle = {

--- a/packages/preferences/components/Preferences/index.jsx
+++ b/packages/preferences/components/Preferences/index.jsx
@@ -73,6 +73,7 @@ const Preferences = ({
         bottom: 0,
         top: 0,
         height: '100%',
+        maxHeight: '100vh',
       }}
     >
       <ProfileSidebar />

--- a/packages/profile-page/components/ProfilePage/index.jsx
+++ b/packages/profile-page/components/ProfilePage/index.jsx
@@ -28,6 +28,7 @@ const profileSideBarStyle = {
   bottom: 0,
   top: 0,
   height: '100%',
+  maxHeight: '100vh',
 };
 
 const contentStyle = {

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -37,7 +37,16 @@ const TabNavigation = ({
   return (
     /* wrapper div with "tabs" id necessary as a selector
     for a11y focus after selecting profile in sidebar */
-    <div id="tabs" style={{ paddingLeft: '0.5rem' }}>
+    <div
+      id="tabs"
+      style={{
+        paddingLeft: '0.5rem',
+        position: 'sticky',
+        top: 0,
+        backgroundColor: 'white',
+        zIndex: 1,
+      }}
+    >
       <Tabs
         selectedTabId={selectedTabId}
         onTabClick={onTabClick}

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -18,6 +18,14 @@ const upgradeCtaStyle = {
   right: 0,
 };
 
+const tabsStyle = {
+  paddingLeft: '0.5rem',
+  position: 'sticky',
+  top: '0',
+  backgroundColor: 'white',
+  zIndex: 1,
+};
+
 const reconnectProfile = () => {
   if (window.location.hostname === 'publish.local.buffer.com') {
     window.location.assign('https://local.buffer.com/manage/');
@@ -53,7 +61,7 @@ class TabNavigation extends React.Component {
     return (
       /* wrapper div with "tabs" id necessary as a selector
       for a11y focus after selecting profile in sidebar */
-      <div id="tabs" style={{ paddingLeft: '0.5rem' }}>
+      <div id="tabs" style={tabsStyle}>
         <Tabs
           selectedTabId={selectedTabId}
           onTabClick={onTabClick}


### PR DESCRIPTION
### Purpose
En Firefox the top menu is not staying visible like it is on Chrome, while the user scrolls through the update.

### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
