### PR TITLE
Fixes styling issue with faux cmoposer input on Safari.

### DIFF
--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -21,8 +21,7 @@ const composerStyle = {
 
 const composerInputStyle = {
   alignItems: 'center',
-  width: '100%',
-  outline: 'none',
+  backgroundColor: '#ffffff',
   border: '1px solid #B8B8B8',
   borderRadius: '4px',
   boxShadow: '0 1px 4px rgba(0,0,0,.16)',
@@ -32,8 +31,10 @@ const composerInputStyle = {
   fontFamily: 'Roboto',
   fontSize: '14px',
   height: '48px',
+  outline: 'none',
   paddingLeft: '16px',
   paddingRight: '16px',
+  width: '100%',
 };
 
 const composerInputIcoCameraStyle = {


### PR DESCRIPTION
### Purpose
- Fixes a visual bug in Safari which causes the faux composer input to look disabled: 
![Image 2019-03-14 at 2 54 47 PM](https://user-images.githubusercontent.com/1670168/54394115-2c48f500-4669-11e9-925d-3502a00b4b03.png)



### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
