### PR TITLE
[PUB-1242] Show calendar tab to team members

### DIFF
--- a/packages/profile-page/components/ProfilePage/index.jsx
+++ b/packages/profile-page/components/ProfilePage/index.jsx
@@ -79,7 +79,6 @@ const TabContent = ({ tabId, profileId, childTabId }) => {
           tabId={tabId}
         />
       );
-    case 'b4bCalendar':
     case 'settings':
       switch (childTabId) {
         case 'posting-schedule':

--- a/packages/shared-components/Tabs/index.jsx
+++ b/packages/shared-components/Tabs/index.jsx
@@ -14,7 +14,7 @@ const Tabs = ({
     if (!tab || !tab.props.tabId) return tab;
     return React.cloneElement(tab, {
       selected: selectedTabId === tab.props.tabId,
-      onClick: onTabClick,
+      onClick: tab.props.onClick || onTabClick,
       secondary,
     });
   })}

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -87,11 +87,12 @@ class TabNavigation extends React.Component {
           {(!features.isFreeUser() || isBusinessAccount) &&
             <Tab tabId={'drafts'}>Drafts</Tab>
           }
-          <FeatureLoader supportedFeatures={'b4b_calendar'}>
+          {/* Pro and up users or Team Members */}
+          {(!features.isFreeUser() || isBusinessAccount) &&
             <Tab tabId={'b4bCalendar'} onClick={() => openCalendarWindow(profileId)}>
               Calendar
             </Tab>
-          </FeatureLoader>
+          }
           <Tab tabId={'settings'}>Settings</Tab>
         </Tabs>
         {shouldShowUpgradeCta &&

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -89,7 +89,7 @@ class TabNavigation extends React.Component {
           }
           {/* Pro and up users or Team Members */}
           {(!features.isFreeUser() || isBusinessAccount) &&
-            <Tab onClick={() => openCalendarWindow(profileId)}>
+            <Tab tabId={'b4bCalendar'} onClick={() => openCalendarWindow(profileId)}>
               Calendar
             </Tab>
           }

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -89,7 +89,7 @@ class TabNavigation extends React.Component {
           }
           {/* Pro and up users or Team Members */}
           {(!features.isFreeUser() || isBusinessAccount) &&
-            <Tab tabId={'b4bCalendar'} onClick={() => openCalendarWindow(profileId)}>
+            <Tab onClick={() => openCalendarWindow(profileId)}>
               Calendar
             </Tab>
           }


### PR DESCRIPTION
### Purpose
Team Members should see the Calendar Tab. Used `isBusinessAccount` prop to flag profiles from team members (includes all Managers and Contributors of team accounts).

### Notes
[PUB-1242](https://buffer.atlassian.net/browse/PUB-1242)
Me and @karelm had talked about what to do in those cases where we have a FeatureLoader and we also want to make the feature available for team members. The solution would be to put the Team Member condition in the Fallback, which in this case would be something like this:
<img width="581" alt="captura de ecra 2019-03-06 as 13 57 48" src="https://user-images.githubusercontent.com/16758464/53886803-bc0ef380-4018-11e9-8cb9-84d5446c48fb.png">
However, after confirming with Super that the Calendar tab is going to be available for all Pro users and up, and looking at how the validation on the other tabs was done in the code, I decided to remove the FeatureLoader, to keep consistency and readability and to optimize the code.
