### PR TITLE
[PUB-1345] Add notifications for trial extension

### DIFF
--- a/packages/notifications-provider/utils/notifications.json
+++ b/packages/notifications-provider/utils/notifications.json
@@ -2,12 +2,16 @@
   "success": {
     "example-with-variable": "This is an example with this {{__variable__}} value",
     "bitly-connect": "Great, your bitly account has been linked with the profile {{__variable__}}",
-    "bitly-disconnect": "Okay, your bitly account has been disconnected."
+    "bitly-disconnect": "Okay, your bitly account has been disconnected.",
+    "trial-extended": "Great! We’ve extended your free trial."
   },
   "error": {
     "connection": "{{__variable__}}",
     "bitly-connect": "{{__variable__}}",
     "bitly-disconnect": "{{__variable__}}",
-    "connection": "{{__variable__}}"
+    "connection": "{{__variable__}}",
+    "trial-extended": "{{__variable__}}",
+    "trial-already-extended": "Ups, it seems you already extended your trial once.",
+    "trial-extension-not-available": "Ups, it seems you might not be eligible for a trial extension."
   }
 }


### PR DESCRIPTION
## Description

Add trial extension notifications to notifications.json.

## Context & Notes

When NP users click on https://buffer.com/billing/renew-trial and renew their trial, they are redirected to NP with 3 parameters to show a success or error message. This PR allows to display those messages.
Related PR: https://github.com/bufferapp/buffer-web/pull/16223
Task: [PUB-1345](https://buffer.atlassian.net/browse/PUB-1345)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [X] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [X] I have identified similar or related features and tested they are still working.
-   [X] I have performed a self-review of my own code.
-   [X] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [X] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
