### PR TITLE
Avoid sending something different than a number as a page for pagination

### DIFF
--- a/packages/server/rpc/sentPosts/index.js
+++ b/packages/server/rpc/sentPosts/index.js
@@ -11,7 +11,7 @@ module.exports = method(
       page = 1;
     }
 
-    rp({
+    return rp({
       uri: `${process.env.API_ADDR}/1/profiles/${profileId}/updates/sent.json`,
       method: 'GET',
       strictSSL: !(process.env.NODE_ENV === 'development'),

--- a/packages/server/rpc/sentPosts/index.js
+++ b/packages/server/rpc/sentPosts/index.js
@@ -30,4 +30,5 @@ module.exports = method(
           updates: mappedUpdates,
         };
       });
-});
+  },
+);

--- a/packages/server/rpc/sentPosts/index.js
+++ b/packages/server/rpc/sentPosts/index.js
@@ -7,7 +7,7 @@ module.exports = method(
   'sentPosts',
   'fetch sent posts',
   ({ profileId, page }, { session }) => {
-    if (typeof page !== 'number') {
+    if (typeof page !== 'number' || isNaN(page)) {
       page = 1;
     }
 

--- a/packages/server/rpc/sentPosts/index.js
+++ b/packages/server/rpc/sentPosts/index.js
@@ -6,7 +6,11 @@ const { buildPostMap } = require('./../../formatters/src');
 module.exports = method(
   'sentPosts',
   'fetch sent posts',
-  ({ profileId, page }, { session }) =>
+  ({ profileId, page }, { session }) => {
+    if (typeof page !== 'number') {
+      page = 1;
+    }
+
     rp({
       uri: `${process.env.API_ADDR}/1/profiles/${profileId}/updates/sent.json`,
       method: 'GET',
@@ -25,5 +29,5 @@ module.exports = method(
           total: parsedResult.total,
           updates: mappedUpdates,
         };
-      }),
-);
+      });
+});


### PR DESCRIPTION
## Description
Fix https://buffer.atlassian.net/browse/PUB-1662.

## Notes
Since there's a lot of indirection on where the page param comes from, I thought it's easier and more effective to be more defensive about this value so if we have something different than a number we set it to 1.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
