### PR TITLE
[PUB-1439] IG First Comment changes for Free users

### DIFF
--- a/packages/shared-components/PostFooter/index.jsx
+++ b/packages/shared-components/PostFooter/index.jsx
@@ -76,7 +76,7 @@ const renderCommentIcon = () => (
   </span>
 );
 
-const renderActionText = (postAction, hasCommentEnabled, comment, hasFirstCommentFlip) => (
+const renderActionText = (postAction, hasCommentEnabled, comment) => (
   hasCommentEnabled && comment.commentEnabled ?
     <span style={igCommentWrapper}>
       {postAction}
@@ -86,14 +86,14 @@ const renderActionText = (postAction, hasCommentEnabled, comment, hasFirstCommen
 );
 
 /* eslint-disable react/prop-types */
-const renderPostAction = (postAction, serviceLink, isSent, hasCommentEnabled, comment, hasFirstCommentFlip) => (
+const renderPostAction = (postAction, serviceLink, isSent, hasCommentEnabled, comment) => (
   isSent ?
     <Link href={serviceLink} unstyled newTab>
       <Text size={'small'} color={'shuttleGray'}>
-        {renderActionText(postAction, hasCommentEnabled, comment, hasFirstCommentFlip)}
+        {renderActionText(postAction, hasCommentEnabled, comment)}
       </Text>
     </Link> :
-    renderActionText(postAction, hasCommentEnabled, comment, hasFirstCommentFlip)
+    renderActionText(postAction, hasCommentEnabled, comment)
 );
 
 const renderText = (
@@ -105,7 +105,6 @@ const renderText = (
   dueTime,
   hasCommentEnabled,
   comment,
-  hasFirstCommentFlip,
 ) => (
   isPastReminder ?
     (<span>
@@ -119,7 +118,7 @@ const renderText = (
         size={'small'}
         color={isSent ? 'shuttleGray' : 'black'}
       >
-        { !hasError ? renderPostAction(postDetails.postAction, serviceLink, isSent, hasCommentEnabled, comment, hasFirstCommentFlip) : '' }
+        { !hasError ? renderPostAction(postDetails.postAction, serviceLink, isSent, hasCommentEnabled, comment) : '' }
       </Text>
     </span>)
 );
@@ -157,7 +156,6 @@ const PostFooter = ({
   commentEnabled,
   commentText,
   hasCommentEnabled,
-  hasFirstCommentFlip,
 }) => {
   const hasError = postDetails.error && postDetails.error.length > 0;
   const isCustomScheduled = postDetails.isCustomScheduled;
@@ -177,7 +175,6 @@ const PostFooter = ({
           dueTime,
           hasCommentEnabled,
           comment,
-          hasFirstCommentFlip,
         )}
       </div>
       {!isSent && !isPastReminder && isManager && (

--- a/packages/shared-components/PostFooter/index.jsx
+++ b/packages/shared-components/PostFooter/index.jsx
@@ -77,7 +77,7 @@ const renderCommentIcon = () => (
 );
 
 const renderActionText = (postAction, hasCommentEnabled, comment, hasFirstCommentFlip) => (
-  hasFirstCommentFlip && hasCommentEnabled && comment.commentEnabled ?
+  hasCommentEnabled && comment.commentEnabled ?
     <span style={igCommentWrapper}>
       {postAction}
       {renderCommentIcon()}


### PR DESCRIPTION
## Description

This change makes it so Free users can see a comment icon in their sent posts and queued posts which have a comment, even though the feature is no longer available to them.

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
This change is required because at the moment, Free users who had a Pro and up status in the past, cannot visually determine if their post was sent with a comment. 
<!--- Is there a related JIRA card? Please link to it here. -->
https://buffer.atlassian.net/browse/PUB-1439?atlOrigin=eyJpIjoiMzZlN2JkNGE5Mzc2NGIwNGE5ZGVkZTU1ODZiMzdjNWQiLCJwIjoiaiJ9

## Success criteria from JIRA card:
-   [ ] Be able to see the first comment for a post already scheduled
-   [ ] See first comment for posts already sent
-   [ ] Be able to remove the first comment from an existing post
-   [ ] Not be able to re-enable the first comment for a post after they have removed it
-   [ ] Still send a post out with the first comment if it already existed in their queue before they became a free user

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`