### PR TITLE
Update composer version to 3.0.2

### DIFF
--- a/packages/composer-popover/package.json
+++ b/packages/composer-popover/package.json
@@ -8,7 +8,7 @@
   },
   "author": "ana@buffer.com",
   "dependencies": {
-    "@bufferapp/composer": "3.0.1"
+    "@bufferapp/composer": "3.0.2"
   },
   "devDependencies": {
     "eslint": "3.19.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,10 +345,10 @@
     react-autocomplete "1.7.2"
     react-day-picker "6.2.1"
 
-"@bufferapp/composer@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-3.0.1.tgz#d98715abd012d2c9ab7c8ade1ca3e5382097bf35"
-  integrity sha512-zqVeSGI4sBZqw+g5Cn3G5HTmH4q+V5wgYReuYI6AFWLdIwq1XpKjxLSyq494S2jHL65hQ8g6S2on/+BDExYL2Q==
+"@bufferapp/composer@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-3.0.2.tgz#0864079814fe2a850accae0538b7b21c4f23c392"
+  integrity sha512-NaSzoStZ8e05aXkXnPfnAxxYXPZ5XpcOQioiUfVs2fg50AclVuMVZPoAbFTm726BuJT2C23F0dR5/RRVTIMazw==
   dependencies:
     "@bufferapp/buffer-js-api" "0.3.0"
     "@bufferapp/buffer-js-metrics" "0.2.0"


### PR DESCRIPTION
### Purpose
Update composer version to 3.0.2 to include changes of removing notification permanently by clicking checkbox instead of checkbox and close button. 
https://buffer.atlassian.net/browse/PUB-1024
### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
