### PR TITLE
Adding a fallback url to sidebar avatars

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/bufferapp/project-donut#readme",
   "devDependencies": {
     "@bufferapp/components": "3.2.1",
-    "@bufferapp/ui": "3.8.1",
+    "@bufferapp/ui": "3.10.0",
     "@storybook/addon-storyshots": "3.4.11",
     "@storybook/react": "3.4.11",
     "axe-core": "2.2.0",

--- a/packages/profile-sidebar/components/ProfileListItem/index.jsx
+++ b/packages/profile-sidebar/components/ProfileListItem/index.jsx
@@ -3,10 +3,8 @@ import PropTypes from 'prop-types';
 import { Text, LockIcon, Link } from '@bufferapp/components';
 import { SensitiveData } from '@bufferapp/publish-shared-components';
 import { calculateStyles } from '@bufferapp/components/lib/utils';
-import { curiousBlueUltraLight } from '@bufferapp/components/style/color';
+import Avatar from '@bufferapp/ui/Avatar';
 import { blue } from '@bufferapp/ui/style/colors';
-
-import ProfileBadge from '../ProfileBadge';
 
 const NewDisconnectedIcon = ({ showProfilesDisconnectedModal, selected }) => (
   <Link
@@ -110,7 +108,14 @@ const ProfileListItem = ({
       >
         <div style={profileBadgeWrapperStyle}>
           <div style={{ marginRight: '16px' }}>
-            <ProfileBadge avatarUrl={avatarUrl} type={type} />
+            <Avatar
+              src={avatarUrl}
+              fallbackUrl="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
+              alt={handle}
+              size="small"
+              type="social"
+              network={type}
+            />
           </div>
           <span style={handleStyle}>
             <SensitiveData>
@@ -137,7 +142,6 @@ const ProfileListItem = ({
 
 ProfileListItem.propTypes = {
   ...Notifications.propTypes,
-  ...ProfileBadge.propTypes,
   handle: PropTypes.string.isRequired,
   locked: PropTypes.bool,
   selected: PropTypes.bool,

--- a/packages/profile-sidebar/components/ProfileSearch/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSearch/index.jsx
@@ -47,6 +47,7 @@ class ProfileSearch extends React.Component {
           <div style={avatarStyle}>
             <Avatar
               src={profile.avatarUrl}
+              fallbackUrl="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
               alt={profile.handle}
               size="small"
               type="social"

--- a/packages/profile-sidebar/components/ProfileSearch/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSearch/index.jsx
@@ -4,6 +4,7 @@ import { Search as SearchIcon } from '@bufferapp/ui/Icon';
 import Search from '@bufferapp/ui/Search';
 import Select from '@bufferapp/ui/Select';
 import Avatar from '@bufferapp/ui/Avatar';
+import styles from './styles.css';
 
 const wrapperStyle = {
   width: '100%',
@@ -44,7 +45,7 @@ class ProfileSearch extends React.Component {
         ...profile,
         title: profile.handle,
         icon: (
-          <div style={avatarStyle}>
+          <div className={styles.searchSidebar} style={avatarStyle}>
             <Avatar
               src={profile.avatarUrl}
               fallbackUrl="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"

--- a/packages/profile-sidebar/components/ProfileSearch/styles.css
+++ b/packages/profile-sidebar/components/ProfileSearch/styles.css
@@ -1,0 +1,3 @@
+.searchSidebar svg {
+  fill: white!important;
+}

--- a/packages/shared-components/ConfirmModal/index.jsx
+++ b/packages/shared-components/ConfirmModal/index.jsx
@@ -68,6 +68,7 @@ const ConfirmModal = ({
       <div style={profileBadgeStyle}>
         <Avatar
           src={avatar}
+          fallbackUrl="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
           alt="avatar for social network"
           size="small"
           type="social"

--- a/yarn.lock
+++ b/yarn.lock
@@ -640,10 +640,10 @@
     "@bufferapp/nav-sidebar" "^0.87.5"
     numeral "2.0.6"
 
-"@bufferapp/ui@3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@bufferapp/ui/-/ui-3.8.1.tgz#083a4bf12bfb02f457e99d8d48c51e27ee82d5fc"
-  integrity sha512-HjdAUMZBV1g5Xk+PxLo8EqOUOaR+NgVrxkcKbLDwW2sMTu/DS0v4UwuN4SkYyPQOkO8uN5nhGwg6B95eOG3/gQ==
+"@bufferapp/ui@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@bufferapp/ui/-/ui-3.10.0.tgz#1e41ad548701edf98eba3cd7091200e52815ab21"
+  integrity sha512-H6WKO/d0F0dk/qDNHmt5ohaFtWeC39LVdYFITbM6915zki98hR/42SZ9MdWyXLvJnfNLsezEzjVGVtvcpdgoAQ==
   dependencies:
     immutability-helper "^2.9.0"
     react "16.6.3"


### PR DESCRIPTION
### Purpose
When using the Avatar component, when the image is broken the current approach to handle these scenarios (a mask) isn't always working resulting in something like this:

<img width="236" alt="Image 2019-05-17 at 3 56 54 PM" src="https://user-images.githubusercontent.com/988972/57935153-721c7680-78c1-11e9-8601-ad716ee7e4b9.png">

This PR adds a prop to send a `fallbackUrl` in case the image fails, and returning something like this instead:

<img width="232" alt="Image 2019-05-17 at 3 57 28 PM" src="https://user-images.githubusercontent.com/988972/57935206-9415f900-78c1-11e9-8669-9b9c0831cd27.png">

I also decided to replace the `ProfileBadge` component to use `Avatar` instead and fix the same bug for the sidebar profile images.

<img width="253" alt="Image 2019-05-17 at 4 45 07 PM" src="https://user-images.githubusercontent.com/988972/57936112-88c3cd00-78c3-11e9-8737-2b8e8a764809.png">

<img width="251" alt="Image 2019-05-17 at 4 45 29 PM" src="https://user-images.githubusercontent.com/988972/57936122-8c575400-78c3-11e9-84a2-6a9257c22e81.png">
