### PR TITLE
Fix for incorrect userId being used in Qualaroo script

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -171,8 +171,8 @@ const segmentScript = `<script>
       }}();
     </script>`;
 
-const qualarooScript = userId => {
-  return `<!-- Qualaroo for buffer.com -->
+const qualarooScript = 
+  `<!-- Qualaroo for buffer.com -->
     <script type="text/javascript">
       var _kiq = _kiq || [];
       (function(){
@@ -181,13 +181,7 @@ const qualarooScript = userId => {
         s.async = true; s.src = '//s3.amazonaws.com/ki.js/50685/d9G.js'; f.parentNode.insertBefore(s, f);
         }, 1);
       })();
-    </script>
-
-    <script> type="text/javascript" charset="utf-8">
-    _kiq.push(['identify', '${userId}']);
-    <script>
-    `;
-};
+    </script>`;
 
 const getHtml = ({ notification, userId, modalKey, modalValue }) =>
   fs
@@ -202,7 +196,7 @@ const getHtml = ({ notification, userId, modalKey, modalValue }) =>
     .replace('{{{showModalScript}}}', showModalScript(modalKey, modalValue))
     .replace('{{{appcues}}}', isProduction ? appcuesScript : '')
     .replace('{{{intercomScript}}}', intercomScript)
-    .replace('{{{qualarooScript}}}', isProduction ? qualarooScript(userId) : '')
+    .replace('{{{qualarooScript}}}', isProduction ? qualarooScript : '')
     .replace('{{{helpScoutScript}}}', helpScoutScript)
     .replace('{{{userScript}}}', getUserScript({ id: userId }))
     .replace('{{{favicon}}}', getFaviconCode({ cacheBust: 'v1' }))

--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -29,6 +29,14 @@ export default ({ dispatch, getState }) => next => (action) => {
       dispatch({ type: actionTypes.FULLSTORY, result: action.result });
       dispatch({ type: actionTypes.APPCUES, result: action.result });
       dispatch({ type: actionTypes.HELPSCOUT_BEACON, result: action.result });
+      dispatch({ type: actionTypes.QUALAROO, result: action.result });
+      break;
+
+    case actionTypes.QUALAROO:
+      if (window && window._kiq) {
+        const { id } = action.result;
+        window._kiq.push(['identify', id]);
+      }
       break;
 
     case `intercom_${dataFetchActionTypes.FETCH_SUCCESS}`: {

--- a/packages/thirdParty/reducer.js
+++ b/packages/thirdParty/reducer.js
@@ -10,6 +10,7 @@ export const actionTypes = keyWrapper('thirdparty', {
   INTERCOM_LOADED: 0,
   HELPSCOUT_BEACON: 0,
   HELPSCOUT_BEACON_LOADED: 0,
+  QUALAROO: 0,
 });
 
 const initialState = {


### PR DESCRIPTION
## Description

The previous user id that was being used to identify the user was actually a session foreign key, not the user's actual user id. 

## Context & Notes
This change is required so that we can continue doing Qualaroo surveys/research in New Publish.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
