### PR TITLE
Adding check for images existence before running updateUploadedImageDimensions

### DIFF
--- a/packages/composer/composer/stores/ComposerStore.js
+++ b/packages/composer/composer/stores/ComposerStore.js
@@ -1214,8 +1214,10 @@ const updateUploadedImageDimensions = (url, width, height) => {
     image = imageCollection.find((uploadedImage) => uploadedImage.url === url)
   ));
 
-  image.width = width;
-  image.height = height;
+  if (image) {
+    image.width = width;
+    image.height = height;
+  }
 };
 
 /**


### PR DESCRIPTION
## Description

[PUB-1660](https://buffer.atlassian.net/browse/PUB-1660) - Adding check for images existence before running updateUploadedImageDimensions

If image doesn't exist because a user has deleted it before it completes uploading, or a use switches to another social network, we dont want it to throw an error anymore when setting the width and height as the image is no longer there


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
