### PR TITLE
CORE-577 global.userId won't be available to get the publish user id from the …

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -220,7 +220,7 @@ app.get('/health-check', controller.healthCheck);
 app.use(
   validateSessionMiddleware({
     production: isProduction,
-    requiredSessionKeys: ['publish.accessToken', 'global.userId'],
+    requiredSessionKeys: ['publish.accessToken', 'publish.foreignKey'],
   }),
 );
 
@@ -253,7 +253,7 @@ const getNotificationFromQuery = (query) => {
 
 app.get('*', (req, res) => {
   const notification = getNotificationFromQuery(req.query);
-  const userId = req.session.global.userId;
+  const userId = req.session.publish.foreignKey;
   const modalKey = req.query.mk ? req.query.mk : null;
   const modalValue = req.query.mv ? req.query.mv : null;
   res.send(getHtml({

--- a/packages/server/middleware.js
+++ b/packages/server/middleware.js
@@ -10,7 +10,7 @@ module.exports.apiError = (err, req, res, next) => { // eslint-disable-line no-u
   } else if (req.app.get('isProduction')) {
     req.app.get('bugsnag').notify(err, {
       originalUrl: req.originalUrl,
-      user: { id: req.session.global.userId },
+      user: { id: req.session.publish.foreignKey },
     });
     res.status(500).send({
       error: 'Whoops something went wrong! We\'ve been alerted and will be sure to take a look',


### PR DESCRIPTION
> This PR requires [this session-service PR](https://github.com/bufferapp/core-session-service/pull/11) to be merged first

Related to [CORE-572](https://buffer.atlassian.net/browse/CORE-572)

### Purpose

global.userId won't be available inthe future to get the publish user id from the session. This PR uses `publish.foreignKey` instead.

### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
