### PR TITLE
[PUB-1414] Hide Analytics Overview tab for Business Trialists using Pinterest/LinkedIn

### DIFF
--- a/packages/analytics/components/Notification/index.jsx
+++ b/packages/analytics/components/Notification/index.jsx
@@ -32,7 +32,7 @@ const getNotificationCopy = (service, isInstagramBusiness) => {
       </div>
     );
   }
-  return (<div>We only support Facebook & Twitter profiles in our analytics right now.</div>);
+  return (<div>We only support Facebook, Instagram, & Twitter profiles in our analytics right now.</div>);
 };
 
 const getTitleCopy = (service, isInstagramBusiness) => {

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -165,7 +165,7 @@ TabNavigation.defaultProps = {
   shouldShowUpgradeCta: false,
   shouldShowNestedSettingsTab: false,
   shouldShowNestedAnalyticsTab: false,
-  shouldHideAnalyticsOverviewTab: true,
+  shouldHideAnalyticsOverviewTab: false,
   selectedChildTabId: null,
   profileId: null,
   isLockedProfile: false,

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -52,6 +52,7 @@ class TabNavigation extends React.Component {
       shouldShowUpgradeCta,
       shouldShowNestedSettingsTab,
       shouldShowNestedAnalyticsTab,
+      shouldHideAnalyticsOverviewTab,
       onUpgradeButtonClick,
       profileId,
       isLockedProfile,
@@ -129,7 +130,9 @@ class TabNavigation extends React.Component {
             secondary
           >
             <Tab tabId={'posts'}>Posts</Tab>
-            <Tab tabId={'overview'}>Overview</Tab>
+            {!shouldHideAnalyticsOverviewTab && 
+              <Tab tabId={'overview'}>Overview</Tab>
+            }
           </Tabs>
         }
         {shouldShowNestedSettingsTab && !isLockedProfile &&
@@ -162,6 +165,7 @@ TabNavigation.defaultProps = {
   shouldShowUpgradeCta: false,
   shouldShowNestedSettingsTab: false,
   shouldShowNestedAnalyticsTab: false,
+  shouldHideAnalyticsOverviewTab: true,
   selectedChildTabId: null,
   profileId: null,
   isLockedProfile: false,
@@ -184,6 +188,7 @@ TabNavigation.propTypes = {
   selectedChildTabId: PropTypes.string,
   shouldShowNestedSettingsTab: PropTypes.bool,
   shouldShowNestedAnalyticsTab: PropTypes.bool,
+  shouldHideAnalyticsOverviewTab: PropTypes.bool,
   profileId: PropTypes.string,
   isLockedProfile: PropTypes.bool,
   isInstagramProfile: PropTypes.bool,

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -14,10 +14,14 @@ export default connect(
     isManager: state.profileSidebar.selectedProfile.isManager,
     selectedTabId: ownProps.tabId,
     selectedChildTabId: ownProps.childTabId,
-    onProTrial: state.appSidebar.user.trial.onTrial,
+    onProTrial: state.appSidebar.user.trial.onTrial && !state.profileSidebar.selectedProfile.business,
     shouldShowUpgradeCta: state.appSidebar.user.is_free_user,
     shouldShowNestedSettingsTab: ownProps.tabId === 'settings',
     shouldShowNestedAnalyticsTab: ownProps.tabId === 'analytics',
+    shouldHideAnalyticsOverviewTab: state.profileSidebar.selectedProfile.business && 
+                                    state.appSidebar.user.trial.onTrial && 
+                                    (state.profileSidebar.selectedProfile.type === 'linkedin' 
+                                    || state.profileSidebar.selectedProfile.type === 'pinterest'),
     profileId: ownProps.profileId,
     isLockedProfile: state.profileSidebar.isLockedProfile,
     isInstagramProfile: state.generalSettings.isInstagramProfile,


### PR DESCRIPTION
### Purpose
Hides the Overview tab under Analytics for Pinterest and LinkedIn accounts for Business trialists new to New Publish only. 
### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`