### PR TITLE
Add HTTP method to composer API proxy requests

### DIFF
--- a/packages/composer-popover/package.json
+++ b/packages/composer-popover/package.json
@@ -8,7 +8,7 @@
   },
   "author": "ana@buffer.com",
   "dependencies": {
-    "@bufferapp/composer": "3.3.1"
+    "@bufferapp/composer": "3.4.0"
   },
   "devDependencies": {
     "eslint": "3.19.0"

--- a/packages/server/rpc/composerApiProxy/index.js
+++ b/packages/server/rpc/composerApiProxy/index.js
@@ -4,20 +4,22 @@ const rp = require('request-promise');
 module.exports = method(
   'composerApiProxy',
   'communicate with buffer api',
-  async ({ url, args }, { session }) => {
+  async ({ url, args, HTTPMethod = 'POST' }, { session }) => {
     let result;
     try {
-      result = await rp({
+      const fieldName = HTTPMethod === 'POST' ? 'form' : 'qs';
+      const requestParams = {
         uri: `${process.env.API_ADDR}${url}`,
-        method: 'POST',
+        method: HTTPMethod,
         strictSSL: process.env.NODE_ENV !== 'development',
-        form: Object.assign(args, {
-          access_token: session.publish.accessToken,
-        }),
+      };
+      requestParams[fieldName] = Object.assign(args, {
+        access_token: session.publish.accessToken,
       });
+
+      result = await rp(requestParams);
     } catch (err) {
       if (err.error) {
-        // debugger;
         // Catch and pass through Buffer API errors
         return Promise.resolve(JSON.parse(err.error));
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,10 +342,10 @@
     react-autocomplete "1.7.2"
     react-day-picker "6.2.1"
 
-"@bufferapp/composer@3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-3.3.1.tgz#08cee7a0cf8a7e431e352331fb779c521e205ba2"
-  integrity sha512-mKYSkJ1njzgXJViCOeQIf6thmn8R+nUR94vtkIE7+SDz33Umz+NJBzjzXUZ3zc3NpJ+hSnjmKc6o8HuYoFkBBA==
+"@bufferapp/composer@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@bufferapp/composer/-/composer-3.4.0.tgz#79bf90071bcb917e3b49b943b129645e22275899"
+  integrity sha512-KeEzwRSOiRWYWpv1iVx10AM9rmg1HmfhDi0OQ12nF6b3OBGHGCxtnvQjOyGyfTTWGiqn1PMNm/9yXhGBvKsssQ==
   dependencies:
     "@bufferapp/buffer-js-api" "0.3.0"
     "@bufferapp/buffer-js-metrics" "0.2.0"


### PR DESCRIPTION
### Purpose
This fixes this issue: https://buffer.atlassian.net/browse/PUB-1017 by accepting an HTTP method param that we get from the composer.

### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
