### PR TITLE
Add tracking to Profile Connect buttons 

### DIFF
--- a/packages/profile-sidebar/components/ProfileConnectShortcut/index.jsx
+++ b/packages/profile-sidebar/components/ProfileConnectShortcut/index.jsx
@@ -1,26 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { trackAction } from '@bufferapp/publish-data-tracking';
 import { Text } from '@bufferapp/components';
 
 import { ProfileBadgeIcon } from '../ProfileBadge';
 
 const handleClick = (network, url) => {
-  if (network === 'instagram') {
-    /**
-     * This silly looking code loads an 'img' with the
-     * Instagram logout URL, which ensures the user is
-     * logged out of Instagram before we send them to
-     * reconnect.
-     */
-    const img = new Image();
-    img.onerror = () => {
+  const goConnectProfile = () => {
+    if (network === 'instagram') {
+      /**
+      * This silly looking code loads an 'img' with the
+      * Instagram logout URL, which ensures the user is
+      * logged out of Instagram before we send them to
+      * reconnect.
+      */
+      const img = new Image();
+      img.onerror = () => {
+        window.location.assign(url);
+      };
+      img.src = 'https://www.instagram.com/accounts/logoutin';
+      document.getElementsByTagName('head')[0].appendChild(img);
+    } else {
       window.location.assign(url);
-    };
-    img.src = 'https://www.instagram.com/accounts/logoutin';
-    document.getElementsByTagName('head')[0].appendChild(img);
-  } else {
-    window.location.assign(url);
-  }
+    }
+  };
+  trackAction({
+    location: 'profile_sidebar',
+    action: `connect_${network}`,
+  }, {
+    success: goConnectProfile(),
+    error: goConnectProfile(),
+  });
 };
 
 const getStyle = (hovered) => ({


### PR DESCRIPTION
### Purpose
Add tracking to Profile Connect buttons (Instagram, Twitter, Facebook)
https://buffer.atlassian.net/browse/PUB-1302
### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
