### PR TITLE
[PUB-1478] Fix sidebar height to display bottom buttons

### DIFF
--- a/packages/profile-sidebar/components/ProfileSidebar/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/index.jsx
@@ -18,8 +18,7 @@ import ProfileSearch from '../ProfileSearch';
 const profileSidebarStyle = {
   display: 'flex',
   flexDirection: 'column',
-  minHeight: '100%',
-  maxHeight: '100%',
+  height: 'calc(100vh - 3.5rem)',
   padding: '1rem',
   boxSizing: 'border-box',
   background: offWhite,


### PR DESCRIPTION
### Purpose
**What?** Change Profile Sidebar height.
**Why?** When the list of profiles in the sidebar exceeds the space available the "Manage Social Accounts" button is pushed out of view.

### Notes
[PUB-1478](https://buffer.atlassian.net/browse/PUB-1478)