### PR TITLE
Added new case when we should hide IG direct posting modal

### DIFF
--- a/packages/modals/middleware.js
+++ b/packages/modals/middleware.js
@@ -94,6 +94,20 @@ export default ({ dispatch, getState }) => next => (action) => {
       break;
     }
 
+    case thirdPartyActionTypes.APPCUES_STARTED: {
+      const tourInProgress = getState().thirdparty.appCues.inProgress;
+      const selectedProfileId = getState().profileSidebar.selectedProfileId;
+
+      if (tourInProgress) {
+        dispatch(actions.hideInstagramDirectPostingModal());
+        dispatch(actions.saveModalToShowLater({
+          modalId: actionTypes.SHOW_IG_DIRECT_POSTING_MODAL,
+          selectedProfileId,
+        }));
+      }
+      break;
+    }
+
     case profileActionTypes.SELECT_PROFILE: {
       const profileId = getState().profileSidebar.selectedProfileId;
       const isIGBusiness = getState().profileSidebar.selectedProfile.service_type === 'business';

--- a/packages/modals/middleware.test.js
+++ b/packages/modals/middleware.test.js
@@ -2,10 +2,17 @@ import {
   actionTypes as dataFetchActionTypes,
   actions as dataFetchActions,
 } from '@bufferapp/async-data-fetch';
+
+import {
+  actionTypes as thirdPartyActionTypes,
+} from '@bufferapp/publish-thirdparty';
 import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar';
 
 import middleware from './middleware';
-import { actions } from './reducer';
+import {
+  actions,
+  actionTypes as modalsActionTypes,
+} from './reducer';
 
 describe('middleware', () => {
   it('should show welcome modal when key is present', () => {
@@ -153,6 +160,41 @@ describe('middleware', () => {
     expect(dispatch)
       .toBeCalledWith(nextAction);
   });
+
+  it('should hide instagram direct posting modal if AppCues tour starts', () => {
+    window._showModal = {
+      key: 'ig-direct-post-modal',
+    };
+    const next = jest.fn();
+    const dispatch = jest.fn();
+    const getState = () => ({
+      profileSidebar: {
+        selectedProfileId: 'id1',
+        selectedProfile: {
+          service_type: 'profile',
+        },
+      },
+      thirdparty: {
+        appCues: {
+          inProgress: true,
+        },
+      },
+    });
+
+    const action = {
+      type: thirdPartyActionTypes.APPCUES_STARTED,
+    };
+
+    const nextAction = {
+      type: modalsActionTypes.HIDE_IG_DIRECT_POSTING_MODAL,
+    };
+    middleware({ dispatch, getState })(next)(action);
+    expect(next)
+      .toBeCalledWith(action);
+    expect(dispatch)
+      .toBeCalledWith(nextAction);
+  });
+
   it('should ignore other actions', () => {
     const next = jest.fn();
     const dispatch = jest.fn();


### PR DESCRIPTION
## Description
Second attempt at fixing https://buffer.atlassian.net/browse/PUB-1607 by hiding the modal if the AppCues tour starts later.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
