### PR TITLE
[PUB-1345] Tweak trial extension notifications

### DIFF
--- a/packages/notifications-provider/utils/notifications.json
+++ b/packages/notifications-provider/utils/notifications.json
@@ -11,7 +11,7 @@
     "bitly-disconnect": "{{__variable__}}",
     "connection": "{{__variable__}}",
     "trial-extended": "{{__variable__}}",
-    "trial-already-extended": "Ups, it seems you already extended your trial once.",
-    "trial-extension-not-available": "Ups, it seems you might not be eligible for a trial extension."
+    "trial-already-extended": "Oops, it seems you already extended your trial once.",
+    "trial-extension-not-available": "Oops, it seems you might not be eligible for a trial extension."
   }
 }


### PR DESCRIPTION
## Description

Tweak copy of trial extension error notifications.

## Context & Notes

The goal is to standardize error messages
[PUB-1345](https://buffer.atlassian.net/browse/PUB-1345)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [X] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [X] I have identified similar or related features and tested they are still working.
-   [X] I have performed a self-review of my own code.
-   [X] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [X] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
