### PR TITLE
[PUB-1635] Hide analytics overview tab if profile is linkedin or pinterest

### DIFF
--- a/packages/tabs/components/TabNavigation/story.jsx
+++ b/packages/tabs/components/TabNavigation/story.jsx
@@ -31,9 +31,9 @@ const store = storeFake({
     user: {
       trial: {
         onTrial: false,
-      }
-    }
-  }
+      },
+    },
+  },
 });
 
 const UpgradeModalDecorator = storyFn => (

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -20,10 +20,8 @@ export default connect(
     shouldShowUpgradeCta: state.appSidebar.user.is_free_user,
     shouldShowNestedSettingsTab: ownProps.tabId === 'settings',
     shouldShowNestedAnalyticsTab: ownProps.tabId === 'analytics',
-    shouldHideAnalyticsOverviewTab: state.profileSidebar.selectedProfile.business &&
-                                    state.appSidebar.user.trial.onTrial &&
-                                    (state.profileSidebar.selectedProfile.type === 'linkedin'
-                                    || state.profileSidebar.selectedProfile.type === 'pinterest'),
+    shouldHideAnalyticsOverviewTab: state.profileSidebar.selectedProfile.type === 'linkedin'
+                                    || state.profileSidebar.selectedProfile.type === 'pinterest',
     profileId: ownProps.profileId,
     isLockedProfile: state.profileSidebar.isLockedProfile,
     isInstagramProfile: state.generalSettings.isInstagramProfile,

--- a/packages/tabs/index.test.js
+++ b/packages/tabs/index.test.js
@@ -1,6 +1,77 @@
-describe('example', () => {
-  it('should pass', () => {
-    expect(2 + 2)
-      .toBe(4);
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+
+import TabNavigation, {
+  reducer,
+  actions,
+  actionTypes,
+  middleware,
+} from './index';
+
+const storeFake = state => ({
+  default: () => {},
+  subscribe: () => {},
+  dispatch: () => {},
+  getState: () => ({ ...state }),
+});
+
+describe('TabNavigation', () => {
+  const store = storeFake({
+    profileSidebar: {
+      selectedProfile: {
+        business: true,
+        isManager: true,
+        type: 'linkedin',
+      },
+      isLockedProfile: false,
+    },
+    appSidebar: {
+      user: {
+        canStartProTrial: true,
+        trial: {
+          onTrial: false,
+        },
+      },
+    },
+    generalSettings: {
+      isInstagramProfile: false,
+    },
+    environment: {
+      environment: 'production',
+    },
+    productFeatures: {
+      planName: 'pro',
+    },
+  });
+
+  it('should render', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <TabNavigation />
+      </Provider>,
+    );
+    expect(wrapper.find(TabNavigation).length)
+      .toBe(1);
+  });
+
+  it('should export reducer', () => {
+    expect(reducer)
+      .toBeDefined();
+  });
+
+  it('should export actions', () => {
+    expect(actions)
+      .toBeDefined();
+  });
+
+  it('should export actionTypes', () => {
+    expect(actionTypes)
+      .toBeDefined();
+  });
+
+  it('should export middleware', () => {
+    expect(middleware)
+      .toBeDefined();
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Hide Analytics "Overview" tab for LinkedIn and Pinterest profiles, as we don't support their analytics.
<!--- Describe your changes in detail. -->

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
Users are seeing the Overview tab for LinkedIn when coming from Classic dashboard. They believe this is the same as the Analysis tab they previously could access and are wanting to see their Data.
<!--- Is there a related JIRA card? Please link to it here. -->
[PUB-1635](https://buffer.atlassian.net/browse/PUB-1635)

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
