### PR TITLE
Display upgrade modal when user reaches end of pro trial

### DIFF
--- a/packages/analytics/index.js
+++ b/packages/analytics/index.js
@@ -8,7 +8,7 @@ export default connect(
     isBusinessAccount: state.profileSidebar.selectedProfile.business,
     isInstagramBusiness: state.profileSidebar.selectedProfile.isInstagramBusiness,
     isAnalyticsSupported: state.profileSidebar.selectedProfile.isAnalyticsSupported,
-    // TODO: Refactor so we're not pulling this state from drafts
+    //  TODO: Refactor so we're not pulling this state from drafts
     canStartBusinessTrial: state.drafts.canStartBusinessTrial,
 
   }),

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -36,9 +36,12 @@
   },
   "upgrade-modal": {
     "proUpgradeHeader": "Upgrade to the Pro Plan!",
+    "proTrialistUpgradeHeader": "Complete your trial and upgrade to the Pro Plan!",
     "proPlanSocialAccounts": "Connect up to 8 social accounts, including Pinterest",
     "proPlanFiltering": "Get powerful post filtering on your recent posts",
     "proPlanCuration": "Curate your content with RSS integrations",
+    "proPlanIGCover": "Create custom covers for Instagram videos",
+    "proPlanIGFirstComment": "Add a first comment to your Instagram posts",
     "proPlanScheduling": "Schedule 100 posts per social account",
     "proPlanCalendar": "Manage everything at a glance with the Social Media Calendar",
     "proPlanBitly": "Shorten your links with Bitly",
@@ -56,9 +59,10 @@
     "securityCode": "Security code",
     "zipCode": "Zip code",
     "zipLeaveBlank": "Leave blank for non-US cards",
-    "upgradeCta": "Upgrade to the Pro Plan!",
+    "upgradeCta": "Upgrade to the Pro Plan",
     "validating": "One moment...",
-    "stayOnFreeCta": "Stay on the Free Plan for now"
+    "stayOnFreeCta": "Stay on the Free Plan for now",
+    "proTrialistStayOnFreeCta": "Downgrade to the Free Plan"
   },
   "welcome-modal": {
     "headline": "We've refreshed the look of Buffer",

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -37,6 +37,7 @@
   "upgrade-modal": {
     "proUpgradeHeader": "Upgrade to the Pro Plan!",
     "proTrialistUpgradeHeader": "Complete your trial and upgrade to the Pro Plan!",
+    "proTrialistSubCopy": "The Pro plan includes up to 8 social accounts, custom thumbnails for Instagram videos, Instagram first comment and more.",
     "proPlanSocialAccounts": "Connect up to 8 social accounts, including Pinterest",
     "proPlanFiltering": "Get powerful post filtering on your recent posts",
     "proPlanCuration": "Curate your content with RSS integrations",

--- a/packages/modals/middleware.js
+++ b/packages/modals/middleware.js
@@ -51,13 +51,16 @@ export default ({ dispatch, getState }) => next => (action) => {
     case `user_${dataFetchActionTypes.FETCH_SUCCESS}`: {
       const message = 'welcome_to_business_modal';
       const { productFeatures: { planName } } = getState();
-      const { messages: readMessages, trial } = action.result; // user
+      const { messages: readMessages, trial, shouldShowProTrialExpiredModal } = action.result; // user
       const hasNotReadWelcomeMessage = readMessages && !readMessages.includes(message);
       const isOnBusinessTrial = planName === 'business' && trial.onTrial;
       if (isOnBusinessTrial && hasNotReadWelcomeMessage) {
         dispatch(actions.showWelcomeB4BTrialModal());
         // Mark modal as seen
         dispatch(dataFetchActions.fetch({ name: 'readMessage', args: { message } }));
+        // if user is free, subscription hasn't been cancelled, hasExpiredProTrial
+      } else if (shouldShowProTrialExpiredModal) {
+        dispatch(actions.showUpgradeModal({ source: 'pro_trial_expired_modal' }));
       }
       break;
     }

--- a/packages/modals/middleware.js
+++ b/packages/modals/middleware.js
@@ -60,7 +60,7 @@ export default ({ dispatch, getState }) => next => (action) => {
         dispatch(dataFetchActions.fetch({ name: 'readMessage', args: { message } }));
         // if user is free, subscription hasn't been cancelled, hasExpiredProTrial
       } else if (shouldShowProTrialExpiredModal) {
-        dispatch(actions.showUpgradeModal({ source: 'pro_trial_expired_modal' }));
+        dispatch(actions.showUpgradeModal({ source: 'pro_trial_expired' }));
       }
       break;
     }

--- a/packages/modals/reducer.js
+++ b/packages/modals/reducer.js
@@ -1,5 +1,4 @@
 import keyWrapper from '@bufferapp/keywrapper';
-import { actionTypes as upgradeModalActionTypes } from '@bufferapp/publish-upgrade-modal';
 
 export const initialState = {
   showUpgradeModal: false,
@@ -42,7 +41,6 @@ export default (state = initialState, action) => {
         upgradeModalSource: action.source,
       };
     case actionTypes.HIDE_UPGRADE_MODAL:
-    case upgradeModalActionTypes.CANCEL_TRIAL:
       return {
         ...state,
         showUpgradeModal: false,

--- a/packages/modals/reducer.js
+++ b/packages/modals/reducer.js
@@ -1,4 +1,5 @@
 import keyWrapper from '@bufferapp/keywrapper';
+import { actionTypes as upgradeModalActionTypes } from '@bufferapp/publish-upgrade-modal';
 
 export const initialState = {
   showUpgradeModal: false,

--- a/packages/modals/reducer.js
+++ b/packages/modals/reducer.js
@@ -42,6 +42,7 @@ export default (state = initialState, action) => {
         upgradeModalSource: action.source,
       };
     case actionTypes.HIDE_UPGRADE_MODAL:
+    case upgradeModalActionTypes.CANCEL_TRIAL:
       return {
         ...state,
         showUpgradeModal: false,

--- a/packages/pusher-sync/package.json
+++ b/packages/pusher-sync/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@bufferapp/publish-profile-sidebar": "2.0.0",
     "@bufferapp/publish-queue": "2.0.0",
-    "@bufferapp/publish-parsers": "1.16.0",
+    "@bufferapp/publish-parsers": "1.16.1",
     "pusher-js": "4.1.0"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,7 +13,7 @@
     "@bufferapp/logger": "0.7.0",
     "@bufferapp/micro-rpc": "0.1.7",
     "@bufferapp/publish-formatters": "1.9.31",
-    "@bufferapp/publish-parsers": "1.16.0",
+    "@bufferapp/publish-parsers": "1.16.1",
     "@bufferapp/session-manager": "0.7.1",
     "@bufferapp/shutdown-helper": "0.2.0",
     "@bugsnag/js": "^5.0.1",

--- a/packages/server/rpc/cancelTrial/index.js
+++ b/packages/server/rpc/cancelTrial/index.js
@@ -19,7 +19,7 @@ module.exports = method(
       });
     } catch (response) {
       throw createError({
-        message: response.error,
+        message: JSON.stringify(response.error.error),
       });
     }
     return result;

--- a/packages/server/rpc/cancelTrial/index.js
+++ b/packages/server/rpc/cancelTrial/index.js
@@ -1,0 +1,27 @@
+const { method, createError } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+module.exports = method(
+  'cancelTrial',
+  'cancel trial',
+  async ({ token }, { session }) => {
+    let result;
+    try {
+      result = await rp({
+        uri: `${process.env.API_ADDR}/1/billing/cancel-trial.json`,
+        method: 'POST',
+        strictSSL: process.env.NODE_ENV !== 'development',
+        json: true,
+        form: {
+          access_token: session.publish.accessToken,
+          product: 'publish',
+        },
+      });
+    } catch (response) {
+      throw createError({
+        message: response.error,
+      });
+    }
+    return result;
+  },
+);

--- a/packages/server/rpc/changeDateTimePreferences/test.js
+++ b/packages/server/rpc/changeDateTimePreferences/test.js
@@ -15,6 +15,7 @@ const mockUser = {
   messages: [],
   plan: 'free',
   email_notifications: [],
+  feature_trials: [],
 };
 describe('rpc/changeDateTimePreferences', () => {
   beforeEach(() => {

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -54,6 +54,7 @@ const gridPosts = require('./grid');
 const shortenUrl = require('./shortenUrl');
 const updatePostLink = require('./updatePostLink');
 const dropPost = require('./dropPost');
+const cancelTrial = require('./cancelTrial');
 
 // Analytics from Analyze -- Delete when we switch to Analyze
 const analyticsStartDate = require('./analytics/analyticsStartDate');
@@ -126,4 +127,5 @@ module.exports = rpc(
   shortenUrl,
   updatePostLink,
   dropPost,
+  cancelTrial,
 );

--- a/packages/server/rpc/upgradeToPro/index.js
+++ b/packages/server/rpc/upgradeToPro/index.js
@@ -9,6 +9,7 @@ const sourceCtaMap = new Map([
   ['pinterest', 'publish-orgAdmin-connect-upgradeToConnectPinterest-1'],
   ['org_admin', 'publish-orgAdmin-planOverview-upgradeForMore-1'],
   ['locked_profile', 'publish-app-lockedProfileTabs-tabsLimitUpgrade-1'],
+  ['pro_trial_expired', 'publish-app-onLoad-proTrialExpired-1'],
 ]);
 const getCtaFromSource = source =>
   sourceCtaMap.get(source) || (`publish-${source || 'unknown'}`);

--- a/packages/stripe/middleware.test.js
+++ b/packages/stripe/middleware.test.js
@@ -69,15 +69,6 @@ describe('middleware', () => {
     validateCreditCard();
   });
 
-  it('if upgraded to pro, it redirects to classic Buffer', () => {
-    window.location.assign = jest.fn();
-    const action = {
-      type: `upgradeToPro_${asyncDataFetchActionTypes.FETCH_SUCCESS}`,
-    };
-    middleware(store)(next)(action);
-    expect(window.location.assign).toHaveBeenCalledWith('https://local.buffer.com/classic');
-  });
-
   describe('error handling', () => {
     it('should trigger a throwValidationError action if response has an error message', (done) => {
       global.Stripe.createToken = (card, cb) => {

--- a/packages/upgrade-modal/components/UpgradeModal/index.jsx
+++ b/packages/upgrade-modal/components/UpgradeModal/index.jsx
@@ -51,6 +51,7 @@ const UpgradeModal = ({
   hideModal,
   isNonprofit,
   hasExpiredProTrial,
+  cancelTrial,
 }) => (<div style={{ position: 'fixed', zIndex: '3000' }}>
   <Popover onOverlayClick={hideModal}>
     <div style={{ maxHeight: '100vh', overflow: 'auto' }}>
@@ -151,7 +152,7 @@ const UpgradeModal = ({
                 {validating ? translations.validating : translations.upgradeCta}
               </Button>
               <br /><br />
-              <Button secondary large borderless onClick={hideModal}>
+              <Button secondary large borderless onClick={hasExpiredProTrial ? cancelTrial : hideModal}>
                 {
                   hasExpiredProTrial
                   ? translations.proTrialistStayOnFreeCta
@@ -174,6 +175,7 @@ UpgradeModal.propTypes = {
   validating: PropTypes.bool.isRequired,
   selectCycle: PropTypes.func.isRequired,
   hideModal: PropTypes.func.isRequired,
+  cancelTrial: PropTypes.func.isRequired,
   isNonprofit: PropTypes.bool.isRequired,
   hasExpiredProTrial: PropTypes.bool,
 };

--- a/packages/upgrade-modal/components/UpgradeModal/index.jsx
+++ b/packages/upgrade-modal/components/UpgradeModal/index.jsx
@@ -59,23 +59,36 @@ const UpgradeModal = ({
         <div style={{ maxWidth: '100vw', overflow: 'auto' }}>
           <div style={{ width: '550px', padding: '0 25px' }}>
             <div style={{ textAlign: 'center', margin: '0 0 1rem 0' }}>
-              <Text size="large" color="outerSpace">{hasExpiredProTrial ? translations.proTrialistUpgradeHeader : translations.proUpgradeHeader}</Text>
+              <Text size="large" color="outerSpace">
+                {hasExpiredProTrial
+                  ? translations.proTrialistUpgradeHeader
+                  : translations.proUpgradeHeader }
+              </Text>
             </div>
-            <div style={{ display: 'flex' }}>
-              <div style={{ flex: '1' }}>
-                <ul style={listStyleLeft}>
-                  <ListItem text={translations.proPlanSocialAccounts} />
-                  <ListItem text={translations.proPlanIGFirstComment} />
-                  <ListItem text={translations.proPlanScheduling} />
-                </ul>
-              </div>
-              <div style={{ flex: '1' }}>
-                <ul style={listStyle}>
-                  <ListItem text={translations.proPlanCalendar} />
-                  <ListItem text={translations.proPlanIGCover} />
-                  <ListItem text={translations.proPlanBitly} />
-                </ul>
-              </div>
+            <div>
+              {hasExpiredProTrial &&
+                <div style={{ textAlign: 'center' }}>
+                  <Text>{translations.proTrialistSubCopy}</Text>
+                </div>
+              }
+              {!hasExpiredProTrial &&
+                <div style={{ display: 'flex' }}>
+                  <div style={{ flex: '1' }}>
+                    <ul style={listStyleLeft}>
+                      <ListItem text={translations.proPlanSocialAccounts} />
+                      <ListItem text={translations.proPlanFiltering} />
+                      <ListItem text={translations.proPlanCuration} />
+                    </ul>
+                  </div>
+                  <div style={{ flex: '1' }}>
+                    <ul style={listStyle}>
+                      <ListItem text={translations.proPlanScheduling} />
+                      <ListItem text={translations.proPlanCalendar} />
+                      <ListItem text={translations.proPlanBitly} />
+                    </ul>
+                  </div>
+                </div>
+              }
             </div>
 
             <Divider marginTop="" marginBottom="1.5rem" />

--- a/packages/upgrade-modal/components/UpgradeModal/index.jsx
+++ b/packages/upgrade-modal/components/UpgradeModal/index.jsx
@@ -50,6 +50,7 @@ const UpgradeModal = ({
   selectCycle,
   hideModal,
   isNonprofit,
+  hasExpiredProTrial,
 }) => (<div style={{ position: 'fixed', zIndex: '3000' }}>
   <Popover onOverlayClick={hideModal}>
     <div style={{ maxHeight: '100vh', overflow: 'auto' }}>
@@ -57,21 +58,20 @@ const UpgradeModal = ({
         <div style={{ maxWidth: '100vw', overflow: 'auto' }}>
           <div style={{ width: '550px', padding: '0 25px' }}>
             <div style={{ textAlign: 'center', margin: '0 0 1rem 0' }}>
-              <Text size="large" color="outerSpace">{translations.proUpgradeHeader}</Text>
+              <Text size="large" color="outerSpace">{hasExpiredProTrial ? translations.proTrialistUpgradeHeader : translations.proUpgradeHeader}</Text>
             </div>
-
             <div style={{ display: 'flex' }}>
               <div style={{ flex: '1' }}>
                 <ul style={listStyleLeft}>
                   <ListItem text={translations.proPlanSocialAccounts} />
-                  <ListItem text={translations.proPlanFiltering} />
-                  <ListItem text={translations.proPlanCuration} />
+                  <ListItem text={translations.proPlanIGFirstComment} />
+                  <ListItem text={translations.proPlanScheduling} />
                 </ul>
               </div>
               <div style={{ flex: '1' }}>
                 <ul style={listStyle}>
-                  <ListItem text={translations.proPlanScheduling} />
                   <ListItem text={translations.proPlanCalendar} />
+                  <ListItem text={translations.proPlanIGCover} />
                   <ListItem text={translations.proPlanBitly} />
                 </ul>
               </div>
@@ -152,7 +152,11 @@ const UpgradeModal = ({
               </Button>
               <br /><br />
               <Button secondary large borderless onClick={hideModal}>
-                {translations.stayOnFreeCta}
+                {
+                  hasExpiredProTrial
+                  ? translations.proTrialistStayOnFreeCta
+                  : translations.stayOnFreeCta
+                }
               </Button>
             </div>
           </div>
@@ -171,6 +175,11 @@ UpgradeModal.propTypes = {
   selectCycle: PropTypes.func.isRequired,
   hideModal: PropTypes.func.isRequired,
   isNonprofit: PropTypes.bool.isRequired,
+  hasExpiredProTrial: PropTypes.bool,
+};
+
+UpgradeModal.defaultProps = {
+  hasExpiredProTrial: false,
 };
 
 export default UpgradeModal;

--- a/packages/upgrade-modal/index.js
+++ b/packages/upgrade-modal/index.js
@@ -10,12 +10,14 @@ export default connect(
     translations: state.i18n.translations['upgrade-modal'],
     validating: state.stripe.validating,
     isNonprofit: state.appSidebar.user.isNonprofit,
+    hasExpiredProTrial: state.appSidebar.user.shouldShowProTrialExpiredModal,
   }),
   dispatch => ({
     storeValue: (id, value) => dispatch(actions.storeValue(id, value)),
     upgradePlan: () => dispatch(actions.upgrade()),
     selectCycle: cycle => dispatch(actions.selectCycle(cycle)),
     hideModal: () => dispatch(modalsActions.hideUpgradeModal()),
+    cancelTrial: () => dispatch(actions.cancelTrial()),
   }),
 )(UpgradeModal);
 

--- a/packages/upgrade-modal/middleware.js
+++ b/packages/upgrade-modal/middleware.js
@@ -1,5 +1,10 @@
 import { trackAction } from '@bufferapp/publish-data-tracking';
+import {
+  actionTypes as dataFetchActionTypes,
+  actions as dataFetchActions,
+} from '@bufferapp/async-data-fetch';
 import { actions as stripeActions } from '@bufferapp/stripe';
+import { actions as notificationActions } from '@bufferapp/notifications';
 import { actionTypes as modalsActionTypes } from '@bufferapp/publish-modals';
 import { actionTypes } from './reducer';
 

--- a/packages/upgrade-modal/middleware.js
+++ b/packages/upgrade-modal/middleware.js
@@ -27,6 +27,23 @@ export default ({ getState, dispatch }) => next => (action) => { // eslint-disab
       });
       break;
     }
+    case actionTypes.CANCEL_TRIAL: {
+      dispatch(dataFetchActions.fetch({
+        name: 'cancelTrial',
+      }));
+      trackAction({
+        location: 'MODALS',
+        action: 'cancel_expired_pro_trial',
+      });
+      break;
+    }
+    case `cancelTrial_${dataFetchActionTypes.FETCH_FAIL}`: {
+      dispatch(notificationActions.createNotification({
+        notificationType: 'error',
+        message: action.error,
+      }));
+      break;
+    }
     case modalsActionTypes.HIDE_UPGRADE_MODAL: {
       trackAction({
         application: 'PUBLISH',

--- a/packages/upgrade-modal/middleware.js
+++ b/packages/upgrade-modal/middleware.js
@@ -5,7 +5,7 @@ import {
 } from '@bufferapp/async-data-fetch';
 import { actions as stripeActions } from '@bufferapp/stripe';
 import { actions as notificationActions } from '@bufferapp/notifications';
-import { actionTypes as modalsActionTypes } from '@bufferapp/publish-modals';
+import { actionTypes as modalsActionTypes, actions as modalActions } from '@bufferapp/publish-modals';
 import { actionTypes } from './reducer';
 
 export default ({ getState, dispatch }) => next => (action) => { // eslint-disable-line
@@ -33,12 +33,12 @@ export default ({ getState, dispatch }) => next => (action) => { // eslint-disab
       break;
     }
     case actionTypes.CANCEL_TRIAL: {
-      dispatch(dataFetchActions.fetch({
-        name: 'cancelTrial',
-      }));
+      dispatch(dataFetchActions.fetch({ name: 'cancelTrial' }));
+      dispatch(modalActions.hideUpgradeModal());
       trackAction({
         location: 'MODALS',
         action: 'cancel_expired_pro_trial',
+        metadata: { source },
       });
       break;
     }
@@ -51,7 +51,6 @@ export default ({ getState, dispatch }) => next => (action) => { // eslint-disab
     }
     case modalsActionTypes.HIDE_UPGRADE_MODAL: {
       trackAction({
-        application: 'PUBLISH',
         location: 'MODALS',
         action: 'hide_upgrade_to_pro',
         metadata: { source },

--- a/packages/upgrade-modal/middleware.test.js
+++ b/packages/upgrade-modal/middleware.test.js
@@ -43,7 +43,6 @@ describe('middleware', () => {
 
       expect(trackAction)
         .toBeCalledWith({
-          application: 'PUBLISH',
           location: 'MODALS',
           action: 'hide_upgrade_to_pro',
           metadata: { source: 'source' },

--- a/packages/upgrade-modal/reducer.js
+++ b/packages/upgrade-modal/reducer.js
@@ -5,6 +5,7 @@ export const actionTypes = keyWrapper('UPGRADE_MODAL', {
   STORE_VALUE: 0,
   UPGRADE: 0,
   SELECT_CYCLE: 0,
+  CANCEL_TRIAL: 0,
 });
 
 export const initialState = {
@@ -55,5 +56,8 @@ export const actions = {
   selectCycle: cycle => ({
     type: actionTypes.SELECT_CYCLE,
     cycle,
+  }),
+  cancelTrial: () => ({
+    type: actionTypes.CANCEL_TRIAL,
   }),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -567,10 +567,10 @@
     moment "2.19.3"
     moment-timezone "0.5.13"
 
-"@bufferapp/publish-parsers@1.16.0":
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/@bufferapp/publish-parsers/-/publish-parsers-1.16.0.tgz#0514d7baa98271dae72beab5cac60500b1bc0a63"
-  integrity sha512-wuFjLKYyvyknRhnzsuDyJHkc0/wgEmlApFH8oZy8XYyteGcwpEYjBDFAC0Kp8x8/YINrgR5TUUuOT6xsU+bdBQ==
+"@bufferapp/publish-parsers@1.16.1":
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/@bufferapp/publish-parsers/-/publish-parsers-1.16.1.tgz#f871b5aeabb9cd9eb53151a8e5b4ccc70d0e75e7"
+  integrity sha512-0qYyj71SShfjjzgXUgIRxlSz3qkyADxQ/oQZUpMv5lcHSElJlZfFSpvs1FJSQeOTanzx5Zg96/AigWCZWSBJkA==
   dependencies:
     "@bufferapp/publish-formatters" "1.9.29"
     twitter-text "3.0.0"


### PR DESCRIPTION
### Purpose
https://buffer.atlassian.net/browse/PUB-1399
If the user gets to the end of the trial and doesn't have any credit card information entered, they should see an upgrade modal prompting them to upgrade to Pro upon next time they load up Buffer, refresh, etc (or as a secondary, minor CTA of downgrade to Free) 
### Notes
We may need to confirm that a user is automatically enrolled if they've entered credit card information. Currently not checking the logic to see if user has already entered credit card information before showing modal.
### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
