### PR TITLE
Grid fixes in link saving

### DIFF
--- a/packages/grid/index.js
+++ b/packages/grid/index.js
@@ -55,6 +55,7 @@ export default connect(
         post,
         profileId: ownProps.profileId,
         link,
+        oldLink: post.link,
       }));
     },
     onSavePostUrl: (post, link) => {

--- a/packages/grid/middleware.js
+++ b/packages/grid/middleware.js
@@ -8,6 +8,8 @@ import { trackAction } from '@bufferapp/publish-data-tracking';
 import { actionTypes as gridActionTypes } from './reducer';
 import { isValidURL, getBaseURL } from './util';
 
+const urlHasProtocol = url => ((url.indexOf('https://') !== -1) || (url.indexOf('http://') !== -1));
+
 export default ({ getState, dispatch }) => next => (action) => { // eslint-disable-line no-unused-vars
   next(action);
   switch (action.type) {
@@ -47,11 +49,16 @@ export default ({ getState, dispatch }) => next => (action) => { // eslint-disab
     case gridActionTypes.SAVE_POST_URL:
       if (action.link) {
         if (isValidURL(action.link)) {
+          let link = action.link;
+          if (!urlHasProtocol(action.link)) {
+            link = `https://${link}`;
+          }
+
           dispatch(dataFetchActions.fetch({
             name: 'updatePostLink',
             args: {
               updateId: action.updateId,
-              link: action.link,
+              link,
             },
           }));
         } else {

--- a/packages/grid/reducer.js
+++ b/packages/grid/reducer.js
@@ -48,10 +48,16 @@ const postReducer = (state, action) => {
         isLightboxOpen: false,
       };
     case actionTypes.SAVE_POST_URL:
+      return {
+        ...state,
+        link: action.link,
+        oldLink: action.link,
+      };
     case actionTypes.UPDATE_POST_URL:
       return {
         ...state,
         link: action.link,
+        oldLink: action.oldLink || null,
       };
     default:
       return state;
@@ -168,12 +174,13 @@ export const actions = {
     post,
     profileId,
   }),
-  handleChangePostUrl: ({ post, profileId, link }) => ({
+  handleChangePostUrl: ({ post, profileId, link, oldLink }) => ({
     type: actionTypes.UPDATE_POST_URL,
     updateId: post.id,
     post,
     profileId,
     link,
+    oldLink,
   }),
   handleSavePostUrl: ({ post, profileId, link }) => ({
     type: actionTypes.SAVE_POST_URL,

--- a/packages/shared-components/GridList/index.jsx
+++ b/packages/shared-components/GridList/index.jsx
@@ -98,7 +98,9 @@ const GridListPost = ({
             onChangePostUrl(post, e.target.value);
           }}
           onBlur={(e) => {
-            onSavePostUrl(post, e.target.value);
+            if (post.oldLink && (post.oldLink !== post.link)) {
+              onSavePostUrl(post, e.target.value);
+            }
           }}
           size="small"
           name="postUrl"


### PR DESCRIPTION
### Purpose
Saving link only when has changed, prepending protocol for urls without it.

### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
