### PR TITLE
[PUB-1369] Set the default time as "Select a slot" on switch from schedule to slot

### DIFF
--- a/packages/composer/composer/components/DateTimeSlotPicker.jsx
+++ b/packages/composer/composer/components/DateTimeSlotPicker.jsx
@@ -14,12 +14,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
+import { InputDate } from '@bufferapp/components';
+
 import TimePicker from '../components/TimePicker';
 import SlotPicker from '../components/SlotPicker';
 import Button from '../components/Button';
 import Select from '../components/Select';
 
-import { InputDate } from '@bufferapp/components';
 import styles from './css/DateTimeSlotPicker.css';
 
 class DateTimeSlotPicker extends React.Component {
@@ -38,6 +39,7 @@ class DateTimeSlotPicker extends React.Component {
       today,
       selectedDateTime,
       shouldDisplaySlotPicker,
+      emptyByDefault: false,
     };
   }
 
@@ -128,7 +130,10 @@ class DateTimeSlotPicker extends React.Component {
   };
 
   onTimePickerChange = this.updateTime;
-  onSlotPickerChange = this.updateTime;
+  onSlotPickerChange = (time) => {
+    this.updateTime(time);
+    this.setState({ emptyByDefault: false });
+  };
 
   onSwitchToSlotPickerClick = () => {
     // Update UI state
@@ -149,6 +154,8 @@ class DateTimeSlotPicker extends React.Component {
 
     const isPinnedToSlot = hasSlotAvailableForSelectedDateTime;
     this.props.onChange(this.state.selectedDateTime, isPinnedToSlot);
+
+    this.setState({ emptyByDefault: true });
   };
 
   onSwitchToTimePickerClick = () => {
@@ -206,7 +213,7 @@ class DateTimeSlotPicker extends React.Component {
   }
 
   render() {
-    const { today, selectedDateTime, shouldDisplaySlotPicker } = this.state;
+    const { today, selectedDateTime, shouldDisplaySlotPicker, emptyByDefault } = this.state;
     const {
       metaData, timezone, shouldUse24hTime, submitButtonCopy, isSlotPickingAvailable,
       availableSchedulesSlotsForDay,
@@ -265,6 +272,7 @@ class DateTimeSlotPicker extends React.Component {
             slot={selectedDateTime}
             onChange={this.onSlotPickerChange}
             className={styles.slotPicker}
+            emptyByDefault={emptyByDefault}
           /> :
           <Select disabled className={styles.slotPicker} value="">
             <option value="">Loading slots…</option>

--- a/packages/composer/composer/components/SlotPicker.jsx
+++ b/packages/composer/composer/components/SlotPicker.jsx
@@ -23,10 +23,12 @@ class SlotPicker extends React.Component {
     slot: PropTypes.instanceOf(moment),
     timezone: PropTypes.string,
     className: PropTypes.string,
+    emptyByDefault: PropTypes.bool,
   };
 
   static defaultProps = {
     metaData: undefined,
+    emptyByDefault: false,
   };
 
   onSlotChange = (e) => {
@@ -68,7 +70,7 @@ class SlotPicker extends React.Component {
   };
 
   render() {
-    const { slots, slot, className } = this.props;
+    const { slots, slot, className, emptyByDefault } = this.props;
     const EMPTY_OPTION_VALUE = 'empty';
 
     const slotTimestamp = slot.unix();
@@ -80,7 +82,8 @@ class SlotPicker extends React.Component {
       (isSlotTimeInFuture &&
         slots.some(({ timestamp, isSlotFree }) => timestamp === slotTimestamp && isSlotFree))
     );
-    const selectedSlot = isSlotTimestampAvailable ? slotTimestamp : EMPTY_OPTION_VALUE;
+    const selectedSlot = isSlotTimestampAvailable && !emptyByDefault ?
+      slotTimestamp : EMPTY_OPTION_VALUE;
 
     const hasSlots = slots.length > 0;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Set the default time as "Select a slot" on switch from schedule to slo

<!--- Describe your changes in detail. -->

## Context & Notes
In the composer, when switching from custom schedule to slot schedule, the time doesn't update in the composer's footer, [JIRA Related task](https://buffer.atlassian.net/browse/PUB-1369)

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
<img width="379" alt="Image 2019-06-05 at 12 49 39 PM" src="https://user-images.githubusercontent.com/988972/58951396-50f8c880-8791-11e9-917c-42f0f1fbdeac.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
