### PR TITLE
[PUB-1467] Show Business Trial Modal and Billing CTA after social account is connected

### DIFF
--- a/packages/cta-banner/components/BillingUpgradeCTABanner/index.jsx
+++ b/packages/cta-banner/components/BillingUpgradeCTABanner/index.jsx
@@ -50,8 +50,9 @@ const BillingUpgradeCTABanner = ({
     trial,
     onClickManageBilling,
     onClickAddBilling,
+    profileCount,
   }) => {
-  if (!trial || (trial && !trial.onTrial)) {
+  if (!trial || (trial && !trial.onTrial) || profileCount == 0) {
     return null;
   }
 
@@ -140,9 +141,11 @@ BillingUpgradeCTABanner.propTypes = {
   }),
   onClickManageBilling: PropTypes.func.isRequired,
   onClickAddBilling: PropTypes.func.isRequired,
+  profileCount: PropTypes.number,
 };
 
 BillingUpgradeCTABanner.defaultProps = {
+  profileCount: 0,
   trial: {
     hasCardDetails: false,
     hasTrialExtended: false,

--- a/packages/cta-banner/components/BillingUpgradeCTABanner/story.jsx
+++ b/packages/cta-banner/components/BillingUpgradeCTABanner/story.jsx
@@ -88,6 +88,7 @@ storiesOf('BillingUpgradeCTABanner', module)
         onClickManageBilling={action('manageBilling')}
         onClickAddBilling={action('addBilling')}
         trial={userWithoutTrial}
+        profileCount={1}
       />
     </Provider>
   ))
@@ -98,6 +99,7 @@ storiesOf('BillingUpgradeCTABanner', module)
         onClickManageBilling={action('manageBilling')}
         onClickAddBilling={action('addBilling')}
         trial={userOnTrial}
+        profileCount={1}
 
       />
     </Provider>
@@ -109,7 +111,7 @@ storiesOf('BillingUpgradeCTABanner', module)
         onClickManageBilling={action('manageBilling')}
         onClickAddBilling={action('addBilling')}
         trial={userOnTrialWithBilling}
-
+        profileCount={1}
       />
     </Provider>
   ))
@@ -120,7 +122,18 @@ storiesOf('BillingUpgradeCTABanner', module)
         onClickManageBilling={action('manageBilling')}
         onClickAddBilling={action('addBilling')}
         trial={userOnTrial}
-
+        profileCount={1}
+      />
+    </Provider>
+  ))
+  .add('pro user on business trial no billing info and no profiles connected', () => (
+    <Provider store={storeBusiness}>
+      <BillingUpgradeCTABanner
+        translations={translations['billing-upgrade-cta-banner']}
+        onClickManageBilling={action('manageBilling')}
+        onClickAddBilling={action('addBilling')}
+        trial={userOnTrial}
+        profileCount={0}
       />
     </Provider>
   ))
@@ -131,7 +144,7 @@ storiesOf('BillingUpgradeCTABanner', module)
         onClickManageBilling={action('manageBilling')}
         onClickAddBilling={action('addBilling')}
         trial={userOnTrialWithBilling}
-
+        profileCount={1}
       />
     </Provider>
   ));

--- a/packages/cta-banner/index.js
+++ b/packages/cta-banner/index.js
@@ -7,6 +7,7 @@ export default connect(
   state => ({
     trial: state.appSidebar.user && state.appSidebar.user.trial,
     translations: state.i18n.translations['billing-upgrade-cta-banner'],
+    profileCount: state.ctaBanner.profileCount,
   }),
   (dispatch) => ({
     onClickManageBilling: () => {

--- a/packages/cta-banner/reducer.js
+++ b/packages/cta-banner/reducer.js
@@ -1,15 +1,20 @@
 import keyWrapper from '@bufferapp/keywrapper';
 
+import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
+
 export const actionTypes = keyWrapper('CTA_BANNER', {
   MANAGE_BILLING: 0,
   ADD_BILLING: 0,
 });
 
 export const initialState = {
+  profileCount: 0,
 };
 
 export default (state = initialState, action) => {
   switch (action.type) {
+    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      return {...state, profileCount: action.result.profileCount};
     default:
       return state;
   }

--- a/packages/modals/middleware.js
+++ b/packages/modals/middleware.js
@@ -61,11 +61,12 @@ export default ({ dispatch, getState }) => next => (action) => {
         trial,
         shouldShowProTrialExpiredModal,
         shouldShowBusinessTrialExpiredModal,
+        profileCount,
       } = action.result; // user
       const hasNotReadWelcomeMessage = readMessages && !readMessages.includes(message);
       const isOnBusinessTrial = planName === 'business' && trial.onTrial;
       const hasNotReadNewFirstCommentMessage = readMessages && !readMessages.includes(igFcMsg);
-      if (isOnBusinessTrial && hasNotReadWelcomeMessage) {
+      if (isOnBusinessTrial && hasNotReadWelcomeMessage && profileCount > 0) {
         dispatch(actions.showWelcomeB4BTrialModal());
         // Mark modal as seen
         dispatch(dataFetchActions.fetch({ name: 'readMessage', args: { message } }));

--- a/packages/modals/middleware.test.js
+++ b/packages/modals/middleware.test.js
@@ -97,6 +97,32 @@ describe('middleware', () => {
     expect(dispatch)
       .toBeCalledWith(actions.showWelcomePaidModal());
   });
+  it('should show welcome b4b trial modal to new trialists', () => {
+    const next = jest.fn();
+    const dispatch = jest.fn();
+    const getState = () => ({
+      productFeatures: {
+        planName: 'business',
+      },
+    });
+    const action = {
+      type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
+      result: {
+        messages: [], // does not have 'welcome_to_business_modal'
+        trial: {
+          onTrial: true,
+        },
+        profileCount: 1,
+      },
+    };
+    middleware({ dispatch, getState })(next)(action);
+    expect(next)
+      .toBeCalledWith(action);
+    expect(dispatch)
+      .toBeCalledWith(actions.showWelcomeB4BTrialModal());
+    expect(dispatch)
+      .toBeCalledWith(dataFetchActions.fetch({ name: 'readMessage', args: { message: 'welcome_to_business_modal' } }));
+  });
   it('should show profiles disconnected modal when one or more is disconnected', () => {
     const next = jest.fn();
     const dispatch = jest.fn();

--- a/packages/modals/middleware.test.js
+++ b/packages/modals/middleware.test.js
@@ -97,31 +97,6 @@ describe('middleware', () => {
     expect(dispatch)
       .toBeCalledWith(actions.showWelcomePaidModal());
   });
-  it('should show welcome b4b trial modal to new trialists', () => {
-    const next = jest.fn();
-    const dispatch = jest.fn();
-    const getState = () => ({
-      productFeatures: {
-        planName: 'business',
-      },
-    });
-    const action = {
-      type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
-      result: {
-        messages: [], // does not have 'welcome_to_business_modal'
-        trial: {
-          onTrial: true,
-        },
-      },
-    };
-    middleware({ dispatch, getState })(next)(action);
-    expect(next)
-      .toBeCalledWith(action);
-    expect(dispatch)
-      .toBeCalledWith(actions.showWelcomeB4BTrialModal());
-    expect(dispatch)
-      .toBeCalledWith(dataFetchActions.fetch({ name: 'readMessage', args: { message: 'welcome_to_business_modal' } }));
-  });
   it('should show profiles disconnected modal when one or more is disconnected', () => {
     const next = jest.fn();
     const dispatch = jest.fn();

--- a/packages/store/reducers.js
+++ b/packages/store/reducers.js
@@ -34,6 +34,7 @@ import { reducer as lockedProfileNotificationReducer } from '@bufferapp/publish-
 import { reducer as thirdpartyReducer } from '@bufferapp/publish-thirdparty';
 import { reducer as b4bTrialCompleteReducer } from '@bufferapp/publish-b4b-trial-complete-modal';
 import { reducer as appShellReducer } from '@bufferapp/publish-app-shell';
+import { reducer as ctaBannerReducer } from '@bufferapp/publish-cta-banner';
 
 // Analyze
 import { reducer as averageReducer } from '@bufferapp/average-table';
@@ -83,6 +84,7 @@ export default ({
   thirdparty: thirdpartyReducer,
   b4bTrialComplete: b4bTrialCompleteReducer,
   appShell: appShellReducer,
+  ctaBanner: ctaBannerReducer,
 
   // Analyze
   average: averageReducer,


### PR DESCRIPTION
### Purpose
As described in the title: a user should not see the Business Trial Modal or Billing CTA unless they have at least one social account connected.
### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`