### PR TITLE
Fix Bugsnag integration environment

### DIFF
--- a/helm/buffer-publish.dev.yaml
+++ b/helm/buffer-publish.dev.yaml
@@ -46,3 +46,5 @@ env:
       secretKeyRef:
         key: stripe-publishable
         name: buffer-publish-keys
+  - name: RELEASE_STAGE
+    value: staging

--- a/helm/buffer-publish.yaml
+++ b/helm/buffer-publish.yaml
@@ -87,6 +87,8 @@ env:
       secretKeyRef:
         key: stripe-publishable
         name: buffer-publish-keys
+  - name: RELEASE_STAGE
+    value: production
 healthcheck: # checkout https://github.com/bufferapp/EKG for complete docs
   enabled: false
   config:

--- a/packages/server/lib/bugsnag.js
+++ b/packages/server/lib/bugsnag.js
@@ -4,14 +4,7 @@ const { join } = require('path');
 
 const BUGSNAG_KEY = process.env.BUGSNAG_KEY;
 const HOSTNAME = process.env.HOSTNAME;
-
-const isProduction = process.env.NODE_ENV === 'production';
-
-/**
- * String is used to detect what kind of server we're on
- * format was pulled from the current setup in k8s.
- */
-const PROD_HOSTNAME_PREFIX = 'buffer-publish-master';
+const RELEASE_STAGE = process.env.RELEASE_STAGE;
 
 const APP_TYPE_SERVER = 'express-server';
 const APP_TYPE_FRONTEND = 'frontend';
@@ -20,15 +13,9 @@ const APP_TYPE_FRONTEND = 'frontend';
  * Get the current `releaseStage` for Bugsnag
  * https://docs.bugsnag.com/platforms/javascript/configuration-options/#releasestage
  */
-const getReleaseStage = () => {
-  if (HOSTNAME && isProduction) {
-    if (HOSTNAME.startsWith(PROD_HOSTNAME_PREFIX)) {
-      return 'production';
-    }
-    return 'staging';
-  }
-  return 'development';
-};
+const getReleaseStage = () => (
+  RELEASE_STAGE || 'development'
+);
 
 /**
  * Get the `appVersion` for Bugsnag.


### PR DESCRIPTION
## Description
Fix stage set in Bugsnag by adding a new env. variable.

## Context & Notes
This is required because we were setting always staging as the env in production.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
