### PR TITLE
[PUB-1408] Remove Business upgrade path from Pro trialists

### DIFF
--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -48,6 +48,7 @@ class TabNavigation extends React.Component {
       selectedChildTabId,
       onTabClick,
       onChildTabClick,
+      onProTrial,
       shouldShowUpgradeCta,
       shouldShowNestedSettingsTab,
       shouldShowNestedAnalyticsTab,
@@ -106,19 +107,21 @@ class TabNavigation extends React.Component {
               </Button>
           </div>
         }
-        <FeatureLoader supportedPlans={'pro'}>
-          <div style={upgradeCtaStyle}>
-            <Button
-              secondary
-              onClick={(e) => {
-                e.preventDefault();
-                onUpgradeButtonClick('b4b');
-              }}
-            >
-              Learn about Buffer for Business
-            </Button>
-          </div>
-        </FeatureLoader>
+        {!onProTrial &&
+          <FeatureLoader supportedPlans={'pro'}>
+            <div style={upgradeCtaStyle}>
+              <Button
+                secondary
+                onClick={(e) => {
+                  e.preventDefault();
+                  onUpgradeButtonClick('b4b');
+                }}
+              >
+                Learn about Buffer for Business
+              </Button>
+            </div>
+          </FeatureLoader>
+        }
         {shouldShowNestedAnalyticsTab && !isLockedProfile &&
           <Tabs
             selectedTabId={selectedChildTabId || 'posts'}
@@ -165,6 +168,7 @@ TabNavigation.defaultProps = {
   isInstagramProfile: false,
   isBusinessAccount: false,
   isManager: false,
+  onProTrial: true,
 };
 
 TabNavigation.propTypes = {
@@ -176,6 +180,7 @@ TabNavigation.propTypes = {
   shouldShowUpgradeCta: PropTypes.bool.isRequired,
   onUpgradeButtonClick: PropTypes.func.isRequired,
   onChildTabClick: PropTypes.func.isRequired,
+  onProTrial: PropTypes.bool,
   selectedChildTabId: PropTypes.string,
   shouldShowNestedSettingsTab: PropTypes.bool,
   shouldShowNestedAnalyticsTab: PropTypes.bool,

--- a/packages/tabs/components/TabNavigation/story.jsx
+++ b/packages/tabs/components/TabNavigation/story.jsx
@@ -30,7 +30,7 @@ const store = storeFake({
   appSidebar: {
     user: {
       trial: {
-        onProTrial: false,
+        onTrial: false,
       }
     }
   }

--- a/packages/tabs/components/TabNavigation/story.jsx
+++ b/packages/tabs/components/TabNavigation/story.jsx
@@ -27,6 +27,13 @@ const store = storeFake({
     planName: 'free',
     features: {},
   },
+  appSidebar: {
+    user: {
+      trial: {
+        onProTrial: false,
+      }
+    }
+  }
 });
 
 const UpgradeModalDecorator = storyFn => (
@@ -105,5 +112,21 @@ storiesOf('TabNavigation', module)
       showUpgradeModal={action('show-upgrade-modal')}
       shouldShowUpgradeCta={false}
       onUpgradeButtonClick={action('on-upgrade-button-click')}
+    />
+  ))
+  .add('isOnProTrial', () => (
+    <TabNavigation
+      selectedTabId={'queue'}
+      onTabClick={action('tab-click')}
+      isBusinessAccount={false}
+      isManager={false}
+      isInstagramProfile
+      shouldShowNestedSettingsTab
+      selectedChildTabId={'general-settings'}
+      onChildTabClick={action('child-tab-click')}
+      showUpgradeModal={action('show-upgrade-modal')}
+      shouldShowUpgradeCta
+      onUpgradeButtonClick={action('on-upgrade-button-click')}
+      onProTrial={true}
     />
   ));

--- a/packages/tabs/components/TabNavigation/story.jsx
+++ b/packages/tabs/components/TabNavigation/story.jsx
@@ -113,20 +113,4 @@ storiesOf('TabNavigation', module)
       shouldShowUpgradeCta={false}
       onUpgradeButtonClick={action('on-upgrade-button-click')}
     />
-  ))
-  .add('isOnProTrial', () => (
-    <TabNavigation
-      selectedTabId={'queue'}
-      onTabClick={action('tab-click')}
-      isBusinessAccount={false}
-      isManager={false}
-      isInstagramProfile
-      shouldShowNestedSettingsTab
-      selectedChildTabId={'general-settings'}
-      onChildTabClick={action('child-tab-click')}
-      showUpgradeModal={action('show-upgrade-modal')}
-      shouldShowUpgradeCta
-      onUpgradeButtonClick={action('on-upgrade-button-click')}
-      onProTrial={true}
-    />
   ));

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -14,6 +14,7 @@ export default connect(
     isManager: state.profileSidebar.selectedProfile.isManager,
     selectedTabId: ownProps.tabId,
     selectedChildTabId: ownProps.childTabId,
+    onProTrial: state.appSidebar.user.trial.onTrial,
     shouldShowUpgradeCta: state.appSidebar.user.is_free_user,
     shouldShowNestedSettingsTab: ownProps.tabId === 'settings',
     shouldShowNestedAnalyticsTab: ownProps.tabId === 'analytics',


### PR DESCRIPTION
### Purpose
Remove the 'Learn about Buffer for Business' option when users are trialing Pro Publish. 
### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`