### PR TITLE
[PUB-1485] Removing unnecessary endpoint call after hashtag creation

### DIFF
--- a/packages/hashtag-group-manager/middleware.js
+++ b/packages/hashtag-group-manager/middleware.js
@@ -9,7 +9,7 @@ import { actionTypes } from './reducer';
 const refreshHashtagGroups = (dispatch, organizationId) => {
   if (organizationId) {
     dispatch(dataFetchActions.fetch({
-      name: 'hashtagGroups',
+      name: 'getHashtagGroups',
       args: {
         organizationId,
       },
@@ -56,7 +56,6 @@ export default ({ getState, dispatch }) => next => (action) => {
       trackAction({ location: 'hashtagManager', action: 'hashtag_inserted', metadata: { organizationId } });
       break;
     case `createHashtagGroup_${dataFetchActionTypes.FETCH_SUCCESS}`:
-      refreshHashtagGroups(dispatch, organizationId);
       trackAction({ location: 'hashtagManager', action: 'hashtag_created', metadata: { organizationId } });
       break;
     default:

--- a/packages/hashtag-group-manager/middleware.js
+++ b/packages/hashtag-group-manager/middleware.js
@@ -42,14 +42,19 @@ export default ({ getState, dispatch }) => next => (action) => {
       }));
       break;
     case `createHashtagGroup_${dataFetchActionTypes.FETCH_FAIL}`:
-    case `deleteHashtagGroup_${dataFetchActionTypes.FETCH_FAIL}`:
       dispatch(notificationActions.createNotification({
         notificationType: 'error',
         message: action.error,
       }));
       break;
+    case `deleteHashtagGroup_${dataFetchActionTypes.FETCH_FAIL}`:
+      dispatch(notificationActions.createNotification({
+        notificationType: 'error',
+        message: action.error,
+      }));
+      refreshHashtagGroups(dispatch, organizationId);
+      break;
     case `profiles_${dataFetchActionTypes.FETCH_SUCCESS}`:
-    case `deleteHashtagGroup_${dataFetchActionTypes.FETCH_SUCCESS}`:
       refreshHashtagGroups(dispatch, organizationId);
       break;
     case actionTypes.INSERT_HASHTAG_GROUP:

--- a/packages/hashtag-group-manager/reducer.js
+++ b/packages/hashtag-group-manager/reducer.js
@@ -29,6 +29,16 @@ export default (state = initialState, action) => {
         ...state,
         name: action.name,
       };
+    case actionTypes.SAVE_HASHTAG_GROUP:
+      const newGroups = [
+        ...state.groups,
+        { _id: 'temp', name: state.name, text: state.text },
+      ].sort((a, b) => (a.name < b.name ? -1 : 1));
+
+      return {
+        ...state,
+        groups: newGroups,
+      };
     case `createHashtagGroup_${dataFetchActionTypes.FETCH_SUCCESS}`:
       return {
         ...state,

--- a/packages/hashtag-group-manager/reducer.js
+++ b/packages/hashtag-group-manager/reducer.js
@@ -19,7 +19,7 @@ export const initialState = {
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case `hashtagGroups_${dataFetchActionTypes.FETCH_SUCCESS}`:
+    case `getHashtagGroups_${dataFetchActionTypes.FETCH_SUCCESS}`:
       return {
         ...state,
         groups: action.result.data.snippets,
@@ -32,6 +32,7 @@ export default (state = initialState, action) => {
     case `createHashtagGroup_${dataFetchActionTypes.FETCH_SUCCESS}`:
       return {
         ...state,
+        groups: action.result.data.snippets,
         name: '',
         text: '',
       };

--- a/packages/hashtag-group-manager/reducer.js
+++ b/packages/hashtag-group-manager/reducer.js
@@ -47,6 +47,11 @@ export default (state = initialState, action) => {
         name: '',
         text: '',
       };
+    case actionTypes.DELETE_HASHTAG_GROUP:
+      return {
+        ...state,
+        groups: state.groups.filter(group => group._id !== action.groupId),
+      };
     default:
       return state;
   }

--- a/packages/server/rpc/getHashtagGroups/index.js
+++ b/packages/server/rpc/getHashtagGroups/index.js
@@ -2,7 +2,7 @@ const { method, createError } = require('@bufferapp/buffer-rpc');
 const rp = require('request-promise');
 
 module.exports = method(
-  'hashtagGroups',
+  'getHashtagGroups',
   'fetch hashtag groups',
   ({ organizationId }, { session }) =>
     rp({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Removing unnecessary endpoint call after hashtag creation, changed the rpc from hashtagGroup to getHashtagGroup, so it's easier to understand.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
We are calling get hashtag groups once a new group is created, which is unnecessary and is causing a delay in the UI.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
