### PR TITLE
[PUB-1354] Remove ig new authentication feature flip

### DIFF
--- a/packages/general-settings/components/GeneralSettings/index.jsx
+++ b/packages/general-settings/components/GeneralSettings/index.jsx
@@ -13,7 +13,6 @@ const ErrorBoundary = getErrorBoundary(true);
 const GeneralSettings = ({
   isInstagramProfile,
   isInstagramBusiness,
-  onSetUpDirectPostingClick,
   linkShorteners,
   profileService,
   loadingLinkShorteners,
@@ -28,7 +27,6 @@ const GeneralSettings = ({
   onDisconnectBitlyURLClick,
   isManager,
   features,
-  hasInstagramFeatureFlip,
   onDirectPostingClick,
   utmCampaign,
   onChangeUtmCampaign,
@@ -48,12 +46,7 @@ const GeneralSettings = ({
   return (
     <ErrorBoundary>
       <div>
-        {!hasInstagramFeatureFlip && isInstagramProfile && !isInstagramBusiness &&
-          <InstagramDirectPosting
-            onDirectPostingClick={onSetUpDirectPostingClick}
-          />
-        }
-        {hasInstagramFeatureFlip && isInstagramProfile && !isInstagramBusiness &&
+        {isInstagramProfile && !isInstagramBusiness &&
           <InstagramDirectPosting
             onDirectPostingClick={onDirectPostingClick}
           />
@@ -109,7 +102,6 @@ GeneralSettings.defaultProps = {
   isManager: true,
   showGACustomizationForm: false,
   googleAnalyticsIsEnabled: false,
-  hasInstagramFeatureFlip: false,
   utmCampaign: null,
   utmSource: null,
   utmMedium: null,
@@ -124,7 +116,6 @@ GeneralSettings.propTypes = {
   isInstagramBusiness: PropTypes.bool.isRequired,
   onConnectBitlyURLClick: PropTypes.func.isRequired,
   onDisconnectBitlyURLClick: PropTypes.func.isRequired,
-  onSetUpDirectPostingClick: PropTypes.func.isRequired,
   linkShorteners: PropTypes.arrayOf(
     PropTypes.shape({
       domain: PropTypes.string,
@@ -145,7 +136,6 @@ GeneralSettings.propTypes = {
   features: PropTypes.shape({
     isFreeUser: PropTypes.func,
   }).isRequired,
-  hasInstagramFeatureFlip: PropTypes.bool,
   onDirectPostingClick: PropTypes.func.isRequired,
   utmCampaign: PropTypes.string,
   onChangeUtmCampaign: PropTypes.func.isRequired,

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -27,15 +27,9 @@ export default connect(
       utmSource: state.generalSettings.utmSource,
       utmMedium: state.generalSettings.utmMedium,
       remindersAreEnabled: state.generalSettings.remindersAreEnabled,
-      hasInstagramFeatureFlip: state.appSidebar.user.features ? state.appSidebar.user.features.includes('new_ig_authentication') : false,
       isLockedProfile: state.profileSidebar.isLockedProfile,
     }),
     (dispatch, ownProps) => ({
-      onSetUpDirectPostingClick: () => {
-        dispatch(actions.handleSetUpDirectPostingClick({
-          profileId: ownProps.profileId,
-        }));
-      },
       onDirectPostingClick: () => {
         dispatch(push(generateProfilePageRoute({
           profileId: ownProps.profileId,

--- a/packages/general-settings/middleware.js
+++ b/packages/general-settings/middleware.js
@@ -11,9 +11,6 @@ import { actionTypes } from './reducer';
 export default ({ dispatch }) => next => (action) => {
   next(action);
   switch (action.type) {
-    case actionTypes.SET_DIRECT_POSTING:
-      window.location = getURL.getInstagramDirectPostingURL(action.profileId);
-      break;
     case actionTypes.CONNECT_BITLY:
       window.location = getURL.getConnectBitlyURL(action.profileId);
       break;

--- a/packages/general-settings/reducer.js
+++ b/packages/general-settings/reducer.js
@@ -3,7 +3,6 @@ import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch
 import keyWrapper from '@bufferapp/keywrapper';
 
 export const actionTypes = keyWrapper('GENERAL_SETTINGS', {
-  SET_DIRECT_POSTING: 0,
   CHANGE_SELECTED_LINK_SHORTENER: 0,
   SHOW_GA_CUSTOMIZATION_FORM: 0,
   TOGGLE_GOOGLE_ANALYTICS: 0,
@@ -132,10 +131,6 @@ export default (state = initialState, action) => {
 };
 
 export const actions = {
-  handleSetUpDirectPostingClick: action => ({
-    type: actionTypes.SET_DIRECT_POSTING,
-    profileId: action.profileId,
-  }),
   handleConnectBitlyURLClick: action => ({
     type: actionTypes.CONNECT_BITLY,
     profileId: action.profileId,

--- a/packages/ig-direct-posting-modal/index.js
+++ b/packages/ig-direct-posting-modal/index.js
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
-import { actions as generalSettingsActions } from '@bufferapp/publish-general-settings';
 import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 // load the presentational component
 import InstagramDirectPostingModal from './components/InstagramDirectPostingModal';
+import { actions } from './reducer';
 
 export default connect(
   state => ({
@@ -14,7 +14,7 @@ export default connect(
   dispatch => ({
     onHideInstagramModal: () => dispatch(modalsActions.hideInstagramDirectPostingModal()),
     onSetUpDirectPostingClick: (profileId) => {
-      dispatch(generalSettingsActions.handleSetUpDirectPostingClick({
+      dispatch(actions.handleSetUpDirectPostingClick({
         profileId,
       }));
     },
@@ -29,3 +29,6 @@ export default connect(
     },
   }),
 )(InstagramDirectPostingModal);
+
+export reducer, { actions, actionTypes } from './reducer';
+export middleware from './middleware';

--- a/packages/ig-direct-posting-modal/index.test.jsx
+++ b/packages/ig-direct-posting-modal/index.test.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
-import Example, {
+import InstagramDirectPostingModal, {
+  reducer,
+  actions,
+  actionTypes,
 } from './index';
-
-import InstagramDirectPostingModal from './components/InstagramDirectPostingModal';
 
 const storeFake = state => ({
   default: () => {},
@@ -33,10 +34,25 @@ describe('InstagramDirectPostingModal', () => {
     });
     const wrapper = mount(
       <Provider store={store}>
-        <Example />
+        <InstagramDirectPostingModal />
       </Provider>,
     );
     expect(wrapper.find(InstagramDirectPostingModal).length)
       .toBe(1);
+  });
+
+  it('should export reducer', () => {
+    expect(reducer)
+      .toBeDefined();
+  });
+
+  it('should export actions', () => {
+    expect(actions)
+      .toBeDefined();
+  });
+
+  it('should export actionTypes', () => {
+    expect(actionTypes)
+      .toBeDefined();
   });
 });

--- a/packages/ig-direct-posting-modal/middleware.js
+++ b/packages/ig-direct-posting-modal/middleware.js
@@ -1,0 +1,15 @@
+import { getURL } from '@bufferapp/publish-formatters';
+import { actionTypes } from './reducer';
+
+
+export default ({ getState, dispatch }) => next => (action) => { // eslint-disable-line
+  next(action);
+
+  switch (action.type) {
+    case actionTypes.SET_DIRECT_POSTING:
+      window.location = getURL.getInstagramDirectPostingURL(action.profileId);
+      break;
+    default:
+      break;
+  }
+};

--- a/packages/ig-direct-posting-modal/package.json
+++ b/packages/ig-direct-posting-modal/package.json
@@ -9,7 +9,8 @@
   "author": "ana@bufferapp.com",
   "dependencies": {
     "@bufferapp/async-data-fetch": "1.9.4",
-    "@bufferapp/publish-general-settings": "2.0.0",
+    "@bufferapp/publish-formatters": "1.9.30",
+    "@bufferapp/keywrapper": "0.2.0",
     "@bufferapp/publish-modals": "2.0.0"
   },
   "devDependencies": {

--- a/packages/ig-direct-posting-modal/reducer.js
+++ b/packages/ig-direct-posting-modal/reducer.js
@@ -1,0 +1,21 @@
+import keyWrapper from '@bufferapp/keywrapper';
+
+export const actionTypes = keyWrapper('IG_DIRECT_POSTING_MODAL', {
+  SET_DIRECT_POSTING: 0,
+});
+
+const initialState = {};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    default:
+      return state;
+  }
+};
+
+export const actions = {
+  handleSetUpDirectPostingClick: action => ({
+    type: actionTypes.SET_DIRECT_POSTING,
+    profileId: action.profileId,
+  }),
+};

--- a/packages/ig-direct-posting-modal/reducer.test.js
+++ b/packages/ig-direct-posting-modal/reducer.test.js
@@ -1,0 +1,12 @@
+import { actions, actionTypes } from './reducer';
+
+describe('reducer', () => {
+  describe('actions', () => {
+    it('handleSetUpDirectPostingClick triggers a SET_DIRECT_POSTING action', () => {
+      expect(actions.handleSetUpDirectPostingClick({ profileId: 'id1' })).toEqual({
+        type: actionTypes.SET_DIRECT_POSTING,
+        profileId: 'id1',
+      });
+    });
+  });
+});

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -85,10 +85,8 @@ const QueuedPosts = ({
   subprofiles,
   isInstagramProfile,
   isInstagramBusiness,
-  onSetUpDirectPostingClick,
   showInstagramDirectPostingModal,
   onDirectPostingClick,
-  hasInstagramFeatureFlip,
   isInstagramLoading,
   isLockedProfile,
   isManager,
@@ -138,13 +136,10 @@ const QueuedPosts = ({
           </div>
 
         </div>
-        {!hasInstagramFeatureFlip && isInstagramProfile && !isInstagramBusiness &&
-          <InstagramDirectPostingBanner onDirectPostingClick={onSetUpDirectPostingClick} />
-        }
-        {hasInstagramFeatureFlip && isInstagramProfile && !isInstagramBusiness &&
+        {isInstagramProfile && !isInstagramBusiness &&
           <InstagramDirectPostingBanner onDirectPostingClick={onDirectPostingClick} />
         }
-        {hasInstagramFeatureFlip && showInstagramDirectPostingModal &&
+        {showInstagramDirectPostingModal &&
           <InstagramDirectPostingModal />
         }
         {!!paused && <QueuePausedBar isManager={isManager} handleClickUnpause={onUnpauseClick} />}
@@ -223,10 +218,8 @@ QueuedPosts.propTypes = {
   isManager: PropTypes.bool.isRequired,
   isInstagramProfile: PropTypes.bool,
   isInstagramBusiness: PropTypes.bool,
-  onSetUpDirectPostingClick: PropTypes.func.isRequired,
   showInstagramDirectPostingModal: PropTypes.bool,
   onDirectPostingClick: PropTypes.func.isRequired,
-  hasInstagramFeatureFlip: PropTypes.bool,
   isInstagramLoading: PropTypes.bool,
   isLockedProfile: PropTypes.bool,
   hasFirstCommentFlip: PropTypes.bool,
@@ -247,7 +240,6 @@ QueuedPosts.defaultProps = {
   isInstagramProfile: false,
   isInstagramBusiness: false,
   showInstagramDirectPostingModal: false,
-  hasInstagramFeatureFlip: false,
   isInstagramLoading: false,
   isLockedProfile: false,
   hasFirstCommentFlip: false,

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -1,7 +1,5 @@
 import { connect } from 'react-redux';
-
 import { actions as profileSidebarActions } from '@bufferapp/publish-profile-sidebar';
-import { actions as generalSettingsActions } from '@bufferapp/publish-general-settings';
 import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
 import { trackAction } from '@bufferapp/publish-data-tracking';
@@ -56,7 +54,6 @@ export default connect(
         showInstagramDirectPostingModal: state.modals.showInstagramDirectPostingModal,
         isBusinessOnInstagram: state.queue.isBusinessOnInstagram,
         isInstagramLoading: state.queue.isInstagramLoading,
-        hasInstagramFeatureFlip: state.appSidebar.user.features ? state.appSidebar.user.features.includes('new_ig_authentication') : false,
         hasFirstCommentFlip: state.appSidebar.user.features ? state.appSidebar.user.features.includes('first_comment') : false,
       };
     }
@@ -147,11 +144,6 @@ export default connect(
     },
     onComposerCreateSuccess: () => {
       dispatch(actions.handleComposerCreateSuccess());
-    },
-    onSetUpDirectPostingClick: () => {
-      dispatch(generalSettingsActions.handleSetUpDirectPostingClick({
-        profileId: ownProps.profileId,
-      }));
     },
     onDirectPostingClick: () => {
       dispatch(dataFetchActions.fetch({

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -31,6 +31,7 @@ import { middleware as dateTimePreferencesMiddleware } from '@bufferapp/date-tim
 import { middleware as closeAccountMiddleware } from '@bufferapp/close-account';
 import { middleware as maintenanceRedirectMiddleware } from '@bufferapp/maintenance-redirect';
 import { middleware as defaultPageMiddleware } from '@bufferapp/default-page';
+import { middleware as instagramDirectPostingModalMiddleware } from '@bufferapp/publish-ig-direct-posting-modal';
 import { middleware as notificationsProviderMiddleware } from '@bufferapp/publish-notifications-provider';
 import { middleware as profilesDisconnectedModalMiddleware } from '@bufferapp/publish-profiles-disconnected-modal';
 import { middleware as accountNotificationsMiddleware } from '@bufferapp/publish-account-notifications';
@@ -103,6 +104,7 @@ const configureStore = (initialstate) => {
         dateTimePreferencesMiddleware,
         closeAccountMiddleware,
         defaultPageMiddleware,
+        instagramDirectPostingModalMiddleware,
         maintenanceRedirectMiddleware,
         draftsMiddleware,
         notificationsProviderMiddleware,

--- a/packages/store/reducers.js
+++ b/packages/store/reducers.js
@@ -21,6 +21,7 @@ import { reducer as upgradeModalReducer } from '@bufferapp/publish-upgrade-modal
 import { reducer as stripeReducer } from '@bufferapp/stripe';
 import { reducer as editEmailReducer } from '@bufferapp/edit-email';
 import { reducer as modalsReducer } from '@bufferapp/publish-modals';
+import { reducer as instagramDirectPostingModalReducer } from '@bufferapp/publish-ig-direct-posting-modal';
 import { reducer as changePasswordReducer } from '@bufferapp/change-password';
 import { reducer as manageAppsReducer } from '@bufferapp/manage-apps-extras';
 import { reducer as twoFactorAuthReducer } from '@bufferapp/publish-two-factor-auth';
@@ -71,6 +72,7 @@ export default ({
   generalSettings: generalSettingsReducer,
   postingSchedule: postingScheduleReducer,
   profilesDisconnectedModal: profilesDisconnectedModalReducer,
+  instagramDirectPostingModal: instagramDirectPostingModalReducer,
   accountNotifications: accountNotificationsReducer,
   stealProfileModal: stealProfileModalReducer,
   lockedProfileNotification: lockedProfileNotificationReducer,


### PR DESCRIPTION
### Purpose
Remove IG new Authentication Flow Feature Flip.
Move Direct Posting actions from general-settings to ig-direct-posting-modal

### Notes
[PUB-1354](https://buffer.atlassian.net/browse/PUB-1354)
