### PR TITLE
[PUB-1258] Create clearer CTAs if profile limit is reached on sidebar prompt click

### DIFF
--- a/packages/profile-sidebar/components/ProfileConnectShortcut/index.jsx
+++ b/packages/profile-sidebar/components/ProfileConnectShortcut/index.jsx
@@ -2,10 +2,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { trackAction } from '@bufferapp/publish-data-tracking';
 import { Text } from '@bufferapp/components';
-
+import { WithFeatureLoader } from '@bufferapp/product-features';
 import { ProfileBadgeIcon } from '../ProfileBadge';
 
-const handleClick = (network, url) => {
+const handleProfileLimitReached = (features, showUpgradeModal, goToConnectSocialAccount) => (
+  features.isFreeUser() ? showUpgradeModal() : goToConnectSocialAccount()
+);
+
+const handleClick = (
+  network,
+  url,
+  profiles,
+  profileLimit,
+  features,
+  showUpgradeModal,
+  goToConnectSocialAccount,
+) => {
+  if (profiles.length >= profileLimit) {
+    handleProfileLimitReached(features, showUpgradeModal, goToConnectSocialAccount);
+    return;
+  }
   const goConnectProfile = () => {
     if (network === 'instagram') {
       /**
@@ -33,7 +49,7 @@ const handleClick = (network, url) => {
   });
 };
 
-const getStyle = (hovered) => ({
+const getStyle = hovered => ({
   display: 'flex',
   alignItems: 'center',
   lineHeight: 1,
@@ -55,8 +71,16 @@ class ProfileConnectShortcut extends React.Component {
     };
   }
   render() {
-    const { label, network, url } = this.props;
-
+    const {
+      label,
+      network,
+      url,
+      profiles,
+      profileLimit,
+      features,
+      showUpgradeModal,
+      goToConnectSocialAccount,
+    } = this.props;
     return (
       <a
         onMouseEnter={() => this.setState({ hovered: true })}
@@ -65,7 +89,15 @@ class ProfileConnectShortcut extends React.Component {
         href="#"
         key={`${network}-connect`}
         notifications=""
-        onClick={() => handleClick(network, url)}
+        onClick={() => handleClick(
+          network,
+          url,
+          profiles,
+          profileLimit,
+          features,
+          showUpgradeModal,
+          goToConnectSocialAccount,
+        )}
       >
         <ProfileBadgeIcon type={network} />
         <span style={{ marginLeft: '8px' }}>
@@ -80,6 +112,15 @@ ProfileConnectShortcut.propTypes = {
   label: PropTypes.string.isRequired,
   network: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
+  profiles: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.string,
+    }),
+  ).isRequired,
+  profileLimit: PropTypes.number.isRequired,
+  features: PropTypes.object.isRequired, // eslint-disable-line
+  goToConnectSocialAccount: PropTypes.func.isRequired,
+  showUpgradeModal: PropTypes.func.isRequired,
 };
 
-export default ProfileConnectShortcut;
+export default WithFeatureLoader(ProfileConnectShortcut);

--- a/packages/profile-sidebar/components/ProfileSidebar/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/index.jsx
@@ -77,9 +77,11 @@ const ProfileSidebar = ({
   translations,
   onProfileClick,
   onDropProfile,
-  onConnectSocialAccountClick,
+  onManageSocialAccountClick,
   profileLimit,
   showProfilesDisconnectedModal,
+  showUpgradeModal,
+  goToConnectSocialAccount,
 
   // Flags for showing connection shortcut buttons
   hasInstagram,
@@ -105,16 +107,28 @@ const ProfileSidebar = ({
         label="Connect Instagram"
         network="instagram"
         url="https://buffer.com/oauth/instagram"
+        profileLimit={profileLimit}
+        profiles={profiles}
+        showUpgradeModal={showUpgradeModal}
+        goToConnectSocialAccount={goToConnectSocialAccount}
       />}
       {!hasFacebook && <ProfileConnectShortcut
         label="Connect Facebook"
         network="facebook"
         url="https://buffer.com/oauth/facebook/choose"
+        profileLimit={profileLimit}
+        profiles={profiles}
+        showUpgradeModal={showUpgradeModal}
+        goToConnectSocialAccount={goToConnectSocialAccount}
       />}
       {!hasTwitter && <ProfileConnectShortcut
         label="Connect Twitter"
         network="twitter"
         url="https://buffer.com/oauth/twitter"
+        profileLimit={profileLimit}
+        profiles={profiles}
+        showUpgradeModal={showUpgradeModal}
+        goToConnectSocialAccount={goToConnectSocialAccount}
       />}
       <div style={buttonDividerStyle}>
         <Divider />
@@ -124,7 +138,7 @@ const ProfileSidebar = ({
         type="secondary"
         fullWidth
         onClick={() => {
-          onConnectSocialAccountClick();
+          onManageSocialAccountClick();
         }}
       />
     </div>
@@ -134,7 +148,9 @@ const ProfileSidebar = ({
 ProfileSidebar.propTypes = {
   loading: PropTypes.bool.isRequired,
   onProfileClick: ProfileList.propTypes.onProfileClick,
-  onConnectSocialAccountClick: PropTypes.func.isRequired,
+  onManageSocialAccountClick: PropTypes.func.isRequired,
+  goToConnectSocialAccount: PropTypes.func.isRequired,
+  showUpgradeModal: PropTypes.func.isRequired,
   selectedProfileId: ProfileList.propTypes.selectedProfileId,
   profiles: PropTypes.arrayOf(PropTypes.shape(ProfileListItem.propTypes)),
   translations: ProfileList.propTypes.translations,

--- a/packages/profile-sidebar/components/ProfileSidebar/story.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/story.jsx
@@ -48,7 +48,8 @@ storiesOf('ProfileSidebar', module)
       lockedProfiles={lockedProfiles}
       translations={translations}
       onProfileClick={action('profile click')}
-      onConnectSocialAccountClick={action('connect social account click')}
+      onManageSocialAccountClick={action('manage social account click')}
+      goToConnectSocialAccount={action('connect social account click')}
       profileLimit={'3'}
     />
   ))
@@ -59,7 +60,8 @@ storiesOf('ProfileSidebar', module)
       translations={translations}
       onProfileClick={action('profile click')}
       selectedProfile={profiles[0]}
-      onConnectSocialAccountClick={action('connect social account click')}
+      onManageSocialAccountClick={action('manage social account click')}
+      goToConnectSocialAccount={action('connect social account click')}
       profileLimit={'3'}
     />
   ));

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -8,12 +8,17 @@ import { actions } from './reducer';
 
 const { formatAnalyticsProfileObj } = require('./analytics');
 
+const reorderProfilesByUnlocked = profiles => (
+  // orders unlocked profiles first, followed by locked
+  profiles.sort((a, b) => (a.disabled - b.disabled))
+);
+
 export default hot(module)(connect(
   (state, ownProps) => ({
     loading: state.profileSidebar.loading,
     selectedProfile: state.profileSidebar.selectedProfile,
     selectedProfileId: ownProps.profileId,
-    profiles: state.profileSidebar.profiles,
+    profiles: reorderProfilesByUnlocked(state.profileSidebar.profiles),
     translations: state.i18n.translations['profile-sidebar'],
     profileLimit: state.appSidebar.user.profile_limit,
     hasInstagram: state.profileSidebar.hasInstagram,

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -47,11 +47,17 @@ export default hot(module)(connect(
         hoverIndex,
       }));
     },
-    onConnectSocialAccountClick: () => {
-      dispatch(actions.handleConnectSocialAccountClick());
+    onManageSocialAccountClick: () => {
+      dispatch(actions.handleManageSocialAccountClick());
     },
     showProfilesDisconnectedModal: () => {
       dispatch(modalActions.showProfilesDisconnectedModal());
+    },
+    showUpgradeModal: () => {
+      dispatch(modalActions.showUpgradeModal({ source: 'app_header' }));
+    },
+    goToConnectSocialAccount: () => {
+      dispatch(actions.handleConnectSocialAccount());
     },
   }),
 )(ProfileSidebar));

--- a/packages/profile-sidebar/middleware.js
+++ b/packages/profile-sidebar/middleware.js
@@ -89,8 +89,11 @@ export default ({ dispatch, getState }) => next => (action) => {
         },
       }));
       break;
-    case actionTypes.CONNECT_SOCIAL_ACCOUNT:
+    case actionTypes.MANAGE_SOCIAL_ACCOUNT:
       window.location = getURL.getManageSocialAccountURL();
+      break;
+    case actionTypes.CONNECT_SOCIAL_ACCOUNT:
+      window.location = getURL.getConnectSocialAccountURL();
       break;
     case `pauseQueue_${dataFetchActionTypes.FETCH_SUCCESS}`:
       dispatch(notificationActions.createNotification({

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -9,6 +9,7 @@ export const actionTypes = keyWrapper('PROFILE_SIDEBAR', {
   PROFILE_PAUSED: 0,
   PUSHER_PROFILE_PAUSED_STATE: 0,
   CONNECT_SOCIAL_ACCOUNT: 0,
+  MANAGE_SOCIAL_ACCOUNT: 0,
   PROFILE_DROPPED: 0,
 });
 
@@ -155,7 +156,10 @@ export const actions = {
     type: actionTypes.PROFILE_PAUSED,
     profileId,
   }),
-  handleConnectSocialAccountClick: () => ({
+  handleManageSocialAccountClick: () => ({
+    type: actionTypes.MANAGE_SOCIAL_ACCOUNT,
+  }),
+  handleConnectSocialAccount: () => ({
     type: actionTypes.CONNECT_SOCIAL_ACCOUNT,
   }),
   onDropProfile: ({ commit, dragIndex, hoverIndex, profileLimit }) => ({


### PR DESCRIPTION
### Purpose
If a free user is at their profile limit and clicks one of these sidebar prompts, we launch a modal that asks them to upgrade

If it's a pro user, redirect them to Org Admin's connect account page. This page already has CTAs built in if the user is at the profile limit and so is a more direct call to action.
https://buffer.atlassian.net/browse/PUB-1258
### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
