### PR TITLE
Giving the location composer bar autocompleter a fixed width

### DIFF
--- a/packages/composer/composer/components/css/LocationComposerBar.css
+++ b/packages/composer/composer/components/css/LocationComposerBar.css
@@ -60,7 +60,7 @@
     position: absolute;
     margin-left: 5px;
     overflow: auto;
-    width: 220%;
+    width: 600px;
     z-index: 100;
     font-size: 12px;
 }


### PR DESCRIPTION
## Description

Giving the location composer bar autocompleter a fixed width

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
