### PR TITLE
CORE-768 stripe SCA required changes to RPC

### DIFF
--- a/packages/server/rpc/createSetupIntent/index.js
+++ b/packages/server/rpc/createSetupIntent/index.js
@@ -6,7 +6,7 @@ const strictSSL = !(process.env.NODE_ENV === 'development');
 module.exports = method(
   'createSetupIntent',
   'create a setup intent in Stripe',
-  ({ session }) => rp({
+  (args, { session }) => rp({
     uri: `${process.env.API_ADDR}/1/billing/create-setup-intent.json`,
     method: 'GET',
     strictSSL,

--- a/packages/server/rpc/createSetupIntent/index.js
+++ b/packages/server/rpc/createSetupIntent/index.js
@@ -8,10 +8,12 @@ module.exports = method(
   'create a setup intent in Stripe',
   ({ session }) => rp({
     uri: `${process.env.API_ADDR}/1/billing/create-setup-intent.json`,
-    method: 'POST',
+    method: 'GET',
     strictSSL,
     qs: {
       access_token: session.publish.accessToken,
+      client_id: process.env.CLIENT_ID,
+      client_secret: process.env.CLIENT_SECRET,
     },
   })
     .then(result => JSON.parse(result))

--- a/packages/server/rpc/createSetupIntent/index.js
+++ b/packages/server/rpc/createSetupIntent/index.js
@@ -8,7 +8,7 @@ module.exports = method(
   'create a setup intent in Stripe',
   (args, { session }) => rp({
     uri: `${process.env.API_ADDR}/1/billing/create-setup-intent.json`,
-    method: 'GET',
+    method: 'POST',
     strictSSL,
     qs: {
       access_token: session.publish.accessToken,

--- a/packages/server/rpc/createSetupIntent/index.js
+++ b/packages/server/rpc/createSetupIntent/index.js
@@ -6,22 +6,19 @@ const strictSSL = !(process.env.NODE_ENV === 'development');
 module.exports = method(
   'createSetupIntent',
   'create a setup intent in Stripe',
-  ({ session }) => {
-    console.log('ARGS', arguments)
-    return rp({
-      uri: `${process.env.API_ADDR}/1/billing/create-setup-intent.json`,
-      method: 'POST',
-      strictSSL,
-      qs: {
-        access_token: session.publish.accessToken,
-      },
-    })
-      .then(result => JSON.parse(result))
-      .catch((err) => {
-        if (err.error) {
-          const { error } = JSON.parse(err.error);
-          throw createError({ message: error });
-        }
-      })
-    }
+  ({ session }) => rp({
+    uri: `${process.env.API_ADDR}/1/billing/create-setup-intent.json`,
+    method: 'POST',
+    strictSSL,
+    qs: {
+      access_token: session.publish.accessToken,
+    },
+  })
+    .then(result => JSON.parse(result))
+    .catch((err) => {
+      if (err.error) {
+        const { error } = JSON.parse(err.error);
+        throw createError({ message: error });
+      }
+    }),
 );

--- a/packages/server/rpc/createSetupIntent/index.js
+++ b/packages/server/rpc/createSetupIntent/index.js
@@ -1,0 +1,27 @@
+const { method, createError } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+const strictSSL = !(process.env.NODE_ENV === 'development');
+
+module.exports = method(
+  'createSetupIntent',
+  'create a setup intent in Stripe',
+  ({ session }) => {
+    console.log('ARGS', arguments)
+    return rp({
+      uri: `${process.env.API_ADDR}/1/billing/create-setup-intent.json`,
+      method: 'POST',
+      strictSSL,
+      qs: {
+        access_token: session.publish.accessToken,
+      },
+    })
+      .then(result => JSON.parse(result))
+      .catch((err) => {
+        if (err.error) {
+          const { error } = JSON.parse(err.error);
+          throw createError({ message: error });
+        }
+      })
+    }
+);

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -60,6 +60,7 @@ const globalAccount = require('./globalAccount');
 const createHashtagGroup = require('./createHashtagGroup');
 const deleteHashtagGroup = require('./deleteHashtagGroup');
 const getHashtagGroups = require('./getHashtagGroups');
+const createSetupIntent = require('./createSetupIntent')
 
 // Analytics from Analyze -- Delete when we switch to Analyze
 const analyticsStartDate = require('./analytics/analyticsStartDate');
@@ -136,4 +137,5 @@ module.exports = rpc(
   createHashtagGroup,
   deleteHashtagGroup,
   getHashtagGroups,
+  createSetupIntent
 );

--- a/packages/server/rpc/switchPlan/index.js
+++ b/packages/server/rpc/switchPlan/index.js
@@ -27,7 +27,7 @@ const getCtaFromSource = source =>
 module.exports = method(
   'switchPlan',
   'switch user plan',
-  async ({ cycle, token, source, plan }, { session }) => {
+  async ({ cycle, paymentMethodId, source, plan }, { session }) => {
     let result;
     try {
       result = await rp({
@@ -37,7 +37,7 @@ module.exports = method(
         json: true,
         form: {
           cycle,
-          stripeToken: token,
+          payment_method_id: paymentMethodId,
           cta: getCtaFromSource(source),
           access_token: session.publish.accessToken,
           product: 'publish',

--- a/packages/server/rpc/switchPlan/test.js
+++ b/packages/server/rpc/switchPlan/test.js
@@ -16,7 +16,7 @@ const session = {
 const switchPlan = source =>
   RPCEndpoint.fn({
     cycle: 'year',
-    token: 'stripe token',
+    paymentMethodId: 'mock payment method id',
     source,
   }, { session });
 
@@ -27,11 +27,11 @@ describe('rpc/switchPlan', () => {
     expect(rp.mock.calls[0][0].form.access_token).toBe(accessToken);
   });
 
-  it('sends over the selected cycle and current stripe token', () => {
+  it('sends over the selected cycle and current payment method id', () => {
     rp.mockReturnValueOnce(Promise.resolve({}));
     switchPlan();
     expect(rp.mock.calls[0][0].form.cycle).toBe('year');
-    expect(rp.mock.calls[0][0].form.stripeToken).toBe('stripe token');
+    expect(rp.mock.calls[0][0].form.payment_method_id).toBe('mock payment method id');
   });
 
   it('it sends the correct cta for specific upgrade paths', () => {


### PR DESCRIPTION
This is part of the PSD2 requirements for Strong Customer Authentication via Stripe payments. **It requires front end changes before it can be merged**

## Description

Changes to the RPC endpoints are included in this PR:

* new PRC method `createSetupIntent` to be called before the user can add/update the credit card
* update `switchPlan` RPC endpoint to use a payment method id instead of the card token used before

## Context & Notes

* JIRA: https://buffer.atlassian.net/browse/CORE-768
* General paper with context is [here](https://paper.dropbox.com/doc/CORE-642-PSD2-Technical-Breakdown--AjMKrvwtz3r4dRmB658IFsV9Ag-jUXdDkVIhFJRWPOALLAut)

## Screenshots (if appropriate)

## Checklist

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
