### PR TITLE
[PUB-1615] Fix "Back to Dashboard" button route in Preferences when user has no profiles

### DIFF
--- a/packages/preferences/index.js
+++ b/packages/preferences/index.js
@@ -34,14 +34,18 @@ export default connect(
     // go back to the last selected profile
     onBackToDashboardClick: ({ selectedProfileId, profiles }) => {
       trackAction({ location: 'preferences', action: 'return_to_dashboard' });
-      const profileId = selectedProfileId || profiles[0].id;
-      const profile = profiles.find(p => p.id === profileId);
-      dispatch(profileSidebarActions.selectProfile({
-        profile,
-      }));
-      dispatch(push(generateProfilePageRoute({
-        profileId,
-      })));
+      if (profiles.length > 0) {
+        const profileId = selectedProfileId || profiles[0].id;
+        const profile = profiles.find(p => p.id === profileId);
+        dispatch(profileSidebarActions.selectProfile({
+          profile,
+        }));
+        dispatch(push(generateProfilePageRoute({
+          profileId,
+        })));
+      } else {
+        dispatch(push('/'));
+      }
     },
   }),
 )(Preferences);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Fix "Back to Dashboard" button route in Preferences when user has no profiles. In that case, instead of being redirected to a profile, gets redirected to the homepage.
<!--- Describe your changes in detail. -->

## Context & Notes
With the new AppShell component, every user has access to the Preferences page. When users without any social account connected tried to click on "Back to Dashboard" they would get an error.
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
[PUB-1615](https://buffer.atlassian.net/browse/PUB-1615)

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
