### PR TITLE
[PUB-1193] Creating rpc calls for update recheck and profile quick analytics

### DIFF
--- a/packages/bookmarklets/index.js
+++ b/packages/bookmarklets/index.js
@@ -1,0 +1,1 @@
+export middleware from './middleware';

--- a/packages/bookmarklets/middleware.js
+++ b/packages/bookmarklets/middleware.js
@@ -1,0 +1,75 @@
+import {
+  actions as dataFetchActions,
+  actionTypes as dataFetchActionTypes,
+} from '@bufferapp/async-data-fetch';
+import { actions as notificationActions } from '@bufferapp/notifications';
+
+const getUrlParameter = (name) => {
+  name = name.replace(/[[]/, '\\[').replace(/[\]]/, '\\]');
+  const regex = new RegExp(`[\\?&]${name}=([^&#]*)`);
+  const results = regex.exec(location.search);
+  return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+};
+
+const getId = () => {
+  const pathArray = window.location.pathname.split('/');
+  return pathArray[3];
+};
+
+export default ({ dispatch }) => next => (action) => {
+  next(action);
+  switch (action.type) {
+    case 'APP_INIT':
+      const id = getId();
+      const isRecheck = getUrlParameter('recheck');
+      const isQuickAnalytics = getUrlParameter('quick_analytics');
+
+      if (id) {
+        if (isRecheck) {
+          dispatch(dataFetchActions.fetch({
+            name: 'updateRecheck',
+            args: {
+              updateId: id,
+            },
+          }));
+        }
+
+        if (isQuickAnalytics) {
+          dispatch(dataFetchActions.fetch({
+            name: 'quickAnalytics',
+            args: {
+              profileId: id,
+            },
+          }));
+        }
+      }
+
+      break;
+    case `updateRecheck_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      dispatch(notificationActions.createNotification({
+        notificationType: 'success',
+        message: 'Analytics should be updated!',
+      }));
+      break;
+    case `updateRecheck_${dataFetchActionTypes.FETCH_FAIL}`:
+      dispatch(notificationActions.createNotification({
+        notificationType: 'error',
+        message: 'There was an error updating the analytics for the update!',
+      }));
+      break;
+    case `quickAnalytics_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      dispatch(notificationActions.createNotification({
+        notificationType: 'success',
+        message: 'Quick Analytics executed for this profile!',
+      }));
+      break;
+    case `quickAnalytics_${dataFetchActionTypes.FETCH_FAIL}`:
+      dispatch(notificationActions.createNotification({
+        notificationType: 'error',
+        message: 'There was an error with the quick analytics for this profile!',
+      }));
+      break;
+    default:
+      break;
+  }
+};

--- a/packages/bookmarklets/package.json
+++ b/packages/bookmarklets/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@bufferapp/publish-bookmarklets",
+  "version": "2.0.0",
+  "description": "New Publish Bookmarklets Update recheck and Profile quick analytics.",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint . --ignore-pattern coverage node_modules"
+  },
+  "author": "mariale.uribe@gmail.com",
+  "dependencies": {
+    "@bufferapp/buffermetrics": "0.9.0"
+  },
+  "devDependencies": {
+    "eslint": "3.19.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/server/rpc/bookmarklets/profileQuickAnalytics/index.js
+++ b/packages/server/rpc/bookmarklets/profileQuickAnalytics/index.js
@@ -1,0 +1,20 @@
+const { method, createError } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+module.exports = method(
+  'quickAnalytics',
+  'quick Analytics through Bookmarklet link',
+  async ({ profileId }, { session }) =>
+    rp({
+      uri: `${process.env.API_ADDR}/1/profiles/${profileId}/quick_analytics.json`,
+      method: 'GET',
+      strictSSL: !(process.env.NODE_ENV === 'development'),
+      qs: {
+        access_token: session.publish.accessToken,
+      },
+    })
+      .then(result => JSON.parse(result))
+      .catch((err) => {
+        throw createError({ message: err.message });
+      }),
+);

--- a/packages/server/rpc/bookmarklets/updateRecheck/index.js
+++ b/packages/server/rpc/bookmarklets/updateRecheck/index.js
@@ -1,0 +1,20 @@
+const { method, createError } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+module.exports = method(
+  'updateRecheck',
+  'recheck a post Analytics through Bookmarklet link',
+  async ({ updateId }, { session }) =>
+    rp({
+      uri: `${process.env.API_ADDR}/1/updates/${updateId}/recheck.json`,
+      method: 'GET',
+      strictSSL: !(process.env.NODE_ENV === 'development'),
+      qs: {
+        access_token: session.publish.accessToken,
+      },
+    })
+      .then(result => JSON.parse(result))
+      .catch((err) => {
+        throw createError({ message: err.message });
+      }),
+);

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -45,6 +45,8 @@ const toggleInstagramReminders = require('./toggleInstagramReminders');
 const mobileReminder = require('./mobileReminder');
 const setNotifications = require('./setNotifications');
 const readMessage = require('./readMessage');
+const updateRecheck = require('./bookmarklets/updateRecheck');
+const profileQuickAnalytics = require('./bookmarklets/profileQuickAnalytics');
 
 // Analytics from Analyze -- Delete when we switch to Analyze
 const analyticsStartDate = require('./analytics/analyticsStartDate');
@@ -108,4 +110,6 @@ module.exports = rpc(
   mobileReminder,
   setNotifications,
   readMessage,
+  updateRecheck,
+  profileQuickAnalytics,
 );

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -35,6 +35,7 @@ import { middleware as profilesDisconnectedModalMiddleware } from '@bufferapp/pu
 import { middleware as accountNotificationsMiddleware } from '@bufferapp/publish-account-notifications';
 import { middleware as publishCTABannerMiddleware } from '@bufferapp/publish-cta-banner';
 import performanceMiddleware from '@bufferapp/performance-tracking/middleware';
+import { middleware as bookmarkletsMiddleware } from '@bufferapp/publish-bookmarklets';
 
 // Remove analytics middleware when publish switches to analyze
 import { middleware as averageMiddleware } from '@bufferapp/average-table';
@@ -99,6 +100,7 @@ const configureStore = (initialstate) => {
         profilesDisconnectedModalMiddleware,
         accountNotificationsMiddleware,
         publishCTABannerMiddleware,
+        bookmarkletsMiddleware,
         // Analyze
         averageMiddleware,
         compareChartMiddleware,


### PR DESCRIPTION
### Purpose
 Creating rpc calls for update recheck and profile quick analytics to user Bookmarklets in New Publish as it is on Buffer web. (http://hi.buffer.com/090600e18142)

### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
