### PR TITLE
[PUB-1482] Fixing sent posts order on Share Again

### DIFF
--- a/packages/composer-popover/components/ComposerWrapper/index.jsx
+++ b/packages/composer-popover/components/ComposerWrapper/index.jsx
@@ -35,12 +35,14 @@ export default connect(
         case 'sent':
           options = {
             editMode: state.sent.editMode,
+            sentPost: true,
             post: state.sent.byProfileId[selectedProfileId].posts[postId],
           };
           break;
         case 'pastReminders':
           options = {
             editMode: state.pastReminders.editMode,
+            sentPost: true,
             post: state.pastReminders.byProfileId[selectedProfileId].posts[postId],
           };
           break;

--- a/packages/composer/composer/components/App.jsx
+++ b/packages/composer/composer/components/App.jsx
@@ -161,12 +161,11 @@ class App extends React.Component {
     csrfToken: PropTypes.string.isRequired,
     imageDimensionsKey: PropTypes.string.isRequired,
     onNewPublish: PropTypes.bool,
-
     options: PropTypes.shape({
       canSelectProfiles: PropTypes.bool.isRequired,
       preserveStateOnClose: PropTypes.bool.isRequired,
       saveButtons: PropTypes.arrayOf(
-        PropTypes.oneOf(Object.keys(SaveButtonTypes))
+        PropTypes.oneOf(Object.keys(SaveButtonTypes)),
       ).isRequired,
       updateId: PropTypes.string,
       position: PropTypes.shape({
@@ -175,6 +174,7 @@ class App extends React.Component {
         margin: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       }),
       onSave: PropTypes.func,
+      sentPost: PropTypes.bool,
     }).isRequired,
   };
 
@@ -189,6 +189,7 @@ class App extends React.Component {
     },
     options: {
       onSave: () => {},
+      sentPost: false,
     },
     profilesData: {
       isContributor: false,
@@ -381,6 +382,7 @@ class App extends React.Component {
         saveButtons={saveButtons}
         isPinnedToSlot={this.state.isPinnedToSlot}
         availableSchedulesSlotsForDay={this.state.availableSchedulesSlotsForDay}
+        sentPost={this.props.options.sentPost}
       />
     );
   }

--- a/packages/composer/composer/components/AppStateless.jsx
+++ b/packages/composer/composer/components/AppStateless.jsx
@@ -117,6 +117,7 @@ const AppStateless = ({
   saveButtons,
   isPinnedToSlot,
   availableSchedulesSlotsForDay,
+  sentPost,
 }) => (
   <div
     ref={appElementRef}
@@ -203,6 +204,7 @@ const AppStateless = ({
         whatPreventsSavingMessages={appState.whatPreventsSaving}
         isOmniboxEnabled={isOmniboxEnabled({ appState })}
         selectedProfiles={selectedProfiles({ profiles })}
+        sentPost={sentPost}
       />
       <ReactTooltip class={styles.tooltip} effect="solid" place="top" />
     </div>
@@ -230,12 +232,14 @@ AppStateless.propTypes = {
   saveButtons: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
   availableSchedulesSlotsForDay: PropTypes.any, // eslint-disable-line
   isPinnedToSlot: PropTypes.bool,
+  sentPost: PropTypes.bool,
 };
 
 AppStateless.defaultProps = {
   onNewPublish: false,
   scheduledAt: null,
   isPinnedToSlot: false,
+  sentPost: false,
 };
 
 export default AppStateless;

--- a/packages/composer/composer/components/UpdateSaver.jsx
+++ b/packages/composer/composer/components/UpdateSaver.jsx
@@ -45,10 +45,12 @@ class UpdateSaver extends React.Component {
       })),
     ]),
     isPinnedToSlot: PropTypes.bool,
+    sentPost: PropTypes.bool,
   };
 
   static defaultProps = {
     isPinnedToSlot: null,
+    sentPost: false,
   };
 
   state = getUpdateSaverState();
@@ -114,9 +116,10 @@ class UpdateSaver extends React.Component {
   render() {
     const {
       appState, userData, metaData, visibleNotifications, timezone, moreThanOneProfileSelected,
-      areAllDraftsSaved, saveButtons, scheduledAt, isSlotPickingAvailable,
-      availableSchedulesSlotsForDay, isPinnedToSlot, selectedProfiles,
+      areAllDraftsSaved, saveButtons, isSlotPickingAvailable,
+      availableSchedulesSlotsForDay, isPinnedToSlot, selectedProfiles, sentPost,
     } = this.props;
+    let { scheduledAt } = this.props;
 
     const {
       isSavingPossible, isDraftsSavePending, draftSaveQueueingType, isOmniboxEnabled,
@@ -223,6 +226,7 @@ class UpdateSaver extends React.Component {
         getActiveSaveButtonCopy(firstStackedButtonType, draftSaveQueueingType);
     }
 
+    if (sentPost) scheduledAt = null;
     const shouldDisplayInlineScheduler = scheduledAt !== null;
     let scheduledAtMoment;
     let humanReadableScheduledAt;

--- a/packages/composer/composer/stores/AppStore.js
+++ b/packages/composer/composer/stores/AppStore.js
@@ -576,7 +576,7 @@ const checkIfSavingPossible = () => {
 
   // Enabled drafts shouldn't be above the optional character limit
   const enabledDrafts = ComposerStore.getEnabledDrafts();
-  const enabledDraftsAboveCharLimit = enabledDrafts.filter((draft) =>
+  const enabledDraftsAboveCharLimit = enabledDrafts.filter(draft =>
     draft.characterCount > draft.service.charLimit);
   const hasEnabledDraftsAboveCharLimit = enabledDraftsAboveCharLimit.length > 0;
 
@@ -584,29 +584,30 @@ const checkIfSavingPossible = () => {
     return {
       isSavingPossible: false,
       whatPreventsSaving: Array.prototype.concat.call(
-        enabledDraftsAboveCharLimit.map((draft) => ({
+        enabledDraftsAboveCharLimit.map(draft => ({
           message: `We can only fit ${draft.service.charLimit} characters in this post`,
           composerId: draft.id,
           code: 1,
         })),
         ...invalidEnabledDraftsInfo.map(({ draft, messages }) => (
-          messages.map((message) => ({
+          messages.map(message => ({
             message,
             composerId: draft.id,
           }))
-        ))
+        )),
       ),
     };
   }
 
   // Enabled drafts, if scheduled, should be scheduled for a time in the future
-  const scheduledAt = ComposerStore.getScheduledAt();
+  const isSentPost = ComposerStore.isSentPost();
+  const scheduledAt = isSentPost ? null : ComposerStore.getScheduledAt();
   const currentTimestampSeconds = Math.floor(Date.now() / 1000);
   if (scheduledAt !== null && scheduledAt <= currentTimestampSeconds) {
     return {
       isSavingPossible: false,
       whatPreventsSaving: [{
-        message: 'The scheduled time seems to be in the past',
+        message: 'The scheduled time seems to be in the past asd',
       }],
     };
   }

--- a/packages/composer/composer/stores/AppStore.js
+++ b/packages/composer/composer/stores/AppStore.js
@@ -607,7 +607,7 @@ const checkIfSavingPossible = () => {
     return {
       isSavingPossible: false,
       whatPreventsSaving: [{
-        message: 'The scheduled time seems to be in the past asd',
+        message: 'The scheduled time seems to be in the past',
       }],
     };
   }
@@ -620,7 +620,7 @@ const updateIsSavingPossible = () => {
 
   state.appState.isSavingPossible = isSavingPossible;
   state.appState.whatPreventsSaving =
-    whatPreventsSaving.map((what) => getNewPreventsSavingObj(what));
+    whatPreventsSaving.map(what => getNewPreventsSavingObj(what));
 };
 
 const getExpandedComposerId = () => state.appState.expandedComposerId;

--- a/packages/composer/composer/stores/ComposerStore.js
+++ b/packages/composer/composer/stores/ComposerStore.js
@@ -297,6 +297,10 @@ const ComposerStore = Object.assign({}, EventEmitter.prototype, {
 
   // scheduledAt and isPinnedToSlot are the same across all drafts
   getScheduledAt: () => state.drafts[0].scheduledAt,
+  isSentPost: () => {
+    const { sentPost } = AppStore.getOptions();
+    return sentPost;
+  },
   isPinnedToSlot: () => state.drafts[0].isPinnedToSlot,
 
   getMeta: () => state.meta,
@@ -305,8 +309,8 @@ const ComposerStore = Object.assign({}, EventEmitter.prototype, {
    * Do not use: synchronous "dispatches" go against Flux's ideas, this method
    * is only used in a single place to prevent a race condition.
    */
-   // eslint-disable-next-line no-use-before-define
-  _syncDispatch: (payload) => onDispatchedPayload(payload),
+  // eslint-disable-next-line no-use-before-define
+  _syncDispatch: payload => onDispatchedPayload(payload),
 });
 
 // Should be used for composition with functions that are passed a draft id as first argument.
@@ -1818,7 +1822,7 @@ const onDispatchedPayload = (payload) => {
       handleRemovedDraftLinks(action.id, action.removedUrls);
       break;
 
-    case ActionTypes.COMPOSER_UPDATE_DRAFTS_SCHEDULED_AT:
+    case ActionTypes.COMPOSER_UPDATE_DRAFTS_SCHEDULED_AT:-
       state.drafts.forEach((draft) => {
         updateDraftScheduledAt(draft.id, action.scheduledAt, action.isPinnedToSlot);
       });

--- a/packages/composer/composer/stores/ComposerStore.js
+++ b/packages/composer/composer/stores/ComposerStore.js
@@ -1822,7 +1822,7 @@ const onDispatchedPayload = (payload) => {
       handleRemovedDraftLinks(action.id, action.removedUrls);
       break;
 
-    case ActionTypes.COMPOSER_UPDATE_DRAFTS_SCHEDULED_AT:-
+    case ActionTypes.COMPOSER_UPDATE_DRAFTS_SCHEDULED_AT:
       state.drafts.forEach((draft) => {
         updateDraftScheduledAt(draft.id, action.scheduledAt, action.isPinnedToSlot);
       });

--- a/packages/composer/interfaces/buffer-publish.jsx
+++ b/packages/composer/interfaces/buffer-publish.jsx
@@ -21,6 +21,7 @@ const ComposerWrapper = ({
   enabledApplicationModes,
   environment,
   editMode,
+  sentPost,
   post,
   onSave,
   preserveStateOnClose,
@@ -64,6 +65,7 @@ const ComposerWrapper = ({
     position: { margin: '0 auto' },
     onSave,
     preserveStateOnClose: emptySlotMode ? false : preserveStateOnClose,
+    sentPost,
   };
 
   const subprofileId = post ? post.subprofile_id : undefined;
@@ -148,6 +150,7 @@ ComposerWrapper.propTypes = {
   preserveStateOnClose: PropTypes.bool.isRequired,
   environment: PropTypes.string.isRequired,
   editMode: PropTypes.bool.isRequired,
+  sentPost: PropTypes.bool,
   emptySlotMode: PropTypes.bool,
   post: PropTypes.shape({}).isRequired,
   csrfToken: PropTypes.string.isRequired,
@@ -166,6 +169,7 @@ ComposerWrapper.defaultProps = {
   csrfToken: '1234', // dummy string for now since MC requires csrfToken
   post: {},
   editMode: false,
+  sentPost: false,
   emptySlotMode: false,
   selectedProfileId: null,
   onInteraction: () => {},

--- a/packages/past-reminders/reducer.js
+++ b/packages/past-reminders/reducer.js
@@ -207,7 +207,6 @@ export const actions = {
       type: actionTypes.OPEN_COMPOSER,
       updateId: post.id,
       editMode: false,
-      post: Object.assign(post, { due_at: null, scheduled_at: null }),
       profileId,
     };
   },

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -200,7 +200,6 @@ export const actions = {
       type: actionTypes.OPEN_COMPOSER,
       updateId: post.id,
       editMode: false,
-      post: Object.assign(post, { due_at: null, scheduled_at: null }),
       profileId,
     };
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Fixing scheduled_at time when sharing a post again, since it's messing the posts order on clicking Share Again.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
[[PUB-1482](https://buffer.atlassian.net/browse/PUB-1482)] On Sent posts tab or Past Reminders, when the user clicks on "Share Again", the post immediately drops to the bottom of the post list.

## Screenshots
![Screen Recording 2019-07-12 at 03 46 PM](https://user-images.githubusercontent.com/988972/61132725-3fa38a00-a4bc-11e9-8644-530f63bbd627.gif)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
