### PR TITLE
[PUB-1504] Add Users menu to Appshell

### DIFF
--- a/packages/app-shell/components/AppShell/index.jsx
+++ b/packages/app-shell/components/AppShell/index.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getURL } from '@bufferapp/publish-server/formatters/src';
-
 import { AppShell as BDSAppShell } from '@bufferapp/ui';
-import { Gear, Return, Plus } from '@bufferapp/ui/Icon';
+import { Gear, Return, Plus, People } from '@bufferapp/ui/Icon';
 import { gray } from '@bufferapp/ui/style/colors';
 
 const InvertedReturnIcon = () => (
@@ -56,6 +55,7 @@ function generateUserMenuItems({
   returnToClassic,
   upgradeToPro,
   openPreferences,
+  showManageTeam,
 }) {
   const userMenuItems = {
     top: [
@@ -66,6 +66,14 @@ function generateUserMenuItems({
         onItemClick: openPreferences,
       },
     ],
+    manageTeam: {
+      id: 'openTeam',
+      title: 'Users',
+      icon: <People color={gray} />,
+      onItemClick: () => {
+        window.location.assign(`${getURL.getManageTeamURL()}`);
+      },
+    },
     returnToClassic: {
       id: 'returnToClassic',
       title: 'Return to Classic',
@@ -81,6 +89,9 @@ function generateUserMenuItems({
     },
   };
   const extraItems = [];
+  if(showManageTeam) {
+    extraItems.push(userMenuItems.manageTeam);
+  }
   if (showReturnToClassic) {
     extraItems.push(userMenuItems.returnToClassic);
   }
@@ -95,6 +106,7 @@ const AppShell = ({
   user,
   showReturnToClassic,
   showUpgradeToPro,
+  showManageTeam,
   returnToClassic,
   upgradeToPro,
   openPreferences,
@@ -107,6 +119,7 @@ const AppShell = ({
       menuItems: generateUserMenuItems({
         showReturnToClassic,
         showUpgradeToPro,
+        showManageTeam,
         returnToClassic,
         upgradeToPro,
         openPreferences,
@@ -120,10 +133,10 @@ AppShell.propTypes = {
   children: PropTypes.node.isRequired,
   showReturnToClassic: PropTypes.bool,
   showUpgradeToPro: PropTypes.bool,
+  showManageTeam: PropTypes.bool,
   returnToClassic: PropTypes.func.isRequired,
   upgradeToPro: PropTypes.func.isRequired,
   openPreferences: PropTypes.func.isRequired,
-
   user: PropTypes.shape({
     name: PropTypes.string.isRequired,
     email: PropTypes.string.isRequired,
@@ -139,6 +152,7 @@ AppShell.defaultProps = {
   },
   showReturnToClassic: false,
   showUpgradeToPro: false,
+  showManageTeam: false,
 };
 
 export default AppShell;

--- a/packages/app-shell/components/AppShell/index.jsx
+++ b/packages/app-shell/components/AppShell/index.jsx
@@ -68,7 +68,7 @@ function generateUserMenuItems({
     ],
     manageTeam: {
       id: 'openTeam',
-      title: 'Users',
+      title: 'Team',
       icon: <People color={gray} />,
       onItemClick: () => {
         window.location.assign(`${getURL.getManageTeamURL()}`);

--- a/packages/app-shell/components/AppShell/index.jsx
+++ b/packages/app-shell/components/AppShell/index.jsx
@@ -89,7 +89,7 @@ function generateUserMenuItems({
     },
   };
   const extraItems = [];
-  if(showManageTeam) {
+  if (showManageTeam) {
     extraItems.push(userMenuItems.manageTeam);
   }
   if (showReturnToClassic) {

--- a/packages/app-shell/index.js
+++ b/packages/app-shell/index.js
@@ -11,6 +11,7 @@ export default connect(
     user: state.appShell.user,
     showReturnToClassic: state.appShell.showReturnToClassic,
     showUpgradeToPro: state.appShell.showUpgradeToPro,
+    showManageTeam: state.appShell.showManageTeam,
   }),
   dispatch => ({
     openPreferences() {

--- a/packages/app-shell/reducer.js
+++ b/packages/app-shell/reducer.js
@@ -19,10 +19,12 @@ export default (state = initialState, action) => {
         user: {
           email: action.result.email,
           name: action.result.name,
+          id: action.result.id,
           // We don't pass an `avatar` so it will try to get their Gravatar
         },
         showReturnToClassic: action.result.showReturnToClassic,
         showUpgradeToPro: action.result.is_free_user,
+        showManageTeam: !action.result.is_free_user,
       };
     default:
       return state;

--- a/packages/app-shell/reducer.js
+++ b/packages/app-shell/reducer.js
@@ -19,7 +19,6 @@ export default (state = initialState, action) => {
         user: {
           email: action.result.email,
           name: action.result.name,
-          id: action.result.id,
           // We don't pass an `avatar` so it will try to get their Gravatar
         },
         showReturnToClassic: action.result.showReturnToClassic,

--- a/packages/server/formatters/src/getURL.js
+++ b/packages/server/formatters/src/getURL.js
@@ -29,6 +29,12 @@ module.exports = {
     }
     return 'https://buffer.com/manage/own'
   },
+  getManageTeamURL: () => {
+    if (window.location.hostname === 'publish.local.buffer.com') {
+      return 'https://local.buffer.com/manage/team-members'
+    }
+    return 'https://buffer.com/manage/team-members'
+  },
   getInstagramDirectPostingURL: profileId => {
     if (window.location.hostname === 'publish.local.buffer.com') {
       return `https://local.buffer.com/instagram/setup?profile_id=${profileId}`


### PR DESCRIPTION
### Purpose
**What?** Add Users menu item to the AppShell, redirecting to the Users section in Org Admin.
**Why** Paid users need a way to easily access the Users section in Org Admin.

### Notes
[PUB-1504](https://buffer.atlassian.net/browse/PUB-1504)
Depends on the deployment of this PR in buffer-web: https://github.com/bufferapp/buffer-web/pull/16188, which adds a new route to access manage/team-members directly.