### PR TITLE
[PUB-1390] Add hasOrganizationMembers prop to profile parser

### DIFF
--- a/packages/server/parsers/src/profileParser.js
+++ b/packages/server/parsers/src/profileParser.js
@@ -1,5 +1,5 @@
 const isInstagramAnalyticsSupported = profile =>
-  profile.service === 'instagram' && profile.is_instagram_business
+  profile.service === 'instagram' && profile.is_instagram_business;
 
 module.exports = profile => ({
   id: profile.id,
@@ -10,6 +10,7 @@ module.exports = profile => ({
   handle: profile.service_username,
   isManager: profile.organization_role === 1,
   ownerId: profile.user_id,
+  hasOrganizationMembers: profile.has_organization_members,
   pendingCount: profile.counts.pending,
   sentCount: profile.counts.sent,
   timezone: profile.timezone,
@@ -45,4 +46,4 @@ module.exports = profile => ({
     (profile.service === 'twitter' ||
       profile.service === 'facebook' ||
       isInstagramAnalyticsSupported(profile)),
-})
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Add hasOrganizationMembers prop to profile parser
<!--- Describe your changes in detail. -->

## Context & Notes
We need the `hasOrganizationMembers` prop to check if a locked profile belongs to a team account.

[PUB-1390](https://buffer.atlassian.net/browse/PUB-1390)
buffer-web PR: https://github.com/bufferapp/buffer-web/pull/16306/
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
