### PR TITLE
[PUB-1614] Displaying first comment section only for Instagram accounts

### DIFF
--- a/packages/composer/composer/components/Composer.jsx
+++ b/packages/composer/composer/components/Composer.jsx
@@ -763,17 +763,25 @@ class Composer extends React.Component {
       this.props.isOnProTrial
     );
 
+    const areAllSelectedProfilesIG = () => {
+      const notInstagram = this.props.selectedProfiles.some(profile => profile.service.name !== 'instagram');
+
+      return !notInstagram || appState.expandedComposerId === 'instagram';
+    };
+
     const shouldDisplayFirstCommentSection = (commentEnabled) => {
       const hasSelectedSomeInstagramDirectProfiles =
         this.props.selectedProfiles.some(profile => profile.instagramDirectEnabled);
       return (
-        commentEnabled || (
-        hasSelectedSomeInstagramDirectProfiles &&
-        this.isInstagram() &&
-        (userHasBusinessOrProPlan ||
-          this.props.canStartProTrial) &&
-        this.isExpanded() &&
-        !appState.isOmniboxEnabled
+        areAllSelectedProfilesIG() && (
+          commentEnabled || (
+            hasSelectedSomeInstagramDirectProfiles &&
+            this.isInstagram() &&
+            (userHasBusinessOrProPlan ||
+              this.props.canStartProTrial) &&
+            this.isExpanded() &&
+            !appState.isOmniboxEnabled
+          )
         )
       );
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Displaying first comment section only for Instagram accounts.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
**JIRA card:** [PUB-1614](https://buffer.atlassian.net/browse/PUB-1614)
When a user has Instagram and other social profiles selected in the composer, and switches from customizing an Instagram post with a first comment to another social profile, the first comment toggle persists. Since first comment is an Instagram-only feature, we should hide it when a user is customizing a post for other profiles. 

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
