### PR TITLE
[PUB-1601] Composer close confirmation modal

### DIFF
--- a/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/index.jsx
+++ b/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Text, Modal } from '@bufferapp/ui';
+import { Modal } from '@bufferapp/ui';
 
 import * as Styles from './style';
 
@@ -13,8 +13,8 @@ const CloseComposerConfirmationModal = ({
     action={{ label: translations.sure, callback: onCloseComposerAndConfirmationModal }}
     secondaryAction={{ label: translations.cancel, callback: onCloseComposerModal }}
   >
-    <Styles.ModalBody>
-      <Text type="span">{translations.text}</Text>
+    <Styles.ModalBody type="p">
+      {translations.text}
     </Styles.ModalBody>
   </Modal>
 );

--- a/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/index.jsx
+++ b/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/index.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Text, Modal } from '@bufferapp/ui';
+
+import * as Styles from './style';
+
+const CloseComposerConfirmationModal = ({
+  translations,
+  onCloseComposerAndConfirmationModal,
+  onCloseComposerModal,
+}) => (
+  <Modal
+    action={{ label: translations.sure, callback: onCloseComposerAndConfirmationModal }}
+    secondaryAction={{ label: translations.cancel, callback: onCloseComposerModal }}
+  >
+    <Styles.ModalBody>
+      <Text type="span">{translations.text}</Text>
+    </Styles.ModalBody>
+  </Modal>
+);
+
+CloseComposerConfirmationModal.propTypes = {
+  translations: PropTypes.object.isRequired,
+  onCloseComposerAndConfirmationModal: PropTypes.func.isRequired,
+  onCloseComposerModal: PropTypes.func.isRequired,
+};
+
+export default CloseComposerConfirmationModal;

--- a/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/index.jsx
+++ b/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/index.jsx
@@ -20,7 +20,7 @@ const CloseComposerConfirmationModal = ({
 );
 
 CloseComposerConfirmationModal.propTypes = {
-  translations: PropTypes.object.isRequired,
+  translations: PropTypes.object.isRequired,  // eslint-disable-line
   onCloseComposerAndConfirmationModal: PropTypes.func.isRequired,
   onCloseComposerModal: PropTypes.func.isRequired,
 };

--- a/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/story.jsx
+++ b/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/story.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { checkA11y } from 'storybook-addon-a11y';
+import CloseComposerConfirmationModal from './index';
+
+const translations = {
+  text: 'Are you sure you want to close the composer? You will lose your progress if you continue!',
+  sure: 'Yes, I\'m sure',
+  cancel: 'Cancel'
+};
+
+storiesOf('CloseComposerConfirmationModal', module)
+  .addDecorator(checkA11y)
+  .add('should show modal', () => (
+    <CloseComposerConfirmationModal
+      translations={translations}
+      onCloseComposerAndConfirmationModal={() => {}}
+      onCloseComposerModal={() => {}}
+      type={'queue'}
+    />
+  ));

--- a/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/story.jsx
+++ b/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/story.jsx
@@ -6,7 +6,7 @@ import CloseComposerConfirmationModal from './index';
 const translations = {
   text: 'Are you sure you want to close the composer? You will lose your progress if you continue!',
   sure: 'Yes, I\'m sure',
-  cancel: 'Cancel'
+  cancel: 'Cancel',
 };
 
 storiesOf('CloseComposerConfirmationModal', module)
@@ -16,6 +16,6 @@ storiesOf('CloseComposerConfirmationModal', module)
       translations={translations}
       onCloseComposerAndConfirmationModal={() => {}}
       onCloseComposerModal={() => {}}
-      type={'queue'}
+      type="queue"
     />
   ));

--- a/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/style.js
+++ b/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/style.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const ModalBody = styled.div`
+  width: 100%;
+  padding: 16px 16px 0 16px;
+  font-size: 14px;
+  box-sizing: border-box;
+`;

--- a/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/style.js
+++ b/packages/close-composer-confirmation-modal/components/CloseComposerConfirmationModal/style.js
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
+import { Text } from '@bufferapp/ui';
 
-export const ModalBody = styled.div`
-  width: 100%;
+export const ModalBody = styled(Text)`
   padding: 16px 16px 0 16px;
-  font-size: 14px;
-  box-sizing: border-box;
+  margin: 0;
 `;

--- a/packages/close-composer-confirmation-modal/index.js
+++ b/packages/close-composer-confirmation-modal/index.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux';
+import { actions as modalsActions } from '@bufferapp/publish-modals';
+import { actions as queueActions } from '@bufferapp/publish-queue';
+import { actions as draftsActions } from '@bufferapp/publish-drafts';
+import { actions } from './reducer';
+
+// load the presentational component
+import CloseComposerConfirmationModal from './components/CloseComposerConfirmationModal';
+
+export default connect(
+  (state, ownProps) => ({
+    translations: state.i18n.translations['close-composer-confirmation-modal'],
+  }),
+  (dispatch, ownProps) => ({
+    onCloseComposerModal: () => dispatch(modalsActions.hideCloseComposerConfirmationModal()),
+    onCloseComposerAndConfirmationModal: () => dispatch(actions.closeComposerAndConfirmationModal()),
+  }),
+)(CloseComposerConfirmationModal);
+
+export reducer, { actions, actionTypes } from './reducer';
+export middleware from './middleware';

--- a/packages/close-composer-confirmation-modal/index.js
+++ b/packages/close-composer-confirmation-modal/index.js
@@ -1,19 +1,18 @@
 import { connect } from 'react-redux';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
-import { actions as queueActions } from '@bufferapp/publish-queue';
-import { actions as draftsActions } from '@bufferapp/publish-drafts';
 import { actions } from './reducer';
 
 // load the presentational component
 import CloseComposerConfirmationModal from './components/CloseComposerConfirmationModal';
 
 export default connect(
-  (state, ownProps) => ({
+  state => ({
     translations: state.i18n.translations['close-composer-confirmation-modal'],
   }),
-  (dispatch, ownProps) => ({
+  dispatch => ({
     onCloseComposerModal: () => dispatch(modalsActions.hideCloseComposerConfirmationModal()),
-    onCloseComposerAndConfirmationModal: () => dispatch(actions.closeComposerAndConfirmationModal()),
+    onCloseComposerAndConfirmationModal:
+      () => dispatch(actions.closeComposerAndConfirmationModal()),
   }),
 )(CloseComposerConfirmationModal);
 

--- a/packages/close-composer-confirmation-modal/middleware.js
+++ b/packages/close-composer-confirmation-modal/middleware.js
@@ -1,0 +1,30 @@
+import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
+import { actions as queueActions } from '@bufferapp/publish-queue';
+import { actions as draftsActions } from '@bufferapp/publish-drafts';
+// import { actions as awaitingApprovalActions } from '@bufferapp/publish-awaitingApproval';
+import { actions as modalsActions } from '@bufferapp/publish-modals';
+import { actionTypes } from './reducer';
+
+export default ({ dispatch, getState }) => next => (action) => {
+  next(action);
+  const { tabId } = getState().tabs;
+
+  switch (action.type) {
+    case actionTypes.CLOSE_COMPOSER_AND_CONFIRMATION_MODAL:
+      switch (tabId) {
+        case 'queue':
+          dispatch(queueActions.handleComposerCreateSuccess());
+          break;
+        case 'drafts':
+        case 'awaitingApproval':
+          dispatch(draftsActions.handleComposerCreateSuccess());
+          break;
+        default:
+          break;
+      }
+      dispatch(modalsActions.hideCloseComposerConfirmationModal());
+      break;
+    default:
+      break;
+  }
+};

--- a/packages/close-composer-confirmation-modal/middleware.js
+++ b/packages/close-composer-confirmation-modal/middleware.js
@@ -1,7 +1,5 @@
-import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 import { actions as queueActions } from '@bufferapp/publish-queue';
 import { actions as draftsActions } from '@bufferapp/publish-drafts';
-// import { actions as awaitingApprovalActions } from '@bufferapp/publish-awaitingApproval';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
 import { actionTypes } from './reducer';
 

--- a/packages/close-composer-confirmation-modal/package.json
+++ b/packages/close-composer-confirmation-modal/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@bufferapp/publish-close-composer-confirmation-modal",
+  "version": "2.0.0",
+  "description": "Confirmation modal for closing the composer",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint . --ignore-pattern coverage node_modules"
+  },
+  "author": "maria.u@bufferapp.com",
+  "dependencies": {
+    "@bufferapp/async-data-fetch": "1.9.4",
+    "@bufferapp/publish-server": "2.0.0",
+    "@bufferapp/keywrapper": "0.2.0",
+    "@bufferapp/publish-modals": "2.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^5.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/close-composer-confirmation-modal/reducer.js
+++ b/packages/close-composer-confirmation-modal/reducer.js
@@ -1,5 +1,4 @@
 import keyWrapper from '@bufferapp/keywrapper';
-import { actionTypes as draftActionTypes } from '@bufferapp/publish-drafts';
 
 export const initialState = {
   closeComposerConfirmationModal: false,

--- a/packages/close-composer-confirmation-modal/reducer.js
+++ b/packages/close-composer-confirmation-modal/reducer.js
@@ -1,0 +1,27 @@
+import keyWrapper from '@bufferapp/keywrapper';
+import { actionTypes as draftActionTypes } from '@bufferapp/publish-drafts';
+
+export const initialState = {
+  closeComposerConfirmationModal: false,
+};
+
+export const actionTypes = keyWrapper('CLOSE_COMPOSER_CONFIRMATION_MODAL', {
+  CLOSE_COMPOSER_AND_CONFIRMATION_MODAL: 0,
+});
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case actionTypes.CLOSE_COMPOSER_AND_CONFIRMATION_MODAL:
+      return {
+        ...state,
+      };
+    default:
+      return state;
+  }
+};
+
+export const actions = {
+  closeComposerAndConfirmationModal: () => ({
+    type: actionTypes.CLOSE_COMPOSER_AND_CONFIRMATION_MODAL,
+  }),
+};

--- a/packages/composer-popover/index.js
+++ b/packages/composer-popover/index.js
@@ -3,17 +3,28 @@ import PropTypes from 'prop-types';
 import { Popover } from '@bufferapp/components';
 import ComposerWrapper from './components/ComposerWrapper';
 
+const onOverlayClick = (onSave, onComposerOverlayClick, editMode) => {
+  // If the composer is in editMode, display the confirmation modal
+  if (editMode) {
+    onComposerOverlayClick();
+  } else {
+    onSave();
+  }
+};
+
 const ComposerPopover = ({
   onSave,
+  onComposerOverlayClick,
   transparentOverlay,
   preserveComposerStateOnClose,
   type,
+  editMode,
 }) => (
   <Popover
     width={'100%'}
     top={'5rem'}
     transparentOverlay={transparentOverlay}
-    onOverlayClick={onSave}
+    onOverlayClick={() => onOverlayClick(onSave, onComposerOverlayClick, editMode)}
   >
     <ComposerWrapper
       type={type}
@@ -25,6 +36,7 @@ const ComposerPopover = ({
 
 ComposerPopover.propTypes = {
   onSave: PropTypes.func.isRequired,
+  onComposerOverlayClick: PropTypes.func.isRequired,
   transparentOverlay: PropTypes.bool,
   preserveComposerStateOnClose: PropTypes.bool,
   type: PropTypes.oneOf(['queue', 'drafts', 'sent', 'pastReminders']),

--- a/packages/drafts/components/DraftList/index.jsx
+++ b/packages/drafts/components/DraftList/index.jsx
@@ -63,6 +63,7 @@ const DraftList = ({
   onImageClickNext,
   onImageClickPrev,
   onImageClose,
+  onComposerOverlayClick,
 }) => {
   if (features.isProUser()) {
     const startTrial = () =>
@@ -126,6 +127,8 @@ const DraftList = ({
                   type={'drafts'}
                   onSave={onComposerCreateSuccess}
                   preserveComposerStateOnClose
+                  onComposerOverlayClick={onComposerOverlayClick}
+                  editMode={editMode}
                 />
               }
               <ComposerInput
@@ -139,6 +142,8 @@ const DraftList = ({
           <ComposerPopover
             type={'drafts'}
             onSave={onComposerCreateSuccess}
+            onComposerOverlayClick={onComposerOverlayClick}
+            editMode={editMode}
           />
         }
         {
@@ -200,6 +205,7 @@ DraftList.propTypes = {
   onImageClose: PropTypes.func.isRequired,
   onImageClickNext: PropTypes.func.isRequired,
   onImageClickPrev: PropTypes.func.isRequired,
+  onComposerOverlayClick: PropTypes.func.isRequired,
 };
 
 DraftList.defaultProps = {

--- a/packages/drafts/index.js
+++ b/packages/drafts/index.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { getDateString, isInThePast } from '@bufferapp/publish-server/formatters/src';
+import { actions as modalsActions } from '@bufferapp/publish-modals';
 
 import { actions } from './reducer';
 import DraftList from './components/DraftList';
@@ -228,6 +229,9 @@ export default connect(
         draft: draft.draft,
         profileId: ownProps.profileId,
       }));
+    },
+    onComposerOverlayClick: () => {
+      dispatch(modalsActions.showCloseComposerConfirmationModal());
     },
   }),
 )(DraftList);

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -162,8 +162,8 @@
     "cancelTrialAndLock": "Cancel Trial and Lock Extra Profiles"
   },
   "close-composer-confirmation-modal": {
-    "text": "Are you sure you want to close the composer? You will lose your progress if you continue!",
-    "sure": "Yes, I'm sure",
+    "text": "Are you sure you want to close the composer? You will lose any unsaved changes.",
+    "sure": "Yes, Close Composer",
     "cancel": "Cancel"
   }
 }

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -160,5 +160,10 @@
     "completeAndUpgrade": "Complete and Upgrade",
     "cancelTrial": "Cancel Trial",
     "cancelTrialAndLock": "Cancel Trial and Lock Extra Profiles"
+  },
+  "close-composer-confirmation-modal": {
+    "text": "Are you sure you want to close the composer? You will lose your progress if you continue!",
+    "sure": "Yes, I'm sure",
+    "cancel": "Cancel"
   }
 }

--- a/packages/modals/components/AppModals/index.jsx
+++ b/packages/modals/components/AppModals/index.jsx
@@ -11,6 +11,7 @@ import InstagramDirectPostingModal from '@bufferapp/publish-ig-direct-posting-mo
 import WelcomeB4BTrialModal from '@bufferapp/publish-welcome-b4b-trial-modal';
 import B4bTrialCompleteModal from '@bufferapp/publish-b4b-trial-complete-modal';
 import InstagramFirstCommentProTrialModal from '@bufferapp/publish-ig-first-comment-pro-trial-modal';
+import CloseComposerConfirmationModal from '@bufferapp/publish-close-composer-confirmation-modal';
 
 const AppModals = ({
   showUpgradeModal,
@@ -23,6 +24,7 @@ const AppModals = ({
   showInstagramFirstCommentModal,
   showB4BTrialExpiredModal,
   showInstagramFirstCommentProTrialModal,
+  showCloseComposerConfirmationModal,
 }) => (
   <React.Fragment>
     {showProfilesDisconnectedModal && <ProfilesDisconnectedModal />}
@@ -35,6 +37,7 @@ const AppModals = ({
     {showStealProfileModal && <StealProfileModal />}
     {showB4BTrialExpiredModal && <B4bTrialCompleteModal />}
     {showInstagramFirstCommentProTrialModal && <InstagramFirstCommentProTrialModal />}
+    {showCloseComposerConfirmationModal && <CloseComposerConfirmationModal />}
   </React.Fragment>
 );
 
@@ -49,6 +52,7 @@ AppModals.propTypes = {
   showInstagramFirstCommentModal: PropTypes.bool.isRequired,
   showB4BTrialExpiredModal: PropTypes.bool.isRequired,
   showInstagramFirstCommentProTrialModal: PropTypes.bool.isRequired,
+  showCloseComposerConfirmationModal: PropTypes.bool.isRequired,
 };
 
 export default AppModals;

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -16,6 +16,7 @@
     "@bufferapp/publish-welcome-paid-modal": "2.0.0",
     "@bufferapp/publish-welcome-b4b-trial-modal": "2.0.0",
     "@bufferapp/publish-profiles-disconnected-modal": "2.0.0",
+    "@bufferapp/publish-close-composer-confirmation-modal": "2.0.0",
     "@bufferapp/buffermetrics": "0.9.0"
   },
   "devDependencies": {

--- a/packages/modals/reducer.js
+++ b/packages/modals/reducer.js
@@ -1,5 +1,4 @@
 import keyWrapper from '@bufferapp/keywrapper';
-import { actionTypes as draftActionTypes } from '@bufferapp/publish-drafts';
 
 export const initialState = {
   showUpgradeModal: false,

--- a/packages/modals/reducer.js
+++ b/packages/modals/reducer.js
@@ -1,4 +1,5 @@
 import keyWrapper from '@bufferapp/keywrapper';
+import { actionTypes as draftActionTypes } from '@bufferapp/publish-drafts';
 
 export const initialState = {
   showUpgradeModal: false,
@@ -14,6 +15,7 @@ export const initialState = {
   showB4BTrialExpiredModal: false,
   upgradeModalB4BSource: null,
   showInstagramFirstCommentProTrialModal: false,
+  showCloseComposerConfirmationModal: false,
   modalToShowLater: null,
 };
 
@@ -39,6 +41,8 @@ export const actionTypes = keyWrapper('MODALS', {
   SHOW_INSTAGRAM_FIRST_COMMENT_PRO_TRIAL_MODAL: 0,
   HIDE_INSTAGRAM_FIRST_COMMENT_PRO_TRIAL_MODAL: 0,
   SAVE_MODAL_TO_SHOW_LATER: 0,
+  HIDE_CLOSE_COMPOSER_CONFIRMATION_MODAL: 0,
+  SHOW_CLOSE_COMPOSER_CONFIRMATION_MODAL: 0,
 });
 
 export default (state = initialState, action) => {
@@ -157,7 +161,16 @@ export default (state = initialState, action) => {
         ...state,
         showInstagramFirstCommentProTrialModal: true,
       };
-
+    case actionTypes.HIDE_CLOSE_COMPOSER_CONFIRMATION_MODAL:
+      return {
+        ...state,
+        showCloseComposerConfirmationModal: false,
+      };
+    case actionTypes.SHOW_CLOSE_COMPOSER_CONFIRMATION_MODAL:
+      return {
+        ...state,
+        showCloseComposerConfirmationModal: true,
+      };
     default:
       return state;
   }
@@ -235,5 +248,11 @@ export const actions = {
   }),
   hideWelcomeB4BTrialModal: () => ({
     type: actionTypes.HIDE_WELCOME_B4B_TRIAL_MODAL,
+  }),
+  hideCloseComposerConfirmationModal: () => ({
+    type: actionTypes.HIDE_CLOSE_COMPOSER_CONFIRMATION_MODAL,
+  }),
+  showCloseComposerConfirmationModal: () => ({
+    type: actionTypes.SHOW_CLOSE_COMPOSER_CONFIRMATION_MODAL,
   }),
 };

--- a/packages/modals/reducer.test.js
+++ b/packages/modals/reducer.test.js
@@ -104,5 +104,13 @@ describe('reducer', () => {
       expect(reducer(stateWithVisibleModal, actions.hideInstagramFirstCommentProTrialModal()))
         .toEqual(Object.assign(initialState, { showInstagramFirstCommentProTrialModal: false }));
     });
+    it('should show close composer confirmation modal', () => {
+      expect(reducer(initialState, actions.showCloseComposerConfirmationModal()))
+        .toEqual(Object.assign(initialState, { showCloseComposerConfirmationModal: true }));
+    });
+    it('should hide close composer confirmation modal', () => {
+      expect(reducer(initialState, actions.hideCloseComposerConfirmationModal()))
+        .toEqual(Object.assign(initialState, { showCloseComposerConfirmationModal: false }));
+    });
   });
 });

--- a/packages/modals/reducer.test.js
+++ b/packages/modals/reducer.test.js
@@ -112,5 +112,25 @@ describe('reducer', () => {
       expect(reducer(initialState, actions.hideCloseComposerConfirmationModal()))
         .toEqual(Object.assign(initialState, { showCloseComposerConfirmationModal: false }));
     });
+    it('should show instagram first comment modal', () => {
+      expect(reducer(initialState, actions.showInstagramFirstCommentModal({ ids: 'ids' })))
+        .toEqual(Object.assign(initialState,
+          { showInstagramFirstCommentModal: true, firstCommentIds: 'ids' }));
+    });
+    it('should hide instagram first comment modal', () => {
+      expect(reducer(initialState, actions.hideInstagramFirstCommentModal()))
+        .toEqual(Object.assign(initialState,
+          { showInstagramFirstCommentModal: false, firstCommentIds: null }));
+    });
+    it('should show upgrade b4b modal', () => {
+      expect(reducer(initialState, actions.showB4BTrialExpiredModal({ source: 'source' })))
+        .toEqual(Object.assign(initialState,
+          { showB4BTrialExpiredModal: true, upgradeModalB4BSource: 'source' }));
+    });
+    it('should hide upgrade b4b modal', () => {
+      expect(reducer(initialState, actions.hideUpgradeB4BModal()))
+        .toEqual(Object.assign(initialState,
+          { showB4BTrialExpiredModal: false }));
+    });
   });
 });

--- a/packages/modals/reducer.test.js
+++ b/packages/modals/reducer.test.js
@@ -132,5 +132,16 @@ describe('reducer', () => {
         .toEqual(Object.assign(initialState,
           { showB4BTrialExpiredModal: false }));
     });
+    it('should save modal to show later', () => {
+      expect(reducer(initialState, actions.saveModalToShowLater({ modalId: 'modalId', profileId: 'profileId' })))
+        .toEqual(Object.assign(initialState, {
+          modalToShowLater: {
+            id: 'modalId',
+            params: {
+              profileId: 'profileId',
+            },
+          },
+        }));
+    });
   });
 });

--- a/packages/profile-sidebar/middleware.js
+++ b/packages/profile-sidebar/middleware.js
@@ -1,5 +1,6 @@
 import { push } from 'connected-react-router';
 import { getURL } from '@bufferapp/publish-server/formatters/src';
+import { actions as tabsActions } from '@bufferapp/publish-tabs';
 
 import {
   generateProfilePageRoute,
@@ -79,6 +80,15 @@ export default ({ dispatch, getState }) => next => (action) => {
             type: 'PROFILE_SELECTOR__SELECT_PROFILE',
             profile: formatAnalyticsProfileObj(profile),
           });
+        }
+
+        // When the page has just loaded or is refreshed,
+        // we want to be able to update the actual selected tab
+        if (getState().tabs.tabId !== params.tabId) {
+          dispatch(tabsActions.selectTab({
+            tabId: params.tabId,
+            profileId: profile.id,
+          }));
         }
       } else if (!isPreferencePage && profiles.length > 0) {
         const selectedProfile = profiles[0];

--- a/packages/profile-sidebar/middleware.js
+++ b/packages/profile-sidebar/middleware.js
@@ -74,13 +74,6 @@ export default ({ dispatch, getState }) => next => (action) => {
         dispatch(actions.selectProfile({
           profile,
         }));
-        // Dispatch different select profile for components in analyze
-        if (profile.isAnalyticsSupported) {
-          dispatch({
-            type: 'PROFILE_SELECTOR__SELECT_PROFILE',
-            profile: formatAnalyticsProfileObj(profile),
-          });
-        }
 
         // When the page has just loaded or is refreshed,
         // we want to be able to update the actual selected tab
@@ -89,6 +82,14 @@ export default ({ dispatch, getState }) => next => (action) => {
             tabId: params.tabId,
             profileId: profile.id,
           }));
+        }
+
+        // Dispatch different select profile for components in analyze
+        if (profile.isAnalyticsSupported) {
+          dispatch({
+            type: 'PROFILE_SELECTOR__SELECT_PROFILE',
+            profile: formatAnalyticsProfileObj(profile),
+          });
         }
       } else if (!isPreferencePage && profiles.length > 0) {
         const selectedProfile = profiles[0];

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -68,6 +68,7 @@ const QueuedPosts = ({
   isManager,
   hasFirstCommentFlip,
   isBusinessAccount,
+  onComposerOverlayClick,
 }) => {
   if (loading) {
     return (
@@ -99,6 +100,8 @@ const QueuedPosts = ({
                 onSave={onComposerCreateSuccess}
                 preserveComposerStateOnClose
                 type={'queue'}
+                onComposerOverlayClick={onComposerOverlayClick}
+                editMode={editMode}
               />
             }
             <ComposerInput
@@ -126,6 +129,8 @@ const QueuedPosts = ({
           <ComposerPopover
             onSave={onComposerCreateSuccess}
             type={'queue'}
+            onComposerOverlayClick={onComposerOverlayClick}
+            editMode={editMode}
           />
         }
         <QueueItems
@@ -171,6 +176,7 @@ QueuedPosts.propTypes = {
   showEmptyQueueMessage: PropTypes.bool,
   onComposerPlaceholderClick: PropTypes.func.isRequired,
   onComposerCreateSuccess: PropTypes.func.isRequired,
+  onComposerOverlayClick: PropTypes.func.isRequired,
   onCancelConfirmClick: PropTypes.func.isRequired,
   onRequeueClick: PropTypes.func.isRequired,
   onDeleteClick: PropTypes.func.isRequired,

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -154,6 +154,9 @@ export default connect(
         },
       }));
     },
+    onComposerOverlayClick: () => {
+      dispatch(modalsActions.showCloseComposerConfirmationModal());
+    },
     onCheckInstagramBusinessClick: () => {
       dispatch(dataFetchActions.fetch({
         name: 'checkInstagramBusiness',

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -49,6 +49,7 @@ import { middleware as hashtagGroupsMiddleware } from '@bufferapp/publish-hashta
 import { middleware as trialMiddleware } from '@bufferapp/publish-trial';
 import { middleware as segmentTrackingMiddleware } from '@bufferapp/publish-analytics-middleware';
 import { middleware as globalAccountMiddleware } from '@bufferapp/global-account';
+import { middleware as closeComposerModalMiddleware } from '@bufferapp/publish-close-composer-confirmation-modal';
 
 // Remove analytics middleware when publish switches to analyze
 import { middleware as averageMiddleware } from '@bufferapp/average-table';
@@ -130,6 +131,7 @@ const configureStore = initialstate => {
         trialMiddleware,
         segmentTrackingMiddleware,
         globalAccountMiddleware,
+        closeComposerModalMiddleware,
         // Analyze
         averageMiddleware,
         compareChartMiddleware,

--- a/packages/store/reducers.js
+++ b/packages/store/reducers.js
@@ -38,6 +38,7 @@ import { reducer as trialReducer } from '@bufferapp/publish-trial';
 import { reducer as hashtagGroupsReducer } from '@bufferapp/publish-hashtag-group-manager';
 import { reducer as disabledQueueReducer } from '@bufferapp/publish-disabled-queue';
 import { reducer as globalAccountReducer } from '@bufferapp/global-account';
+import { reducer as closeComposerModalReducer } from '@bufferapp/publish-close-composer-confirmation-modal';
 
 // Analyze
 import { reducer as averageReducer } from '@bufferapp/average-table';
@@ -92,6 +93,7 @@ export default {
   hashtagGroups: hashtagGroupsReducer,
   disabledQueue: disabledQueueReducer,
   globalAccount: globalAccountReducer,
+  closeComposerModal: closeComposerModalReducer,
 
   // Analyze
   average: averageReducer,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Creating a confirmation to make sure users don't lose progress when clicking outside of the composer.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
Currently to edit a post already in your queue, you click the "Edit" button on that post and then make your changes in the Composer that pops up. If you click out of this composer at any time, you lose all your progress immediately and without warning. 

**Jira card:** [PUB-1601](https://buffer.atlassian.net/browse/PUB-1601)

## Screenshots

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
