### PR TITLE
fix Analyze Facebook posts

### DIFF
--- a/packages/server/rpc/analytics/postsAnalyzeApi/index.js
+++ b/packages/server/rpc/analytics/postsAnalyzeApi/index.js
@@ -1,0 +1,43 @@
+const { method } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+function mapSortBy(sortBy) {
+  switch (sortBy) {
+    case 'sent_at':
+      return 'date';
+
+    case 'engagement_rate':
+      return 'EngagementRate';
+
+    default:
+      return sortBy;
+  }
+}
+
+function normalizeDate(posts) {
+  return posts.map(post => ({ ...post,
+    date: post.date * 1000
+  }));
+}
+
+module.exports = method(
+  'posts_analyze_api',
+  'fetch analytics posts for profiles and pages',
+  ({ profileId, startDate, endDate, sortBy, descending, limit, searchTerms }, req) =>
+    rp({
+      uri: `${req.app.get('analyzeApiAddr')}/posts`,
+      method: 'POST',
+      strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
+      body: {
+        profile_id: profileId,
+        start_date: startDate,
+        end_date: endDate,
+        sort_by: mapSortBy(sortBy),
+        descending,
+        limit,
+        search_terms: searchTerms,
+      },
+      json: true,
+    }).then(({ response }) => normalizeDate(response)),
+
+);

--- a/packages/server/rpc/analytics/postsAnalyzeApi/index.test.js
+++ b/packages/server/rpc/analytics/postsAnalyzeApi/index.test.js
@@ -1,0 +1,69 @@
+/* eslint-disable import/first */
+
+jest.mock('micro-rpc-client');
+jest.mock('request-promise');
+import rp from 'request-promise';
+import posts from './';
+
+describe('rpc/posts_analyze_api', () => {
+  const request = {
+    app: {
+      get: () => 'analyze-api',
+    },
+  };
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should have the expected name', () => {
+    expect(posts.name)
+      .toBe('posts_analyze_api');
+  });
+
+  it('should have the expected docs', () => {
+    expect(posts.docs)
+      .toBe('fetch analytics posts for profiles and pages');
+  });
+
+  it('should fetch posts for the given profileId and date range', async () => {
+    const profileId = 'profile-123';
+    const startDate = '2019-02-01';
+    const endDate = '2019-02-28';
+    const sortBy = 'sent_at';
+    const descending = 'false';
+    const limit = 5;
+    const searchTerms = ['foo'];
+    rp.mockReturnValueOnce(Promise.resolve({
+      response: ['post 1', 'post 2', 'post 3'],
+    }));
+
+    await posts.fn({ profileId, startDate, endDate, sortBy, descending, limit, searchTerms }, request);
+
+    expect(rp.mock.calls[0]).toEqual([{
+      uri: 'analyze-api/posts',
+      method: 'POST',
+      strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
+      body: {
+        profile_id: profileId,
+        start_date: startDate,
+        end_date: endDate,
+        sort_by: 'date',
+        descending,
+        limit,
+        search_terms: searchTerms,
+      },
+      json: true,
+    }]);
+  });
+
+  it('should normalize post date', async () => {
+    rp.mockReturnValueOnce(Promise.resolve({
+      response: [{ date: 42, foo: 'foo' }],
+    }));
+
+    const response = await posts.fn({}, request);
+    expect(response[0])
+      .toEqual({ date: 42000, foo: 'foo' });
+  });
+});
+

--- a/packages/server/rpc/analytics/utils/postParser.js
+++ b/packages/server/rpc/analytics/utils/postParser.js
@@ -1,0 +1,101 @@
+const { getDateString } = require('../utils/date');
+const { parseTwitterLinks } = require('./linkParsing');
+
+const getImageUrls = (post) => {
+  if (!(post.media && post.media.picture && post.extra_media)) return [];
+  const imageUrls = post.extra_media.map(media =>
+    media.photo,
+  );
+
+  imageUrls.unshift(post.media.picture);
+  return imageUrls;
+};
+
+const getPostActionString = ({ post }) => {
+  const timestampToConvert = post.sent_at || post.due_at;
+  // due_at set to 0 when user has no scheduled posting times
+  if (timestampToConvert === 0) {
+    return 'NO TIME SET';
+  }
+  const dateString = getDateString(
+    timestampToConvert,
+    post.profile_timezone,
+    {
+      twentyFourHourTime: post.twentyfour_hour_time,
+    },
+  );
+  return `This post ${post.sent_at ? 'was' : 'will be'} sent ${dateString}.`;
+};
+
+const getPostDetails = ({ post }) => ({
+  postAction: getPostActionString({ post }),
+  isRetweet: post.retweet !== undefined,
+});
+
+const getRetweetProfileInfo = (post) => {
+  const retweet = post.retweet;
+  if (!retweet) {
+    return undefined;
+  }
+
+  return {
+    name: retweet.profile_name,
+    handle: `@${retweet.username}`,
+    avatarUrl: retweet.avatars.https,
+  };
+};
+
+const getPostType = ({ post }) => {
+  if (!post.media || post.retweet) {
+    return 'text';
+  } else if (post.media && post.media.picture && !post.extra_media) {
+    return 'image';
+  } else if (post.media && post.media.picture && post.extra_media) {
+    return 'multipleImage';
+  } else if (post.media && post.media.video) {
+    return 'video';
+  } else if (post.media && post.media.link) {
+    return 'link';
+  }
+  return 'text';
+};
+
+module.exports = {
+  postsMapper: (post) => {
+    const media = post.media || {};
+    const isVideo = media.video;
+    let retweetComment;
+    let text;
+
+    if (post.retweet) {
+      text = post.retweet.text;
+      retweetComment = post.retweet.comment;
+    } else {
+      text = post.text;
+    }
+    return {
+      day: post.day,
+      id: post.id,
+      isConfirmingDelete: post.isDeleting && !post.requestingDraftAction,
+      isDeleting: post.isDeleting && post.requestingDraftAction,
+      isWorking: !post.isDeleting && post.requestingDraftAction,
+      imageSrc: isVideo ? media.thumbnail : media.picture,
+      imageUrls: getImageUrls(post),
+      links: parseTwitterLinks(text),
+      profileTimezone: post.profile_timezone,
+      linkAttachment: {
+        title: media.title,
+        url: media.expanded_link,
+        description: media.description,
+        thumbnailUrl: media.preview,
+      },
+      postDetails: getPostDetails({ post }),
+      retweetComment,
+      retweetCommentLinks: parseTwitterLinks(retweetComment),
+      retweetProfile: getRetweetProfileInfo(post),
+      sent: post.status === 'sent',
+      text,
+      type: getPostType({ post }),
+    };
+  },
+};


### PR DESCRIPTION
## Description
This updates Analyze `rpc/posts` so that it uses the new endpoint for Facebook posts.

## Context & Notes
This fixes https://buffer.atlassian.net/browse/PUB-1673 and missing metrics in the posts

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
