### PR TITLE
Remove firstComment flip condition from composer

### DIFF
--- a/packages/composer/composer/components/AppStateless.jsx
+++ b/packages/composer/composer/components/AppStateless.jsx
@@ -180,7 +180,6 @@ const AppStateless = ({
         hasIGDirectFlip={userData.hasIGDirectFlip || false}
         hasIGLocationTaggingFeature={userData.hasIGLocationTaggingFeature || false}
         hasIGDirectVideoFlip={userData.hasIGDirectVideoFlip || false}
-        hasFirstCommentFlip={userData.hasFirstCommentFlip || false}
         hasShopgridFlip={userData.hasShopgridFlip || false}
         isFreeUser={userData.isFreeUser || false}
         isBusinessUser={userData.isBusinessUser || false}

--- a/packages/composer/composer/components/Composer.jsx
+++ b/packages/composer/composer/components/Composer.jsx
@@ -160,7 +160,6 @@ class Composer extends React.Component {
     canStartProTrial: PropTypes.bool,
     isOnProTrial: PropTypes.bool,
     hasIGDirectVideoFlip: PropTypes.bool,
-    hasFirstCommentFlip: PropTypes.bool,
     hasShopgridFlip: PropTypes.bool,
     isFreeUser: PropTypes.bool.isRequired,
     isBusinessUser: PropTypes.bool.isRequired,
@@ -173,7 +172,6 @@ class Composer extends React.Component {
     canStartProTrial: false,
     isOnProTrial: false,
     hasIGDirectVideoFlip: false,
-    hasFirstCommentFlip: false,
     hasShopgridFlip: false,
     profiles: [],
     expandedComposerId: null,
@@ -564,7 +562,6 @@ class Composer extends React.Component {
       composerPosition,
       hasIGLocationTaggingFeature,
       hasIGDirectVideoFlip,
-      hasFirstCommentFlip,
       hasShopgridFlip,
     } = this.props;
 
@@ -735,7 +732,6 @@ class Composer extends React.Component {
         (userHasBusinessOrProPlan ||
           this.props.canStartProTrial) &&
         this.isExpanded() &&
-        hasFirstCommentFlip &&
         !appState.isOmniboxEnabled
         )
       );

--- a/packages/composer/composer/components/ComposerSection.jsx
+++ b/packages/composer/composer/components/ComposerSection.jsx
@@ -34,7 +34,6 @@ class ComposerSection extends React.Component {
     isOnProTrial: PropTypes.bool.isRequired,
     hasIGDirectVideoFlip: PropTypes.bool.isRequired,
     isFreeUser: PropTypes.bool.isRequired,
-    hasFirstCommentFlip: PropTypes.bool,
     hasShopgridFlip: PropTypes.bool,
     isBusinessUser: PropTypes.bool,
   };
@@ -42,7 +41,6 @@ class ComposerSection extends React.Component {
   static defaultProps = {
     isOmniboxEnabled: null,
     composerPosition: null,
-    hasFirstCommentFlip: false,
     hasShopgridFlip: false,
     isBusinessUser: false,
   };
@@ -64,7 +62,7 @@ class ComposerSection extends React.Component {
       appState, profiles, visibleNotifications, areAllDraftsSaved, selectedProfiles,
       shouldEnableFacebookAutocomplete, shouldShowInlineSubprofileDropdown,
       isOmniboxEnabled, composerPosition, hasIGDirectFlip, hasIGLocationTaggingFeature,
-      hasIGDirectVideoFlip, isFreeUser, hasFirstCommentFlip, isBusinessUser, canStartProTrial,
+      hasIGDirectVideoFlip, isFreeUser, isBusinessUser, canStartProTrial,
       isOnProTrial, hasShopgridFlip,
     } = this.props;
 
@@ -114,7 +112,6 @@ class ComposerSection extends React.Component {
           canStartProTrial={canStartProTrial}
           isOnProTrial={isOnProTrial}
           hasIGDirectVideoFlip={hasIGDirectVideoFlip}
-          hasFirstCommentFlip={hasFirstCommentFlip}
           hasShopgridFlip={hasShopgridFlip}
           isFreeUser={isFreeUser}
           isBusinessUser={isBusinessUser}

--- a/packages/composer/composer/stores/AppStore.js
+++ b/packages/composer/composer/stores/AppStore.js
@@ -152,7 +152,6 @@ const getNewUserData = (data) => ({
   hasIGDirectFlip: data.hasIGDirectFlip,
   hasIGLocationTaggingFeature: data.hasIGLocationTaggingFeature,
   hasIGDirectVideoFlip: data.hasIGDirectVideoFlip,
-  hasFirstCommentFlip: data.hasFirstCommentFlip,
   canStartProTrial: data.canStartProTrial,
   isOnProTrial: data.isOnProTrial,
   hasShopgridFlip: data.hasShopgridFlip,

--- a/packages/composer/composer/utils/DataImportUtils.js
+++ b/packages/composer/composer/utils/DataImportUtils.js
@@ -164,7 +164,6 @@ const DataImportUtils = {
           canStartProTrial: userData.canStartProTrial,
           isOnProTrial: userData.isOnProTrial,
           hasIGDirectVideoFlip: userData.hasIGDirectVideoFlip,
-          hasFirstCommentFlip: hasFeature(userData.features, 'first_comment'),
           hasShopgridFlip: hasFeature(userData.features, 'grid_preview'),
           profileGroups: userData.profile_groups ?
             userData.profile_groups.map((group) => ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Remove ig first comment feature flip condition from composer. It's no longer needed now that free users can see toggle. 
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
