### PR TITLE
Preventing business users to see the upgrade to pro modal.

### DIFF
--- a/packages/cta-banner/middleware.js
+++ b/packages/cta-banner/middleware.js
@@ -1,12 +1,18 @@
 import { actions as modalsActions } from '@bufferapp/publish-modals';
+import { openBillingWindow } from '@bufferapp/publish-tabs/utils';
 import { actionTypes } from '.';
 
 export default ({ getState, dispatch }) => next => (action) => { // eslint-disable-line
+  const { user } = getState().appSidebar;
   next(action);
 
   switch (action.type) {
     case actionTypes.START_SUBSCRIPTION:
-      dispatch(modalsActions.showUpgradeModal({ source: 'cta_banner_upgrade' }));
+      if (user && user.is_business_user) {
+        openBillingWindow();
+      } else {
+        dispatch(modalsActions.showUpgradeModal({ source: 'cta_banner_upgrade' }));
+      }
       break;
     default:
       break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
When users are on business trialists, and click the Upgrade button, are being able to see the upgrade to pro modal.

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
