### PR TITLE
Fix issue: If there isn't a space between two hashtags, Buffer doesn't count them properly.

### DIFF
--- a/packages/composer/composer/entities/Draft.js
+++ b/packages/composer/composer/entities/Draft.js
@@ -1,6 +1,6 @@
 import { AttachmentTypes } from '../AppConstants';
 import { MENTION_REGEX } from '../utils/draft-js-custom-plugins/mention';
-import { HASHTAG_REGEX } from '../utils/draft-js-custom-plugins/hashtag';
+import countHashtagsInText from '../lib/validation/HashtagCounter';
 
 class Draft {
   constructor(service, editorState) {
@@ -76,16 +76,13 @@ class Draft {
   }
 
   getNumberOfHashtagsInText() {
-    const contentState = this.editorState.getCurrentContent();
-    const captionText = contentState.getPlainText();
-    const matchesInCaption = captionText.match(HASHTAG_REGEX);
-    return matchesInCaption !== null ? matchesInCaption.length : 0;
+    const captionText = this.editorState.getCurrentContent().getPlainText();
+    return countHashtagsInText(captionText);
   }
 
   getNumberOfHashtagsInComment() {
     const commentText = this.commentText || '';
-    const matchesInComment = commentText.match(HASHTAG_REGEX);
-    return matchesInComment !== null ? matchesInComment.length : 0;
+    return countHashtagsInText(commentText);
   }
 
   getNumberOfHashtags() {

--- a/packages/composer/composer/lib/validation/HashtagCounter.js
+++ b/packages/composer/composer/lib/validation/HashtagCounter.js
@@ -1,0 +1,15 @@
+const hashtagRegex = require('hashtag-regex');
+
+const countHashtagsInText = (text) => {
+  let counter = 0;
+
+  const regex = hashtagRegex();
+
+  while (regex.exec(text)) {
+    counter += 1;
+  }
+  return counter;
+};
+
+
+export default countHashtagsInText;

--- a/packages/composer/composer/tests/lib/validation/HashtagCounter.test.js
+++ b/packages/composer/composer/tests/lib/validation/HashtagCounter.test.js
@@ -3,13 +3,35 @@ import countHashtagsInText from '../../../lib/validation/HashtagCounter';
 describe('countHashtagsInText', () => {
   describe('there are not any hashtags', () => {
     it('returns 0 if there are none', () => {
-      expect(countHashtagsInText('text without hashtags')).toBe(0);
+      const text = 'text without hashtags';
+      expect(countHashtagsInText(text)).toBe(0);
     });
   });
 
   describe('there are hashtags', () => {
-    it('returns number of hashtags if there are none', () => {
-      expect(countHashtagsInText('text without hashtags')).toBe(0);
+    it('returns number of simple hashtags', () => {
+      const text = 'test #one #two #three test';
+      expect(countHashtagsInText(text)).toBe(3);
+    });
+
+    it('returns number of hashtags together', () => {
+      const text = 'test #one#two#three #four test';
+      expect(countHashtagsInText(text)).toBe(4);
+    });
+
+    it('returns number of hashtags with emojis', () => {
+      const text = 'test #one#two #three #four #🙂 #🏯 test';
+      expect(countHashtagsInText(text)).toBe(6);
+    });
+
+    it('returns number of hashtags with UTF8 characters', () => {
+      const text = 'test #one #two #árbol #cayó';
+      expect(countHashtagsInText(text)).toBe(4);
+    });
+
+    it('returns number of hashtags with UTF8 characters together', () => {
+      const text = 'test #one#two#árbol#cayó';
+      expect(countHashtagsInText(text)).toBe(4);
     });
   });
 });

--- a/packages/composer/composer/tests/lib/validation/HashtagCounter.test.js
+++ b/packages/composer/composer/tests/lib/validation/HashtagCounter.test.js
@@ -1,0 +1,15 @@
+import countHashtagsInText from '../../../lib/validation/HashtagCounter';
+
+describe('countHashtagsInText', () => {
+  describe('there are not any hashtags', () => {
+    it('returns 0 if there are none', () => {
+      expect(countHashtagsInText('text without hashtags')).toBe(0);
+    });
+  });
+
+  describe('there are hashtags', () => {
+    it('returns number of hashtags if there are none', () => {
+      expect(countHashtagsInText('text without hashtags')).toBe(0);
+    });
+  });
+});

--- a/packages/composer/package.json
+++ b/packages/composer/package.json
@@ -88,6 +88,7 @@
     "events": "1.1.1",
     "fetch-jsonp": "1.0.3",
     "flux": "2.1.1",
+    "hashtag-regex": "^2.0.0",
     "immutable": "3.7.6",
     "keymirror": "0.1.1",
     "lodash.clonedeep": "4.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7320,6 +7320,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+hashtag-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hashtag-regex/-/hashtag-regex-2.0.0.tgz#9b32413529e9ca28b41e7c6378e35677b178d5ad"
+  integrity sha512-6qWo1g10ggwyorTjMEswX/z8DkODD1XnfjBjndIAj7rnUOgVlwYQz4UPQU9yBz2jBGd3Im1D1wlzzI/o6Q1Ptw==
+
 hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"


### PR DESCRIPTION
## Description
Fix https://buffer.atlassian.net/browse/PUB-374 by using an external package to count the hashtags in the comment and caption of a draft in the composer.

## Screenshots
http://hi.buffer.com/b96d95d013bf

## Checklist

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
