### PR TITLE
Ensure pending count is never a negative number

### DIFF
--- a/packages/profile-sidebar/components/ProfileList/index.jsx
+++ b/packages/profile-sidebar/components/ProfileList/index.jsx
@@ -18,7 +18,7 @@ const ProfileList = ({
         avatarUrl={profile.avatarUrl}
         type={profile.type}
         handle={profile.handle}
-        notifications={profile.pendingCount}
+        pendingCount={profile.pendingCount}
         selected={profile.id === selectedProfileId}
         locked={profile.disabled}
         disconnected={profile.isDisconnected}

--- a/packages/profile-sidebar/components/ProfileListItem/index.jsx
+++ b/packages/profile-sidebar/components/ProfileListItem/index.jsx
@@ -40,8 +40,10 @@ const profileBadgeWrapperStyle = {
   alignItems: 'center',
 };
 
-const Notifications = ({ notifications, selected }) => (
-  <Text size="mini" color={selected ? 'white' : 'shuttleGray'}>{notifications}</Text>
+const Notifications = ({ pendingCount, selected }) => (
+  <Text size="mini" color={selected ? 'white' : 'shuttleGray'}>
+    {pendingCount < 0 ? 0 : pendingCount}
+  </Text>
 );
 
 const handleStyle = {
@@ -51,17 +53,17 @@ const handleStyle = {
 };
 
 Notifications.propTypes = {
-  notifications: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  pendingCount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Notifications.defaultProps = {
-  notifications: null,
+  pendingCount: null,
 };
 
 const ProfileListItem = ({
   avatarUrl,
   type,
-  notifications,
+  pendingCount,
   handle,
   locked,
   disconnected,
@@ -134,7 +136,7 @@ const ProfileListItem = ({
             selected={selected}
           />
         ) : (
-          <Notifications notifications={notifications} selected={selected} />
+          <Notifications pendingCount={pendingCount} selected={selected} />
         )}
       </div>
     </Link>

--- a/packages/profile-sidebar/components/ProfileListItem/index.jsx
+++ b/packages/profile-sidebar/components/ProfileListItem/index.jsx
@@ -40,7 +40,7 @@ const profileBadgeWrapperStyle = {
   alignItems: 'center',
 };
 
-const Notifications = ({ pendingCount, selected }) => (
+const PendingCountNotification = ({ pendingCount, selected }) => (
   <Text size="mini" color={selected ? 'white' : 'shuttleGray'}>
     {pendingCount < 0 ? 0 : pendingCount}
   </Text>
@@ -52,11 +52,11 @@ const handleStyle = {
   textOverflow: 'ellipsis',
 };
 
-Notifications.propTypes = {
+PendingCountNotification.propTypes = {
   pendingCount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
-Notifications.defaultProps = {
+PendingCountNotification.defaultProps = {
   pendingCount: null,
 };
 
@@ -136,7 +136,7 @@ const ProfileListItem = ({
             selected={selected}
           />
         ) : (
-          <Notifications pendingCount={pendingCount} selected={selected} />
+          <PendingCountNotification pendingCount={pendingCount} selected={selected} />
         )}
       </div>
     </Link>
@@ -144,7 +144,7 @@ const ProfileListItem = ({
 };
 
 ProfileListItem.propTypes = {
-  ...Notifications.propTypes,
+  ...PendingCountNotification.propTypes,
   handle: PropTypes.string.isRequired,
   locked: PropTypes.bool,
   selected: PropTypes.bool,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
Ensure post count is not a negative number
## Description
I noticed while working on a different task that sometimes after deleting posts, the pending count number can become negative (ex. `-1`). I thought this had been fixed awhile back? Adding a quick check to ensure pending number is never less than 0. 

Also added specificity to the component, since it's solely being used for pending count. 
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
