### PR TITLE
[PUB-1487] Do not show IG first comment modal until social account is connected

### DIFF
--- a/packages/modals/middleware.js
+++ b/packages/modals/middleware.js
@@ -75,7 +75,7 @@ export default ({ dispatch, getState }) => next => (action) => {
         dispatch(actions.showUpgradeModal({ source: 'pro_trial_expired' }));
       } else if (shouldShowBusinessTrialExpiredModal) {
         dispatch(actions.showB4BTrialExpiredModal({ source: 'b4b_trial_expired' }));
-      } else if (hasNotReadNewFirstCommentMessage) {
+      } else if (hasNotReadNewFirstCommentMessage && profileCount > 0) {
         dispatch(actions.showInstagramNewFirstCommentUserModal());
         // Mark modal as seen
         dispatch(dataFetchActions.fetch({ name: 'readMessage', args: { message: igFcMsg } }));


### PR DESCRIPTION
### Purpose
As stated above, this PR makes it so the IG first comment modal is not shown until after the user has connected a social account. 
### Notes

### Review

#### Staging Deployment
To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`