### PR TITLE
[PUB-1496] Exclude free users in Fullstory data collection

### DIFF
--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -45,15 +45,18 @@ export default ({ dispatch, getState }) => next => (action) => {
       break;
     }
     case actionTypes.FULLSTORY:
-      if (window) {
-        if (window.FS && window.FS.identify) {
-          const { id } = action.result;
-          const {
-            productFeatures: { planName },
-          } = getState();
-          window.FS.identify(id, {
-            pricingPlan_str: planName,
-          });
+      if (!action.result.is_free_user) {
+        if (window) {
+          console.log('got some fullstory stuff happening');
+          if (window.FS && window.FS.identify) {
+            const { id } = action.result;
+            const {
+              productFeatures: { planName },
+            } = getState();
+            window.FS.identify(id, {
+              pricingPlan_str: planName,
+            });
+          }
         }
       }
       break;

--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -47,7 +47,6 @@ export default ({ dispatch, getState }) => next => (action) => {
     case actionTypes.FULLSTORY:
       if (!action.result.is_free_user) {
         if (window) {
-          console.log('got some fullstory stuff happening');
           if (window.FS && window.FS.identify) {
             const { id } = action.result;
             const {

--- a/packages/thirdParty/middleware.test.js
+++ b/packages/thirdParty/middleware.test.js
@@ -30,6 +30,18 @@ const mockUser = {
   helpScoutConfig: '{ "param1": true, "param2": 24 }',
 };
 
+const mockFreeUser = {
+  id: 'bar',
+  createdAt: 'date',
+  plan: 'free',
+  planCode: '100',
+  trial: {},
+  orgUserCount: 2,
+  profileCount: 3,
+  is_free_user: true,
+  helpScoutConfig: '{ "param1": true, "param2": 24 }',
+};
+
 const mockIntercomUser = {
   app_id: '1234',
   id: 'foo',
@@ -105,6 +117,14 @@ describe('middleware', () => {
     expect(global.FS.identify).toHaveBeenCalledWith(mockUser.id, {
       pricingPlan_str: 'business',
     });
+  });
+  it('Fullstory does not collect free user data', () => {
+    const action = {
+      type: actionTypes.FULLSTORY,
+      result: mockFreeUser,
+    };
+    middleware(store)(next)(action);
+    expect(global.FS.identify).not.toHaveBeenCalled();
   });
   it('marks Appcues as loaded and identifies a B4B user with Appcues', () => {
     const action = {

--- a/packages/thirdParty/middleware.test.js
+++ b/packages/thirdParty/middleware.test.js
@@ -108,6 +108,14 @@ describe('middleware', () => {
       result: mockUser,
     });
   });
+  it('Fullstory does not collect free user data', () => {
+    const action = {
+      type: actionTypes.FULLSTORY,
+      result: mockFreeUser,
+    };
+    middleware(store)(next)(action);
+    expect(global.FS.identify).not.toHaveBeenCalled();
+  });
   it('identifies the user with Fullstory', () => {
     const action = {
       type: actionTypes.FULLSTORY,
@@ -117,14 +125,6 @@ describe('middleware', () => {
     expect(global.FS.identify).toHaveBeenCalledWith(mockUser.id, {
       pricingPlan_str: 'business',
     });
-  });
-  it('Fullstory does not collect free user data', () => {
-    const action = {
-      type: actionTypes.FULLSTORY,
-      result: mockFreeUser,
-    };
-    middleware(store)(next)(action);
-    expect(global.FS.identify).not.toHaveBeenCalled();
   });
   it('marks Appcues as loaded and identifies a B4B user with Appcues', () => {
     const action = {


### PR DESCRIPTION
## Description
Adding a check to the third party middleware to ensure we don't collect data for Fullstory from free users. 

## Context & Notes
This change is required because Fullstory quota is limited, so we want to only collect data from paid user interactions.

JIRA card: https://buffer.atlassian.net/browse/PUB-1496?atlOrigin=eyJpIjoiYWQ5ZWNkMzYzNTA0NGU2OGIwZThlNDIzNTY3ZDVhMjkiLCJwIjoiaiJ9

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`