### PR TITLE
[PUB-1659] Fixing Bugsnag issue Failed to set the currentTime

### DIFF
--- a/packages/composer/composer/components/InstagramThumbnailSlider.jsx
+++ b/packages/composer/composer/components/InstagramThumbnailSlider.jsx
@@ -23,7 +23,7 @@ class InstagramThumbnailSlider extends React.Component {
     // moves the video & seek bar to correct place
     const video = document.getElementById('thumbnailVideo');
     const time = video.duration * (event.target.value / 100);
-    video.currentTime = time;
+    if (isFinite(time)) video.currentTime = time;
     this.setState({ value: event.target.value });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Fixing Bugsnag issue: Failed to set the 'currentTime' property on 'HTMLMediaElement': The provided double value is non-finite.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
Jira card [[PUB-1659]](https://buffer.atlassian.net/browse/PUB-1659)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`


[PUB-1659]: https://buffer.atlassian.net/browse/PUB-1659