### PR TITLE
[PUB-1701] Calling get drafts only on fetch profiles success to prevent calling …

### DIFF
--- a/packages/drafts/middleware.js
+++ b/packages/drafts/middleware.js
@@ -22,16 +22,14 @@ export default ({ dispatch, getState }) => next => (action) => {
   const state = getState();
 
   switch (action.type) {
-    case `profiles_${dataFetchActionTypes.FETCH_SUCCESS}`:
-      if (state.profileSidebar.selectedProfileId) {
-        dispatch(dataFetchActions.fetch({
-          name: 'draftPosts',
-          args: {
-            profileId: state.profileSidebar.selectedProfileId,
-            isFetchingMore: false,
-          },
-        }));
-      }
+    case profileActionTypes.SELECT_PROFILE:
+      dispatch(dataFetchActions.fetch({
+        name: 'draftPosts',
+        args: {
+          profileId: action.profile.id,
+          isFetchingMore: false,
+        },
+      }));
       break;
     case actionTypes.DRAFT_CONFIRMED_DELETE: {
       dispatch(dataFetchActions.fetch({
@@ -45,10 +43,10 @@ export default ({ dispatch, getState }) => next => (action) => {
       dispatch(analyticsActions.trackEvent('Draft Deleted', metadata));
       break;
     }
-/*
-In Classic it's REQUESTING_DRAFT_APPROVE.
-Sends draft to queue, which means approves draft
-*/
+    /*
+    In Classic it's REQUESTING_DRAFT_APPROVE.
+    Sends draft to queue, which means approves draft
+    */
     case actionTypes.DRAFT_APPROVE:
       dispatch(dataFetchActions.fetch({
         name: 'approveDraft',

--- a/packages/drafts/middleware.js
+++ b/packages/drafts/middleware.js
@@ -22,14 +22,16 @@ export default ({ dispatch, getState }) => next => (action) => {
   const state = getState();
 
   switch (action.type) {
-    case profileActionTypes.SELECT_PROFILE:
-      dispatch(dataFetchActions.fetch({
-        name: 'draftPosts',
-        args: {
-          profileId: action.profile.id,
-          isFetchingMore: false,
-        },
-      }));
+    case `profiles_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      if (state.profileSidebar.selectedProfileId) {
+        dispatch(dataFetchActions.fetch({
+          name: 'draftPosts',
+          args: {
+            profileId: state.profileSidebar.selectedProfileId,
+            isFetchingMore: false,
+          },
+        }));
+      }
       break;
     case actionTypes.DRAFT_CONFIRMED_DELETE: {
       dispatch(dataFetchActions.fetch({

--- a/packages/drafts/middleware.test.js
+++ b/packages/drafts/middleware.test.js
@@ -12,6 +12,7 @@ describe('middleware', () => {
   const dispatch = jest.fn();
   const state = {
     profileSidebar: {
+      selectedProfileId: 'id1',
       selectedProfile: {
         service_type: 'personal_profile',
         service: 'twitter',
@@ -29,7 +30,7 @@ describe('middleware', () => {
 
   it('should fetch draftPosts', () => {
     const action = {
-      type: profileActionTypes.SELECT_PROFILE,
+      type: 'profiles_FETCH_SUCCESS',
       profile: {
         id: 'id1',
       },

--- a/packages/drafts/middleware.test.js
+++ b/packages/drafts/middleware.test.js
@@ -30,7 +30,7 @@ describe('middleware', () => {
 
   it('should fetch draftPosts', () => {
     const action = {
-      type: 'profiles_FETCH_SUCCESS',
+      type: profileActionTypes.SELECT_PROFILE,
       profile: {
         id: 'id1',
       },

--- a/packages/drafts/reducer.js
+++ b/packages/drafts/reducer.js
@@ -118,11 +118,8 @@ const draftsReducer = (state = {}, action) => {
   switch (action.type) {
     case `draftPosts_${dataFetchActionTypes.FETCH_SUCCESS}`: {
       const { drafts } = action.result;
-      if (action.args.isFetchingMore) {
+      if (action.args.isFetchingMore || Object.keys(state).length > Object.keys(drafts).length) {
         return { ...state, ...drafts };
-      }
-      if (Object.keys(state).length > Object.keys(drafts).length) {
-        return state;
       }
       return drafts;
     }

--- a/packages/drafts/reducer.js
+++ b/packages/drafts/reducer.js
@@ -121,6 +121,9 @@ const draftsReducer = (state = {}, action) => {
       if (action.args.isFetchingMore) {
         return { ...state, ...drafts };
       }
+      if (Object.values(state).length > Object.values(drafts).length) {
+        return state;
+      }
       return drafts;
     }
     case actionTypes.DRAFT_DELETED: {

--- a/packages/drafts/reducer.js
+++ b/packages/drafts/reducer.js
@@ -121,7 +121,7 @@ const draftsReducer = (state = {}, action) => {
       if (action.args.isFetchingMore) {
         return { ...state, ...drafts };
       }
-      if (Object.values(state).length > Object.values(drafts).length) {
+      if (Object.keys(state).length > Object.keys(drafts).length) {
         return state;
       }
       return drafts;

--- a/packages/profile-page/index.js
+++ b/packages/profile-page/index.js
@@ -14,10 +14,10 @@ export default hot(
         getProfilePageParams({ path: ownProps.history.location.pathname }) ||
         {};
       // With analytics, the reducer state name doesnt match the tabId
-      const reducerName =
-        tabId === 'analytics' && (!childTabId || childTabId === 'posts')
-          ? 'sent'
-          : tabId;
+      let reducerName = tabId === 'analytics' && (!childTabId || childTabId === 'posts')
+        ? 'sent'
+        : tabId;
+      if (tabId === 'awaitingApproval' || tabId === 'pendingApproval') reducerName = 'drafts';
       if (
         state[reducerName] &&
         state[reducerName].byProfileId &&

--- a/packages/profile-sidebar/middleware.js
+++ b/packages/profile-sidebar/middleware.js
@@ -71,13 +71,15 @@ export default ({ dispatch, getState }) => next => (action) => {
       const isPlansPage = !!getPlansPageParams({
         path,
       });
-      const { profiles, isOnBusinessTrial, hasOnboardingFeatureFlip } = getState().profileSidebar;
+      const { profiles, isOnBusinessTrial, hasOnboardingFeatureFlip, selectedProfileId } = getState().profileSidebar;
       if (params && params.profileId) {
         const profile = [...profiles].find(p => p.id === params.profileId);
 
-        dispatch(actions.selectProfile({
-          profile,
-        }));
+        if (selectedProfileId !== params.profileId) {
+          dispatch(actions.selectProfile({
+            profile,
+          }));
+        }
 
         // When the page has just loaded or is refreshed,
         // we want to be able to update the actual selected tab


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Calling get drafts only on fetch profiles success to prevent calling it multiple times.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
Jira Card: [[PUB-1701](https://buffer.atlassian.net/browse/PUB-1701)]

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
