### PR TITLE
[PUB-1456] Adds missing call in the middleware to save the swapped posts

### DIFF
--- a/packages/queue/middleware.js
+++ b/packages/queue/middleware.js
@@ -154,6 +154,21 @@ export default ({ dispatch, getState }) => next => (action) => {
       }));
       break;
     }
+    case actionTypes.POSTS_SWAPPED: {
+      dispatch(dataFetchActions.fetch({
+        name: 'swapPosts',
+        args: {
+          updateSourceId: action.postSource.id,
+          sourcePinned: action.postTarget.postProps.pinned,
+          sourceDueAt: action.postTarget.postProps.due_at,
+
+          updateTargetId: action.postTarget.id,
+          targetPinned: action.postSource.postProps.pinned,
+          targetDueAt: action.postSource.postProps.due_at,
+        },
+      }));
+      break;
+    }
 
     /**
      * Watch for Pusher events to keep post counts up-to-date throughout the app.

--- a/packages/queue/middleware.test.js
+++ b/packages/queue/middleware.test.js
@@ -256,6 +256,43 @@ describe('middleware', () => {
       }));
   });
 
+  it('should swap posts', () => {
+    const action = {
+      type: actionTypes.POSTS_SWAPPED,
+      postSource: {
+        id: 'id1',
+        postProps: {
+          pinned: true,
+          due_at: 234,
+        },
+      },
+      postTarget: {
+        id: 'id2',
+        postProps: {
+          pinned: false,
+          due_at: 564,
+        },
+      },
+      profileId: 'profileId1',
+    };
+    middleware({ dispatch })(next)(action);
+    expect(next)
+      .toBeCalledWith(action);
+    expect(dispatch)
+      .toBeCalledWith(dataFetchActions.fetch({
+        name: 'swapPosts',
+        args: {
+          updateSourceId: action.postSource.id,
+          sourcePinned: action.postTarget.postProps.pinned,
+          sourceDueAt: action.postTarget.postProps.due_at,
+
+          updateTargetId: action.postTarget.id,
+          targetPinned: action.postSource.postProps.pinned,
+          targetDueAt: action.postSource.postProps.due_at,
+        },
+      }));
+  });
+
   it('should trigger a notification if post is successfully shared', () => {
     const RPC_NAME = 'sharePostNow';
     const action = dataFetchActions.fetchSuccess({

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -52,6 +52,7 @@ const gridPosts = require('./grid');
 const shortenUrl = require('./shortenUrl');
 const updatePostLink = require('./updatePostLink');
 const dropPost = require('./dropPost');
+const swapPosts = require('./swapPosts');
 const cancelTrial = require('./cancelTrial');
 const intercom = require('./intercom');
 
@@ -122,6 +123,7 @@ module.exports = rpc(
   shortenUrl,
   updatePostLink,
   dropPost,
+  swapPosts,
   cancelTrial,
   intercom,
 );

--- a/packages/server/rpc/swapPosts/index.js
+++ b/packages/server/rpc/swapPosts/index.js
@@ -1,0 +1,32 @@
+const { method, createError } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+module.exports = method(
+  'swapPosts',
+  'handles changing posts time when swapped',
+  ({
+     updateSourceId,
+     sourcePinned,
+     sourceDueAt,
+     updateTargetId,
+     targetPinned,
+     targetDueAt,
+   }, { session }) =>
+    rp({
+      uri: `${process.env.API_ADDR}/1/updates/${updateSourceId}/swap_posts.json`,
+      method: 'POST',
+      strictSSL: !(process.env.NODE_ENV === 'development'),
+      qs: {
+        access_token: session.publish.accessToken,
+        sourcePinned,
+        sourceDueAt,
+        updateTargetId,
+        targetPinned,
+        targetDueAt,
+      },
+    })
+      .then(() => 'OK')
+      .catch((err) => {
+        throw createError({ message: err.message });
+      }),
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Adding missing call in the middleware to save the swapped posts in the backend.

<!--- Describe your changes in detail. -->

## Context & Notes
When drag and swapping posts, it's not being saved in the backend, so I included the rpc call to the backend.

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
