### PR TITLE
Remove initial loading case from profile sidebar

### DIFF
--- a/packages/profile-sidebar/middleware.js
+++ b/packages/profile-sidebar/middleware.js
@@ -11,8 +11,6 @@ import {
   actions as dataFetchActions,
 } from '@bufferapp/async-data-fetch';
 
-import { actionTypes as initialLoadingActionTypes } from '@bufferapp/publish-initial-loading';
-
 import { actions as notificationActions } from '@bufferapp/notifications';
 import {
   actions,
@@ -56,8 +54,7 @@ export default ({ dispatch, getState }) => next => (action) => {
         }));
       }
       break;
-    case `profiles_${dataFetchActionTypes.FETCH_SUCCESS}`:
-    case initialLoadingActionTypes.PROFILE_LOADING_REDIRECT: {
+    case `profiles_${dataFetchActionTypes.FETCH_SUCCESS}`: {
       const profilesLoaded = getState().profileSidebar.loading === false;
       if (!profilesLoaded) {
         break;
@@ -103,7 +100,7 @@ export default ({ dispatch, getState }) => next => (action) => {
         dispatch(push('/new-connection-business-trialists'));
       } else if (!isPreferencePage && profiles.length === 0) {
         dispatch(push('/new-connection'));
-      } 
+      }
       break;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Remove initialLoading case from the appSidebar
<!--- Describe your changes in detail. -->

## Context & Notes
Sometimes, users with profiles are redirected first to `/new-connection-business-trialists` or `/new-connection` for a bit, and then they are redirected to their queue. That means that at the time the `(!isPreferencePage && profiles.length === 0)` condition is first checked, the profiles request response hasn't happened yet. We believe making sure this code only runs in the case `profiles_${dataFetchActionTypes.FETCH_SUCCESS}` will do the trigger.
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
