### PR TITLE
Updated jest config so the test pass again

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,5 +16,8 @@ module.exports = {
   globals: {
     __PACKAGES__: '../packages',
   },
+  testPathIgnorePatterns: [
+    'package/sidebar/node_modules',
+  ],
   testURL: 'https://publish.local.buffer.com',
 };


### PR DESCRIPTION
### Purpose
The problem was that jest was trying to execute the tests in node_modules. I think this PR can solve that. 

### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
