### PR TITLE
Update API env. variable to use new PHP 7 api

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,7 +38,7 @@ env:
       fieldRef:
         fieldPath: status.hostIP
   - name: API_ADDR
-    value: https://api.bufferapp.com
+    value: https://k8s-api-php71.buffer.com
   - name: BUGSNAG_KEY
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
### Purpose
Since there isn't an easy way to send a part of the traffic to the PHP 7.1 API and we're already using it in many places, this PR should start sending all the traffic there too from New Publish.

### Review
I'd love to have your eyes on it @erickhun since I'm not fully sure if I need to change something else. 

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
