### PR TITLE
[PUB-1732] Reverting pro trials starts to direct pro upgrades

### DIFF
--- a/packages/app-shell/components/AppShell/index.jsx
+++ b/packages/app-shell/components/AppShell/index.jsx
@@ -109,11 +109,7 @@ function generateUserMenuItems({
     extraItems.push(userMenuItems.returnToClassic);
   }
   if (showUpgradeToPro) {
-    if (showStartProTrial) {
-      extraItems.push(userMenuItems.startProTrial);
-    } else {
-      extraItems.push(userMenuItems.upgradeToPro);
-    }
+    extraItems.push(userMenuItems.upgradeToPro);
   }
   return [...userMenuItems.top, ...extraItems];
 }

--- a/packages/composer/composer/action-creators/AppActionCreators.js
+++ b/packages/composer/composer/action-creators/AppActionCreators.js
@@ -202,27 +202,14 @@ const AppActionCreators = {
               // the link.
               message: removeLinkFromErrorMessageText(
                 unsuccessfulResponse.message,
-                'embedded-cta-link'
+                'embedded-cta-link',
               ),
               isUnique: true,
               cta: {
-                label: isFreeUser && canStartProTrial ? 'Start Pro Trial' : 'Show Paid Plans',
-                action: (event) => {
+                label: 'Show Paid Plans',
+                action: () => {
                   const { environment } = AppStore.getMetaData();
                   if (isFreeUser) {
-                    if (canStartProTrial) {
-                      if (event && event.target && !event.target.disabled) {
-                        event.target.disabled = true;
-                      }
-                      AppActionCreators.triggerInteraction({
-                        message: {
-                          action: 'START_PRO_TRIAL',
-                          scope,
-                          source,
-                        },
-                      });
-                      return;
-                    }
                     if (AppStore.isExtension()) {
                       window.open(`${bufferOrigins.get(environment)}/pricing`);
                     } else {

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -107,19 +107,12 @@ class TabNavigation extends React.Component {
             </Text>
             <div style={{ marginLeft: '8px', display: 'inline-block' }}>
               <Button
-                label={canStartProTrial ? 'Start a 7 day Pro Trial' : 'Upgrade to Pro'}
+                label={'Upgrade for more'}
                 type="secondary"
                 size="small"
                 onClick={(e) => {
                   e.preventDefault();
-                  if (canStartProTrial) {
-                    window.location.assign(`${getURL.getStartTrialURL({
-                      trialType: 'pro',
-                      cta: SEGMENT_NAMES.HEADER_PRO_TRIAL,
-                    })}`);
-                  } else {
-                    onUpgradeButtonClick('pro');
-                  }
+                  onUpgradeButtonClick('pro');
                 }}
               />
             </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Reverting PRO trial starts back to be direct upgrades.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
Related JIRA task: [PUB-1732](https://buffer.atlassian.net/browse/PUB-1732)

## Screenshots
**App header menu CTA button**
<img width="347" alt="Image 2019-07-25 at 11 51 55 AM" src="https://user-images.githubusercontent.com/988972/61864917-9fddf700-aed2-11e9-9ba0-61b5d6015207.png">

**Queue limit in Composer**
<img width="592" alt="Image 2019-07-25 at 11 53 26 AM" src="https://user-images.githubusercontent.com/988972/61865052-d582e000-aed2-11e9-9b3b-2cb67a7f7ba9.png">

**App shell menu button**
<img width="229" alt="Image 2019-07-25 at 11 54 20 AM" src="https://user-images.githubusercontent.com/988972/61865120-f3e8db80-aed2-11e9-87c3-10a83eecd21d.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
