### PR TITLE
fix twitter posts rpc

### DIFF
--- a/packages/server/rpc/analytics/posts/index.js
+++ b/packages/server/rpc/analytics/posts/index.js
@@ -14,10 +14,9 @@ const fetchTopPosts = (
   limit,
   searchTerms,
   accessToken,
-  apiAddr,
 ) =>
   rp({
-    uri: `${apiAddr}/1/profiles/${profileId}/analytics/all_posts.json`,
+    uri: `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/all_posts.json`,
     method: 'GET',
     strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
     qs: {
@@ -71,7 +70,6 @@ module.exports = method(
       limit,
       searchTerms,
       req.session.publish.accessToken,
-      req.app.get('analyzeApiAddr'),
     );
 
     return parsePosts(Object.values(posts.updates_with_stats));


### PR DESCRIPTION
Fix posts breakdown table for Twitter profiles in the overview tab.

## Description
To make sure we are properly fetching twitter updates in the Overview tab.

## Context & Notes
This fixes a bug I accidentally introduced with #828, which was causing RPC to fetch posts on the wrong API address for twitter.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [X] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [X] I have identified similar or related features and tested they are still working.
-   [X] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
