### PR TITLE
Fix profile page story

### DIFF
--- a/packages/profile-page/components/ProfilePage/story.jsx
+++ b/packages/profile-page/components/ProfilePage/story.jsx
@@ -10,24 +10,7 @@ import { checkA11y } from 'storybook-addon-a11y';
 import ProfilePage from './index';
 
 const history = createHistory();
-
-const storeFake = state => ({
-  default: () => {},
-  subscribe: () => {},
-  dispatch: () => {},
-  getState: () => ({ ...state }),
-});
-
-const store = storeFake({
-  appSidebar: {
-    user: {
-      trial: {
-        onTrial: false,
-      }
-    }
-  }
-});
-
+const store = createStore();
 const stubbedHistory = {
   location: {
     pathname: '/profile/1234/tab/queue',

--- a/packages/profile-page/components/ProfilePage/story.jsx
+++ b/packages/profile-page/components/ProfilePage/story.jsx
@@ -10,7 +10,24 @@ import { checkA11y } from 'storybook-addon-a11y';
 import ProfilePage from './index';
 
 const history = createHistory();
-const store = createStore();
+
+const storeFake = state => ({
+  default: () => {},
+  subscribe: () => {},
+  dispatch: () => {},
+  getState: () => ({ ...state }),
+});
+
+const store = storeFake({
+  appSidebar: {
+    user: {
+      trial: {
+        onTrial: false,
+      }
+    }
+  }
+});
+
 const stubbedHistory = {
   location: {
     pathname: '/profile/1234/tab/queue',

--- a/packages/tabs/components/TabNavigation/story.jsx
+++ b/packages/tabs/components/TabNavigation/story.jsx
@@ -56,6 +56,7 @@ storiesOf('TabNavigation', module)
       showUpgradeModal={action('show-upgrade-modal')}
       shouldShowUpgradeCta
       onUpgradeButtonClick={action('on-upgrade-button-click')}
+      onProTrial
     />
   ))
   .add('isInstagramProfile', () => (
@@ -71,6 +72,7 @@ storiesOf('TabNavigation', module)
       showUpgradeModal={action('show-upgrade-modal')}
       shouldShowUpgradeCta
       onUpgradeButtonClick={action('on-upgrade-button-click')}
+      onProTrial
     />
   ))
   .add('should show grid tab', () => (
@@ -84,6 +86,7 @@ storiesOf('TabNavigation', module)
       showUpgradeModal={action('show-upgrade-modal')}
       shouldShowUpgradeCta
       onUpgradeButtonClick={action('on-upgrade-button-click')}
+      onProTrial
     />
   ))
   .add('isContributor', () => (
@@ -98,6 +101,7 @@ storiesOf('TabNavigation', module)
       showUpgradeModal={action('show-upgrade-modal')}
       shouldShowUpgradeCta={false}
       onUpgradeButtonClick={action('on-upgrade-button-click')}
+      onProTrial
     />
   ))
   .add('isManager, isBusinessAccount', () => (
@@ -112,5 +116,6 @@ storiesOf('TabNavigation', module)
       showUpgradeModal={action('show-upgrade-modal')}
       shouldShowUpgradeCta={false}
       onUpgradeButtonClick={action('on-upgrade-button-click')}
+      onProTrial
     />
   ));

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -14,7 +14,7 @@ export default connect(
     isManager: state.profileSidebar.selectedProfile.isManager,
     selectedTabId: ownProps.tabId,
     selectedChildTabId: ownProps.childTabId,
-    onProTrial: state.appSidebar.user.trial.onTrial,
+    onProTrial: state.appSidebar.user.trial && state.appSidebar.user.trial.onTrial,
     shouldShowUpgradeCta: state.appSidebar.user.is_free_user,
     shouldShowNestedSettingsTab: ownProps.tabId === 'settings',
     shouldShowNestedAnalyticsTab: ownProps.tabId === 'analytics',


### PR DESCRIPTION
### Purpose
Profile Page stories were failing because of a check for a user being on a trial. The value was undefined at the time of the check. 
### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
