### PR TITLE
[PUB-1390] Change logic drag locked team profiles

### DIFF
--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -27,6 +27,7 @@ export const initialState = {
   hasTwitter: true,
   isSearchPopupVisible: false,
   searchText: null,
+  userId: null,
 };
 
 const moveProfileInArray = (arr, from, to) => {
@@ -43,7 +44,7 @@ const moveProfileInArray = (arr, from, to) => {
   return clone;
 };
 
-const handleProfileDropped = (profiles, action) => {
+const handleProfileDropped = (profiles, action, userId) => {
   const { profileLimit, hoverIndex, dragIndex } = action;
   const reorderedProfiles = moveProfileInArray(profiles, dragIndex, hoverIndex);
     /* The reducer will return an object with 3 properties, each of them an array of profiles.
@@ -55,9 +56,9 @@ const handleProfileDropped = (profiles, action) => {
     teamProfiles,
   } = reorderedProfiles.reduce(
     (acc, cur) => {
-      /* If the profile has organization members (team members) it can't be unlocked,
+      /* If the user is not the owner it can't be unlocked,
       it goes to the teamProfiles array. */
-      if (cur.hasOrganizationMembers) {
+      if (cur.ownerId !== userId) {
         return { ...acc, teamProfiles: [...acc.teamProfiles, cur] };
       }
 
@@ -205,7 +206,7 @@ export default (state = initialState, action) => {
       if (!action.commit) {
         return {
           ...state,
-          profiles: handleProfileDropped(state.profiles, action),
+          profiles: handleProfileDropped(state.profiles, action, state.userId),
         };
       }
       return state;
@@ -217,6 +218,12 @@ export default (state = initialState, action) => {
       return {
         ...state,
         profiles: profilesReducer(state.profiles, action),
+      };
+    }
+    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`: {
+      return {
+        ...state,
+        userId: action.result.id,
       };
     }
     default:

--- a/packages/profile-sidebar/reducer.test.js
+++ b/packages/profile-sidebar/reducer.test.js
@@ -11,6 +11,7 @@ describe('reducer', () => {
       profiles: [],
       loading: false,
       selectedProfileId: '',
+      userId: null,
       selectedProfile: {},
       isBusinessAccount: false,
       isLockedProfile: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Prevent users from unlocking blocked team accounts by dragging them.
<!--- Describe your changes in detail. -->

## Context & Notes
If a profile is locked and the user is not its owner (it means the owner downgraded the plan), by dragging the profile it will not get unlocked. These types of profiles will never be able to be moved to the top of unlocked profiles, because we have a profile order in the sidebar: first unlocked, then locked profiles.

[PUB-1390](https://buffer.atlassian.net/browse/PUB-1390)
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
![locked](https://user-images.githubusercontent.com/16758464/61129257-e9c6e600-a4ab-11e9-978a-05726006fb37.gif)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
