### PR TITLE
Instagram first comment modal for New Publish users

### DIFF
--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -93,6 +93,12 @@
     "continue": "Continue",
     "cancel": "Cancel"
   },
+  "instagram-new-first-comment-user-modal": {
+    "heading": "Include a first comment when you schedule a post to Instagram.",
+    "mainContent": "Want to keep hashtags out of your Instagram caption? You can now include a comment when you schedule an Instagram post, and Buffer will automatically publish it for you.",
+    "continue": "Continue",
+    "imageAlt": "Publish your first comment directly to Instagram"
+  },
   "profiles-disconnected-modal": {
     "headline": "We’ve lost access to some of your social accounts",
     "body1": "We’ve lost access to the following social accounts, in order for us to resume posting to these accounts you will need to reconnect them.",

--- a/packages/ig-new-first-comment-user-modal/README.md
+++ b/packages/ig-new-first-comment-user-modal/README.md
@@ -1,0 +1,4 @@
+# @bufferapp/publish-ig-new-first-comment-user-modal
+
+A modal prompting users that they now have access to Instagram first comment
+this is handled using the readMessage feature

--- a/packages/ig-new-first-comment-user-modal/components/InstagramNewFirstCommentUserModal/InstagramNewFirstCommentUserModal.css
+++ b/packages/ig-new-first-comment-user-modal/components/InstagramNewFirstCommentUserModal/InstagramNewFirstCommentUserModal.css
@@ -1,0 +1,61 @@
+.headerDivBG {
+  background-image: url("data:image/svg+xml,%3Csvg width='432' height='40' viewBox='0 0 432 40' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 0 0 0 0 H 432 V 40 H 0 V 0 Z' fill='%23E466C5'/%3E%3Cmask id='mask0' mask-type='alpha' maskUnits='userSpaceOnUse' x='5' y='0' width='334' height='40'%3E%3Cpath d='M 0 0 H 335 V 40 H 0 V 0 Z' fill='url(%23paint0_linear)'/%3E%3C/mask%3E%3Cg mask='url(%23mask0)'%3E%3Ccircle cx='9' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='19' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='9' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='19' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='29' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='39' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='29' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='39' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='49' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='59' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='49' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='59' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='69' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='79' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='69' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='79' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='89' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='99' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='89' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='99' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='109' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='119' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='109' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='119' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='9' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='19' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='29' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='39' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='49' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='59' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='69' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='79' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='89' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='99' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='109' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='119' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='129' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='139' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='129' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='139' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='149' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='159' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='149' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='159' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='169' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='179' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='169' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='179' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='189' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='199' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='189' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='199' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='209' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='219' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='209' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='219' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='229' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='239' cy='10' r='1' fill='%23981A78'/%3E%3Ccircle cx='229' cy='20' r='1' fill='%23981A78'/%3E%3Ccircle cx='129' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='139' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='149' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='159' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='169' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='179' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='189' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='199' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='209' cy='30' r='1' fill='%23981A78'/%3E%3Ccircle cx='219' cy='30' r='1' fill='%23981A78'/%3E%3C/g%3E%3Cdefs%3E%3ClinearGradient id='paint0_linear' x1='0' y1='0' x2='222' y2='40' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%23E466C5'/%3E%3Cstop offset='1' stop-color='%23E466C5' stop-opacity='0'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E%0A");  background-color: #E466C5;
+  height: 40px;
+  width: 432px;
+  border-radius: 4px 4px 0 0;
+  position: relative;
+}
+
+.newFeatureTag {
+  background-color: #570F45;
+  color: white;
+  font-family: 'Roboto', 'ffmprobold', 'Open Sans', Helvetica, sans-serif;
+  font-size: 0.8em;
+  font-weight: bold;
+  margin-left: 24px;
+  margin-top: 32px;
+  padding: 0 5px;
+  position: absolute;
+  text-transform: uppercase;
+}
+
+.mainDivBackground {
+  width: 432px;
+  padding: 15px 20px;
+  box-sizing: border-box;
+}
+
+.card {
+  width: 432px;
+  padding: 0;
+  line-height: 1.5;
+  background-color: white;
+  border: 0;
+  border-radius: 4px;
+}
+
+.contentContainer {
+  marginTop: 10px;
+}
+
+.barBottomStyle {
+  background-color: white;
+  border-radius: 0 0 4px 4px;
+  border-top: 1px solid #E0E0E0;
+  margin-top: 15px;
+  padding: 15px 15px;
+  text-align: right;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+
+}
+
+.imageBarStyle {
+  width: 432px;
+  text-align: center;
+}
+
+.imageStyle {
+  width: 400px;
+}

--- a/packages/ig-new-first-comment-user-modal/components/InstagramNewFirstCommentUserModal/index.jsx
+++ b/packages/ig-new-first-comment-user-modal/components/InstagramNewFirstCommentUserModal/index.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Popover,
+  Text,
+} from '@bufferapp/components';
+
+import { Button } from '@bufferapp/ui';
+
+import styles from './InstagramNewFirstCommentUserModal.css';
+
+const InstagramNewFirstCommentUserModal = ({ translations, hideModal }) => (<div>
+  <Popover>
+    <div className={styles.card}>
+      <div className={styles.headerDivBG}>
+        <div className={styles.newFeatureTag}><Text color="white" weight="bold" size="small">New feature</Text></div>
+      </div>
+      <div className={styles.mainDivBackground}>
+        <Text color={'black'} weight="bold">
+          {translations.heading}
+        </Text>
+        <div className={styles.contentContainer}>
+          <Text size="mini">
+            {translations.mainContent}
+          </Text>
+        </div>
+      </div>
+      <div className={styles.imageBarStyle}>
+        <img
+          className={styles.imageStyle}
+          src="https://buffer.com/images/modals/instagram/ig_first_comment.gif"
+          alt={translations.imageAlt}
+        />
+      </div>
+      <div className={styles.barBottomStyle}>
+        <Button
+          label={translations.continue}
+          onClick={hideModal}
+        />
+
+      </div>
+    </div>
+  </Popover>
+</div>);
+
+InstagramNewFirstCommentUserModal.propTypes = {
+  translations: PropTypes.object.isRequired, // eslint-disable-line
+  hideModal: PropTypes.func.isRequired,
+};
+
+export default InstagramNewFirstCommentUserModal;

--- a/packages/ig-new-first-comment-user-modal/components/InstagramNewFirstCommentUserModal/story.jsx
+++ b/packages/ig-new-first-comment-user-modal/components/InstagramNewFirstCommentUserModal/story.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { checkA11y } from 'storybook-addon-a11y';
+import translations from '@bufferapp/publish-i18n/translations/en-us.json';
+
+import InstagramNewFirstCommentUserModal from './index';
+
+storiesOf('IGNewFirstCommentUserModal', module)
+  .addDecorator(checkA11y)
+  .add('should show instagram modal', () => (
+    <InstagramNewFirstCommentUserModal
+      translations={translations['instagram-new-first-comment-user-modal']}
+      hideModal={action('hide-modal')}
+    />
+  ));

--- a/packages/ig-new-first-comment-user-modal/index.js
+++ b/packages/ig-new-first-comment-user-modal/index.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+import { actions as modalsActions } from '@bufferapp/publish-modals';
+
+import InstagramNewFirstCommentUserModal from './components/InstagramNewFirstCommentUserModal';
+
+export default connect(
+  (state) => {
+    return {
+      translations: state.i18n.translations['instagram-new-first-comment-user-modal'],
+    };
+  },
+  dispatch => ({
+    hideModal: () => dispatch(modalsActions.hideInstagramNewFirstCommentUserModal()),
+  }),
+)(InstagramNewFirstCommentUserModal);

--- a/packages/ig-new-first-comment-user-modal/package.json
+++ b/packages/ig-new-first-comment-user-modal/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@bufferapp/publish-ig-new-first-comment-user-modal",
+  "version": "2.0.0",
+  "description": "A modal showing users the Instagram first comment feature if they havent seen it before",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint . --ignore-pattern coverage node_modules"
+  },
+  "author": "karel@buffer.com",
+  "dependencies": {
+    "@bufferapp/publish-modals": "2.0.0"
+  },
+  "devDependencies": {
+    "eslint": "3.19.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/modals/components/AppModals/index.jsx
+++ b/packages/modals/components/AppModals/index.jsx
@@ -10,6 +10,7 @@ import InstagramFirstCommentModal from '@bufferapp/publish-ig-first-comment-moda
 import InstagramDirectPostingModal from '@bufferapp/publish-ig-direct-posting-modal';
 import WelcomeB4BTrialModal from '@bufferapp/publish-welcome-b4b-trial-modal';
 import B4bTrialCompleteModal from '@bufferapp/publish-b4b-trial-complete-modal';
+import InstagramNewFirstCommentUserModal from '@bufferapp/publish-ig-new-first-comment-user-modal';
 
 const AppModals = ({
   showUpgradeModal,
@@ -20,12 +21,14 @@ const AppModals = ({
   showInstagramDirectPostingModal,
   showWelcomeB4BTrialModal,
   showInstagramFirstCommentModal,
+  showInstagramNewFirstCommentUserModal,
   showB4BTrialExpiredModal,
 }) => (
   <React.Fragment>
     {showUpgradeModal && <UpgradeModal />}
     {showWelcomeModal && <WelcomeModal />}
     {showInstagramFirstCommentModal && <InstagramFirstCommentModal />}
+    {showInstagramNewFirstCommentUserModal && <InstagramNewFirstCommentUserModal />}
     {showWelcomePaidModal && <WelcomePaidModal />}
     {showWelcomeB4BTrialModal && <WelcomeB4BTrialModal />}
     {showProfilesDisconnectedModal && <ProfilesDisconnectedModal />}
@@ -44,6 +47,7 @@ AppModals.propTypes = {
   showInstagramDirectPostingModal: PropTypes.bool.isRequired,
   showWelcomeB4BTrialModal: PropTypes.bool.isRequired,
   showInstagramFirstCommentModal: PropTypes.bool.isRequired,
+  showInstagramNewFirstCommentUserModal: PropTypes.bool.isRequired,
   showB4BTrialExpiredModal: PropTypes.bool.isRequired,
 };
 

--- a/packages/modals/middleware.js
+++ b/packages/modals/middleware.js
@@ -15,6 +15,7 @@ import {
   getShowModalValue,
   resetShowModalKey,
   shouldShowInstagramFirstCommentModal,
+  shouldShowInstagramNewFirstCommentUserModal,
 } from './util/showModal';
 
 export default ({ dispatch, getState }) => next => (action) => {
@@ -31,6 +32,9 @@ export default ({ dispatch, getState }) => next => (action) => {
       }
       if (shouldShowInstagramFirstCommentModal()) {
         dispatch(actions.showInstagramFirstCommentModal());
+      }
+      if (shouldShowInstagramNewFirstCommentUserModal()) {
+        dispatch(actions.showInstagramNewFirstCommentUserModal());
       }
       if (shouldShowWelcomeModal()) {
         dispatch(actions.showWelcomeModal());
@@ -50,6 +54,7 @@ export default ({ dispatch, getState }) => next => (action) => {
       break;
     case `user_${dataFetchActionTypes.FETCH_SUCCESS}`: {
       const message = 'welcome_to_business_modal';
+      const igFcMsg = 'paid_users_to_new_publish_ig_first_comment';
       const { productFeatures: { planName } } = getState();
       const {
         messages: readMessages,
@@ -59,6 +64,7 @@ export default ({ dispatch, getState }) => next => (action) => {
       } = action.result; // user
       const hasNotReadWelcomeMessage = readMessages && !readMessages.includes(message);
       const isOnBusinessTrial = planName === 'business' && trial.onTrial;
+      const hasNotReadNewFirstCommentMessage = readMessages && !readMessages.includes(igFcMsg);
       if (isOnBusinessTrial && hasNotReadWelcomeMessage) {
         dispatch(actions.showWelcomeB4BTrialModal());
         // Mark modal as seen
@@ -68,6 +74,10 @@ export default ({ dispatch, getState }) => next => (action) => {
         dispatch(actions.showUpgradeModal({ source: 'pro_trial_expired' }));
       } else if (shouldShowBusinessTrialExpiredModal) {
         dispatch(actions.showB4BTrialExpiredModal({ source: 'b4b_trial_expired' }));
+      } else if (hasNotReadNewFirstCommentMessage) {
+        dispatch(actions.showInstagramNewFirstCommentUserModal());
+        // Mark modal as seen
+        dispatch(dataFetchActions.fetch({ name: 'readMessage', args: { message: igFcMsg } }));
       }
       break;
     }

--- a/packages/modals/reducer.js
+++ b/packages/modals/reducer.js
@@ -11,6 +11,7 @@ export const initialState = {
   showInstagramDirectPostingModal: false,
   showWelcomeB4BTrialModal: false,
   showInstagramFirstCommentModal: false,
+  showInstagramNewFirstCommentUserModal: false,
   showB4BTrialExpiredModal: false,
   upgradeModalB4BSource: null,
 };
@@ -34,6 +35,8 @@ export const actionTypes = keyWrapper('MODALS', {
   HIDE_UPGRADE_B4B_MODAL: 0,
   SHOW_INSTAGRAM_FIRST_COMMENT_MODAL: 0,
   HIDE_INSTAGRAM_FIRST_COMMENT_MODAL: 0,
+  SHOW_INSTAGRAM_NEW_FIRST_COMMENT_USER_MODAL: 0,
+  HIDE_INSTAGRAM_NEW_FIRST_COMMENT_USER_MODAL: 0,
 });
 
 export default (state = initialState, action) => {
@@ -71,6 +74,11 @@ export default (state = initialState, action) => {
         showInstagramFirstCommentModal: true,
         firstCommentIds: action.ids,
       };
+    case actionTypes.SHOW_INSTAGRAM_NEW_FIRST_COMMENT_USER_MODAL:
+      return {
+        ...state,
+        showInstagramNewFirstCommentUserModal: true,
+      };
     case actionTypes.HIDE_WELCOME_MODAL:
       return {
         ...state,
@@ -91,6 +99,11 @@ export default (state = initialState, action) => {
         ...state,
         showInstagramFirstCommentModal: false,
         firstCommentIds: null,
+      };
+    case actionTypes.HIDE_INSTAGRAM_NEW_FIRST_COMMENT_USER_MODAL:
+      return {
+        ...state,
+        showInstagramNewFirstCommentUserModal: false,
       };
     case actionTypes.SHOW_PROFILES_DISCONNECTED_MODAL:
       return {
@@ -157,6 +170,9 @@ export const actions = {
     type: actionTypes.SHOW_INSTAGRAM_FIRST_COMMENT_MODAL,
     ids,
   }),
+  showInstagramNewFirstCommentUserModal: () => ({
+    type: actionTypes.SHOW_INSTAGRAM_NEW_FIRST_COMMENT_USER_MODAL,
+  }),
   showWelcomeModal: () => ({
     type: actionTypes.SHOW_WELCOME_MODAL,
   }),
@@ -171,6 +187,9 @@ export const actions = {
   }),
   hideInstagramFirstCommentModal: () => ({
     type: actionTypes.HIDE_INSTAGRAM_FIRST_COMMENT_MODAL,
+  }),
+  hideInstagramNewFirstCommentUserModal: () => ({
+    type: actionTypes.HIDE_INSTAGRAM_NEW_FIRST_COMMENT_USER_MODAL,
   }),
   showProfilesDisconnectedModal: () => ({
     type: actionTypes.SHOW_PROFILES_DISCONNECTED_MODAL,

--- a/packages/modals/util/showModal.js
+++ b/packages/modals/util/showModal.js
@@ -29,6 +29,9 @@ export const shouldShowStealProfileModal = () =>
 export const shouldShowInstagramFirstCommentModal = () =>
   getShowModalKey() === 'instagram-first-comment-modal';
 
+export const shouldShowInstagramNewFirstCommentUserModal = () =>
+  getShowModalKey() === 'instagram-new-first-comment-user-modal';
+
 export const shouldShowWelcomeModal = () =>
   getShowModalKey() === 'welcome-modal-1';
 


### PR DESCRIPTION
### Purpose

[PUB-1365](https://buffer.atlassian.net/browse/PUB-1365) -  Implementing Welcome to Instagram first comment modal

Users should see this modal if they have the first_comment feature and don't have the readmessage `paid_users_to_new_publish_ig_first_comment`

or can be triggered via the ?mk=instagram-new-first-comment-user-modal query param

the readmessage is automatically triggered when they see this, so dismiss / not it will disappear after first viewing to ensure its not overbearing on the end user

