### PR TITLE
[PUB-1701] Draft tabs content loading

### DIFF
--- a/packages/drafts/middleware.test.js
+++ b/packages/drafts/middleware.test.js
@@ -1,5 +1,6 @@
 import { actionTypes as notificationActionTypes } from '@bufferapp/notifications';
 import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar';
+import { actionTypes as tabsActionTypes } from '@bufferapp/publish-tabs';
 import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
 import {
   actions as dataFetchActions,
@@ -20,6 +21,12 @@ describe('middleware', () => {
         serviceId: 'foo123',
       },
     },
+    profile: {
+      id: 'id1',
+    },
+    router: {
+      location: { pathname: '/preferences/test' },
+    },
   };
   const getState = jest.fn(() => state);
 
@@ -30,10 +37,10 @@ describe('middleware', () => {
 
   it('should fetch draftPosts', () => {
     const action = {
-      type: profileActionTypes.SELECT_PROFILE,
-      profile: {
-        id: 'id1',
-      },
+      type: tabsActionTypes.SELECT_TAB,
+      profileId: 'id1',
+      tabId: 'drafts',
+      location: { pathname: '/preferences/test' },
     };
     middleware({ dispatch, getState })(next)(action);
     expect(next)
@@ -42,8 +49,10 @@ describe('middleware', () => {
       .toBeCalledWith(dataFetchActions.fetch({
         name: 'draftPosts',
         args: {
-          profileId: action.profile.id,
+          profileId: action.profileId,
           isFetchingMore: false,
+          needsApproval: false,
+          clear: true,
         },
       }));
   });

--- a/packages/drafts/reducer.js
+++ b/packages/drafts/reducer.js
@@ -156,6 +156,16 @@ const draftsReducer = (state = {}, action) => {
 const profileReducer = (state = profileInitialState, action) => {
   switch (action.type) {
     case `draftPosts_${dataFetchActionTypes.FETCH_START}`:
+      if (action.args.clear) {
+        return {
+          loading: !action.args.isFetchingMore,
+          loadingMore: action.args.isFetchingMore,
+          moreToLoad: false,
+          page: 1,
+          drafts: {},
+          total: 0,
+        };
+      }
       return {
         ...state,
         loading: !action.args.isFetchingMore,

--- a/packages/profile-page/index.js
+++ b/packages/profile-page/index.js
@@ -47,14 +47,18 @@ export default hot(
       },
       onLoadMore: ({ profileId, page, tabId }) => {
         let requestName;
+        let needsApproval = false;
         switch (tabId) {
           case 'queue':
             requestName = 'queued';
             break;
           case 'drafts':
+            requestName = 'draft';
+            break;
           case 'awaitingApproval':
           case 'pendingApproval':
             requestName = 'draft';
+            needsApproval = true;
             break;
           case 'grid':
             requestName = 'grid';
@@ -75,6 +79,7 @@ export default hot(
               profileId,
               page,
               isFetchingMore: true,
+              needsApproval,
             },
           }),
         );

--- a/packages/server/rpc/draftPosts/index.js
+++ b/packages/server/rpc/draftPosts/index.js
@@ -6,7 +6,7 @@ const { buildPostMap } = require('./../../formatters/src');
 module.exports = method(
   'draftPosts',
   'fetch posts with status set as draft',
-  ({ profileId, page }, { session }) =>
+  ({ profileId, page, needsApproval }, { session }) =>
     rp({
       uri: `${process.env.API_ADDR}/1/profiles/${profileId}/updates/drafts.json`,
       method: 'GET',
@@ -15,6 +15,7 @@ module.exports = method(
         access_token: session.publish.accessToken,
         page,
         count: 20,
+        needs_approval: needsApproval,
       },
     })
     .then(result => JSON.parse(result))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Fixing the way we load drafts, awaiting approval and pending approval tabs.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
We are currently experiencing a bug in which users can't load more drafts when reaching to the bottom of the page, the reason was the way we were fetching and displaying the drafts in our UI.

The solution was to load the drafts data on tab change, instead on profile change only, and also "reseting" the drafts state when this change takes place, so that we can see the actual content for the selected tab.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
