### PR TITLE
[PUB-1402] Making the queue the default view if it's not a valid tab

### DIFF
--- a/packages/profile-page/components/ProfilePage/index.jsx
+++ b/packages/profile-page/components/ProfilePage/index.jsx
@@ -67,7 +67,7 @@ const tabContentStyle = {
  * @param isFreeUser
  * @param onChangeTab method to change tab
  */
-const handleTabChange = (
+const verifyTab = (
   tabId,
   profileId,
   selectedProfile,
@@ -95,7 +95,7 @@ const handleTabChange = (
 
 const TabContent = ({ tabId, profileId, childTabId, loadMore, selectedProfile, features, onChangeTab }) => {
   // if current tabId is not valid, redirect to the queue
-  handleTabChange(tabId, profileId, selectedProfile, features.isFreeUser(), onChangeTab);
+  verifyTab(tabId, profileId, selectedProfile, features.isFreeUser(), onChangeTab);
 
   switch (tabId) {
     case 'queue':

--- a/packages/profile-page/components/ProfilePage/index.jsx
+++ b/packages/profile-page/components/ProfilePage/index.jsx
@@ -19,6 +19,7 @@ import {
 } from '@bufferapp/publish-shared-components';
 import { WithFeatureLoader } from '@bufferapp/product-features';
 import getErrorBoundary from '@bufferapp/publish-web/components/ErrorBoundary';
+import { getValidTab } from '@bufferapp/publish-tabs/utils';
 
 const ErrorBoundary = getErrorBoundary(true);
 
@@ -56,7 +57,27 @@ const tabContentStyle = {
   height: '100%',
 };
 
-const TabContent = ({ tabId, profileId, childTabId, loadMore }) => {
+const handleTabChange = (tabId, profileId, selectedProfile, features, onChangeTab) => {
+  let isInstagramProfile = false;
+  let isBusinessAccount = false;
+  let isManager = false;
+
+  if (selectedProfile) {
+    isInstagramProfile = selectedProfile.service === 'instagram';
+    isBusinessAccount = selectedProfile.business;
+    isManager = selectedProfile.isManager;
+
+    const validTabId =
+      getValidTab(tabId, isBusinessAccount, isInstagramProfile, isManager, features.isFreeUser());
+
+    if (tabId !== validTabId) {
+      onChangeTab(validTabId, profileId);
+    }
+  }
+};
+
+const TabContent = ({ tabId, profileId, childTabId, loadMore, selectedProfile, features, onChangeTab }) => {
+  handleTabChange(tabId, profileId, selectedProfile, features, onChangeTab);
   switch (tabId) {
     case 'queue':
       return <QueuedPosts profileId={profileId} />;
@@ -114,6 +135,9 @@ function ProfilePage({
   loadingMore,
   moreToLoad,
   page,
+  selectedProfile,
+  features,
+  onChangeTab,
 }) {
   const isQueueTab = tabId === 'queue';
   const isOtherPostsTab =
@@ -162,6 +186,9 @@ function ProfilePage({
               profileId={profileId}
               childTabId={childTabId}
               loadMore={onLoadMore}
+              selectedProfile={selectedProfile}
+              features={features}
+              onChangeTab={onChangeTab}
             />
             {loadingMore && (
               <div style={loadingAnimationStyle}>
@@ -187,6 +214,7 @@ ProfilePage.propTypes = {
   loadingMore: PropTypes.bool.isRequired,
   moreToLoad: PropTypes.bool.isRequired,
   page: PropTypes.number.isRequired,
+  onChangeTab: PropTypes.func,
 };
 
 ProfilePage.defaultProps = {
@@ -195,6 +223,7 @@ ProfilePage.defaultProps = {
   page: 1,
   posts: [],
   total: 0,
+  onChangeTab: () => {},
 };
 
 export default WithFeatureLoader(ProfilePage);

--- a/packages/profile-page/components/ProfilePage/index.jsx
+++ b/packages/profile-page/components/ProfilePage/index.jsx
@@ -57,7 +57,23 @@ const tabContentStyle = {
   height: '100%',
 };
 
-const handleTabChange = (tabId, profileId, selectedProfile, features, onChangeTab) => {
+/**
+ * Verifies if the user can access to the current tabId
+ * and changes the tab only if validTabId is different from current tabId
+ *
+ * @param tabId
+ * @param profileId
+ * @param selectedProfile
+ * @param isFreeUser
+ * @param onChangeTab method to change tab
+ */
+const handleTabChange = (
+  tabId,
+  profileId,
+  selectedProfile,
+  isFreeUser,
+  onChangeTab,
+) => {
   let isInstagramProfile = false;
   let isBusinessAccount = false;
   let isManager = false;
@@ -68,8 +84,9 @@ const handleTabChange = (tabId, profileId, selectedProfile, features, onChangeTa
     isManager = selectedProfile.isManager;
 
     const validTabId =
-      getValidTab(tabId, isBusinessAccount, isInstagramProfile, isManager, features.isFreeUser());
+      getValidTab(tabId, isBusinessAccount, isInstagramProfile, isManager, isFreeUser);
 
+    // if current tabId is not valid, redirect to the queue
     if (tabId !== validTabId) {
       onChangeTab(validTabId, profileId);
     }
@@ -77,7 +94,9 @@ const handleTabChange = (tabId, profileId, selectedProfile, features, onChangeTa
 };
 
 const TabContent = ({ tabId, profileId, childTabId, loadMore, selectedProfile, features, onChangeTab }) => {
-  handleTabChange(tabId, profileId, selectedProfile, features, onChangeTab);
+  // if current tabId is not valid, redirect to the queue
+  handleTabChange(tabId, profileId, selectedProfile, features.isFreeUser(), onChangeTab);
+
   switch (tabId) {
     case 'queue':
       return <QueuedPosts profileId={profileId} />;
@@ -120,11 +139,20 @@ TabContent.propTypes = {
   tabId: PropTypes.string,
   childTabId: PropTypes.string,
   profileId: PropTypes.string.isRequired,
+  onChangeTab: PropTypes.func,
+  selectedProfile: PropTypes.shape({
+    service: PropTypes.string,
+    business: PropTypes.bool,
+    isManager: PropTypes.bool,
+  }),
+  features: PropTypes.object.isRequired, // eslint-disable-line
 };
 
 TabContent.defaultProps = {
   tabId: '',
   childTabId: '',
+  onChangeTab: () => {},
+  selectedProfile: {},
 };
 
 function ProfilePage({
@@ -215,6 +243,12 @@ ProfilePage.propTypes = {
   moreToLoad: PropTypes.bool.isRequired,
   page: PropTypes.number.isRequired,
   onChangeTab: PropTypes.func,
+  selectedProfile: PropTypes.shape({
+    service: PropTypes.string,
+    business: PropTypes.bool,
+    isManager: PropTypes.bool,
+  }),
+  features: PropTypes.object.isRequired, // eslint-disable-line
 };
 
 ProfilePage.defaultProps = {
@@ -224,6 +258,7 @@ ProfilePage.defaultProps = {
   posts: [],
   total: 0,
   onChangeTab: () => {},
+  selectedProfile: null,
 };
 
 export default WithFeatureLoader(ProfilePage);

--- a/packages/profile-page/index.js
+++ b/packages/profile-page/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader/root';
 import { getProfilePageParams } from '@bufferapp/publish-routes';
 import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
+import { actions } from '@bufferapp/publish-tabs';
 import ProfilePage from './components/ProfilePage';
 
 // default export = container
@@ -32,11 +33,18 @@ export default hot(
           translations: state.i18n.translations.example,
           view: state[reducerName].byProfileId[profileId].tabId || null,
           isBusinessAccount: state.profileSidebar.selectedProfile.business,
+          selectedProfile: state.profileSidebar.selectedProfile,
         };
       }
       return {};
     },
     dispatch => ({
+      onChangeTab: (tabId, profileId) => {
+        dispatch(actions.selectTab({
+          tabId,
+          profileId,
+        }));
+      },
       onLoadMore: ({ profileId, page, tabId }) => {
         let requestName;
         switch (tabId) {

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -29,9 +29,14 @@ export default hot(connect(
   (dispatch, ownProps) => ({
     onProfileClick: (profile) => {
       if (profile.id !== ownProps.profileId) {
+        let tabId = ownProps.tabId;
+        if ((ownProps.tabId === 'pastReminders' || ownProps.tabId === 'grid')
+            && profile.service !== 'instagram') {
+          tabId = 'queue';
+        }
         dispatch(push(generateProfilePageRoute({
           profileId: profile.id,
-          tabId: ownProps.tabId,
+          tabId,
         })));
         dispatch(actions.selectProfile({
           profile,

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -30,8 +30,8 @@ export default hot(connect(
     onProfileClick: (profile) => {
       if (profile.id !== ownProps.profileId) {
         let tabId = ownProps.tabId;
-        if ((ownProps.tabId === 'pastReminders' || ownProps.tabId === 'grid')
-            && profile.service !== 'instagram') {
+        if (profile.service !== 'instagram' &&
+           (ownProps.tabId === 'pastReminders' || ownProps.tabId === 'grid')) {
           tabId = 'queue';
         }
         dispatch(push(generateProfilePageRoute({

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -3,6 +3,7 @@ import { generateProfilePageRoute } from '@bufferapp/publish-routes';
 import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader/root';
 import { actions as modalActions } from '@bufferapp/publish-modals';
+import { actions as tabsActions } from '@bufferapp/publish-tabs';
 import ProfileSidebar from './components/ProfileSidebar';
 import { actions } from './reducer';
 
@@ -29,15 +30,10 @@ export default hot(connect(
   (dispatch, ownProps) => ({
     onProfileClick: (profile) => {
       if (profile.id !== ownProps.profileId) {
-        let tabId = ownProps.tabId;
-        if (profile.service !== 'instagram' &&
-           (ownProps.tabId === 'pastReminders' || ownProps.tabId === 'grid')) {
-          tabId = 'queue';
-        }
-        dispatch(push(generateProfilePageRoute({
+        dispatch(tabsActions.selectTab({
+          tabId: ownProps.tabId,
           profileId: profile.id,
-          tabId,
-        })));
+        }));
         dispatch(actions.selectProfile({
           profile,
         }));

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -41,6 +41,7 @@ import { middleware as publishCTABannerMiddleware } from '@bufferapp/publish-cta
 import { middleware as thirdpartyMiddleware } from '@bufferapp/publish-thirdparty';
 import { middleware as bookmarkletsMiddleware } from '@bufferapp/publish-bookmarklets';
 import { middleware as b4bTrialCompleteModalMiddleware } from '@bufferapp/publish-b4b-trial-complete-modal';
+import { middleware as tabsMiddleware } from '@bufferapp/publish-tabs';
 
 // Remove analytics middleware when publish switches to analyze
 import { middleware as averageMiddleware } from '@bufferapp/average-table';
@@ -113,6 +114,7 @@ const configureStore = initialstate => {
         bookmarkletsMiddleware,
         thirdpartyMiddleware,
         b4bTrialCompleteModalMiddleware,
+        tabsMiddleware,
         // Analyze
         averageMiddleware,
         compareChartMiddleware,

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -7,6 +7,7 @@ import {
 import { Button } from '@bufferapp/ui';
 import { Text } from '@bufferapp/components';
 import FeatureLoader, { WithFeatureLoader } from '@bufferapp/product-features';
+import { getValidTab } from '../../utils';
 
 const upgradeCtaStyle = {
   transform: 'translate(0, 1px)',
@@ -38,13 +39,28 @@ class TabNavigation extends React.Component {
   constructor(props) {
     super(props);
     this.state = { loading: false };
+
+    this.isValidTab = this.isValidTab.bind(this);
   }
 
-  render () {
+  isValidTab (tabId) {
     const {
       features,
       isBusinessAccount,
       isManager,
+      isInstagramProfile,
+    } = this.props;
+
+    return tabId === getValidTab(
+      tabId,
+      isBusinessAccount,
+      isInstagramProfile,
+      isManager,
+      features.isFreeUser());
+  }
+
+  render () {
+    const {
       selectedTabId,
       selectedChildTabId,
       onTabClick,
@@ -56,7 +72,6 @@ class TabNavigation extends React.Component {
       shouldHideAnalyticsOverviewTab,
       onUpgradeButtonClick,
       isLockedProfile,
-      isInstagramProfile,
     } = this.props;
 
     return (
@@ -68,24 +83,24 @@ class TabNavigation extends React.Component {
           onTabClick={onTabClick}
         >
           <Tab tabId={'queue'}>Queue</Tab>
-          {isInstagramProfile &&
+          {this.isValidTab('pastReminders') &&
             <Tab tabId={'pastReminders'}>Past Reminders</Tab>
           }
           <Tab tabId={'analytics'}>Analytics</Tab>
           {/* Team Members who are Managers */}
-          {isBusinessAccount && isManager &&
+          {this.isValidTab('awaitingApproval') &&
             <Tab tabId={'awaitingApproval'}>Awaiting Approval</Tab>
           }
           {/* Team Members who are Contributors */}
-          {isBusinessAccount && !isManager &&
+          {this.isValidTab('pendingApproval') &&
             <Tab tabId={'pendingApproval'}>Pending Approval</Tab>
           }
           {/* Pro and up users or Team Members */}
-          {(!features.isFreeUser() || isBusinessAccount) &&
+          {this.isValidTab('drafts') &&
             <Tab tabId={'drafts'}>Drafts</Tab>
           }
           {/* Business users or Team Members */}
-          {isBusinessAccount && isInstagramProfile &&
+          {this.isValidTab('grid') &&
             <Tab tabId={'grid'}>Shop Grid</Tab>
           }
           <Tab tabId={'settings'}>Settings</Tab>

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -1,11 +1,11 @@
 import { push } from 'connected-react-router';
-import { generateProfilePageRoute, generateChildTabRoute } from '@bufferapp/publish-routes';
+import { generateChildTabRoute } from '@bufferapp/publish-routes';
 import { connect } from 'react-redux';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
 import { trackAction } from '@bufferapp/publish-data-tracking';
 
 import TabNavigation from './components/TabNavigation';
-
+import { actions } from './reducer';
 
 // default export = container
 export default connect(
@@ -27,15 +27,16 @@ export default connect(
     profileId: ownProps.profileId,
     isLockedProfile: state.profileSidebar.isLockedProfile,
     isInstagramProfile: state.generalSettings.isInstagramProfile,
+    selectedProfile: state.profileSidebar.selectedProfile,
   }),
   (dispatch, ownProps) => ({
     onTabClick: (tabId) => {
       const profileId = ownProps.profileId;
       trackAction({ location: 'tabs', action: `click_tab_${tabId}`, metadata: { profileId } });
-      dispatch(push(generateProfilePageRoute({
+      dispatch(actions.selectTab({
         tabId,
         profileId,
-      })));
+      }));
     },
     onUpgradeButtonClick: (plan) => {
       if (plan === 'pro') {
@@ -63,3 +64,4 @@ export default connect(
 
 // export reducer, actions and action types
 export reducer, { actions, actionTypes } from './reducer';
+export middleware from './middleware';

--- a/packages/tabs/middleware.js
+++ b/packages/tabs/middleware.js
@@ -1,0 +1,21 @@
+import { push } from 'connected-react-router';
+import { generateProfilePageRoute } from '@bufferapp/publish-routes';
+
+import { actionTypes } from './reducer';
+
+export default ({ getState, dispatch }) => next => (action) => { // eslint-disable-line no-unused-vars
+  next(action);
+  switch (action.type) {
+    case actionTypes.SELECT_TAB:
+      if ((action.tabId !== getState().tabId) ||
+          (action.profileId !== getState().profileId)) {
+        dispatch(push(generateProfilePageRoute({
+          profileId: action.profileId,
+          tabId: action.tabId,
+        })));
+      }
+      break;
+    default:
+      break;
+  }
+};

--- a/packages/tabs/reducer.js
+++ b/packages/tabs/reducer.js
@@ -1,10 +1,34 @@
-const initialState = {};
+import keyWrapper from '@bufferapp/keywrapper';
+
+export const actionTypes = keyWrapper('TABS', {
+  SELECT_TAB: 0,
+});
+
+const initialState = {
+  profiles: [],
+  tabId: 'queue',
+  selectedProfileId: '',
+  selectedProfile: {},
+  isBusinessAccount: false,
+};
 
 export default (state = initialState, action) => {
   switch (action.type) {
+    case actionTypes.SELECT_TAB: {
+      return {
+        ...state,
+        tabId: action.tabId,
+      };
+    }
     default:
       return state;
   }
 };
 
-export const actions = {};
+export const actions = {
+  selectTab: ({ tabId, profileId }) => ({
+    type: actionTypes.SELECT_TAB,
+    tabId,
+    profileId,
+  }),
+};

--- a/packages/tabs/utils/index.js
+++ b/packages/tabs/utils/index.js
@@ -10,4 +10,54 @@ const openBillingWindow = () => {
   window.location.href = `${getBaseURL()}/app/account/receipts?content_only=true`;
 };
 
-export { openCalendarWindow, openBillingWindow };
+/**
+ * Checks if the user can go the selected tab and returns the proper one in case is invalid
+ *
+ * @param selectedTab: the new tab trying to be accessed
+ * @param isBusinessAccount
+ * @param isInstagramProfile
+ * @param isManager
+ * @param isFreeUser
+ *
+ * @returns string validTabId with the valid tab, default value is 'queue'
+ */
+const getValidTab = (selectedTab, isBusinessAccount, isInstagramProfile, isManager, isFreeUser) => {
+  let validTabId = selectedTab;
+
+  switch (selectedTab) {
+    case 'queue':
+      validTabId = 'queue';
+      break;
+    case 'pastReminders':
+      validTabId = isInstagramProfile ? 'pastReminders' : 'queue';
+      break;
+    case 'analytics':
+      validTabId = 'analytics';
+      break;
+    case 'awaitingApproval':
+      /* Team Members who are Managers */
+      validTabId = (isBusinessAccount && isManager) ? 'awaitingApproval' : 'queue';
+      break;
+    case 'pendingApproval':
+      /* Team Members who are Contributors */
+      validTabId = (isBusinessAccount && !isManager) ? 'pendingApproval' : 'queue';
+      break;
+    case 'drafts':
+      /* Pro and up users or Team Members */
+      validTabId = (!isFreeUser || isBusinessAccount) ? 'drafts' : 'queue';
+      break;
+    case 'grid':
+      /* Business users or Team Members */
+      validTabId = (isBusinessAccount && isInstagramProfile) ? 'grid' : 'queue';
+      break;
+    case 'settings':
+      validTabId = 'settings';
+      break;
+    default:
+      validTabId = 'queue';
+  }
+
+  return validTabId;
+};
+
+export { openCalendarWindow, openBillingWindow, getValidTab };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Currently, we only have a validation for a user to be able to access a tab, in the Tab itself, and not in the Tab Content, which leads to certain issues, for example, if the user changes a profile, is capable of seeing a "new" set of valid tabs, but still see the content even if it's invalid (examples of this behavior are grid and past reminders tabs)

**Example Gif**
![Screen Recording 2019-06-12 at 01 14 PM](https://user-images.githubusercontent.com/988972/59347085-0f799780-8d14-11e9-9a18-235d2f5893fb.gif)

With these changes, we are validating both the Tab and the Content in a single file, which will make it easier for us in the future if we decide to add a new tab.

<!--- Describe your changes in detail. -->

## Context & Notes
When a user has an Instagram profile selected and is wether in Past Reminders or Grid tab, when switching profile to a non-instagram account they should see the queue by default instead.

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
