### PR TITLE
[PUB-1653] Hide HelpScout Beacon during Appcues tour

### DIFF
--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -6,8 +6,6 @@ import { actionTypes } from './reducer';
 
 import {
   HELPSCOUT_ID,
-  APPCUES_PRO_TRIAL_FLOW_ID,
-  APPCUES_PRO_TRIAL_TEST_FLOW_ID,
 } from './constants';
 
 const checkExtensionInstalled = () => {
@@ -76,7 +74,6 @@ export default ({ dispatch, getState }) => next => (action) => {
             profileCount,
             is_business_user: isBusinessUser,
           } = action.result;
-
           if (isBusinessUser || plan === 'pro') {
             dispatch({
               type: actionTypes.APPCUES_LOADED,
@@ -95,28 +92,18 @@ export default ({ dispatch, getState }) => next => (action) => {
               profileCount, // Number of profiles _owned_ by the user
             });
 
-            // Only dispatch event for a particular Appcues flow
-            const shouldDispatchEvent = event => (
-              event.flowId === APPCUES_PRO_TRIAL_FLOW_ID ||
-              event.flowId === APPCUES_PRO_TRIAL_TEST_FLOW_ID
-            );
-
-            const dispatchAppcuesStartedIfProTrialFlow = (event) => {
-              if (shouldDispatchEvent(event)) {
-                dispatch({
-                  type: actionTypes.APPCUES_STARTED,
-                });
-              }
+            const dispatchAppcuesStarted = () => {
+              dispatch({
+                type: actionTypes.APPCUES_STARTED,
+              });
             };
 
-            window.Appcues.on('flow_started', dispatchAppcuesStartedIfProTrialFlow);
+            window.Appcues.on('flow_started', dispatchAppcuesStarted);
 
-            const dispatchAppcuesFinished = (event) => {
-              if (shouldDispatchEvent(event)) {
-                dispatch({
-                  type: actionTypes.APPCUES_FINISHED,
-                });
-              }
+            const dispatchAppcuesFinished = () => {
+              dispatch({
+                type: actionTypes.APPCUES_FINISHED,
+              });
             };
 
             window.Appcues.on('flow_completed', dispatchAppcuesFinished);
@@ -125,6 +112,13 @@ export default ({ dispatch, getState }) => next => (action) => {
           }
         }
       }
+      break;
+    case actionTypes.APPCUES_STARTED:
+      const beaconDiv = document.querySelector('beacon-container');
+      beaconDiv.style.display = 'none';
+      break;
+    case actionTypes.APPCUES_FINISHED:
+      beaconDiv.style.display = '';
       break;
     case actionTypes.HELPSCOUT_BEACON:
       if (window && window.Beacon) {


### PR DESCRIPTION
## Description
This change is specifically being made for Appcues tours for new business trialists. We want to hide the Beacon as to not confuse folx regarding their next steps.

## Context & Notes
https://buffer.atlassian.net/browse/PUB-1653

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`