### PR TITLE
[PUB-1907] Add storygroup composer wrapper with popover

### DIFF
--- a/packages/story-group-composer/components/StoryGroupPopover/index.jsx
+++ b/packages/story-group-composer/components/StoryGroupPopover/index.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Popover } from '@bufferapp/components';
+import StoryGroupWrapper from '../StoryGroupWrapper';
+
+const StoryGroupPopover = ({
+  onOverlayClick,
+}) => (
+  <Popover
+    width="100%"
+    top="5rem"
+    onOverlayClick={onOverlayClick}
+  >
+    <StoryGroupWrapper />
+  </Popover>
+);
+
+StoryGroupPopover.propTypes = {
+  onOverlayClick: PropTypes.func.isRequired,
+};
+
+export default StoryGroupPopover;

--- a/packages/story-group-composer/components/StoryGroupWrapper/index.jsx
+++ b/packages/story-group-composer/components/StoryGroupWrapper/index.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const WrapperStyle = styled.div`
+  width: 686px;
+  height: 100%;
+  background-color: white;
+  top: 0;
+  right: 0;
+  border-radius: 3px;
+`;
+
+const ADD_STORY = 'addStory';
+const ADD_NOTE = 'addNote';
+
+/*
+ * Wrapper to make sure to display add story view or add note view
+ */
+
+const StoryGroupWrapper = () => {
+  // hooks: https://reactjs.org/docs/hooks-state.html
+  const [viewMode, setViewMode] = useState(ADD_STORY);
+
+  return (
+    <WrapperStyle>
+      {viewMode === ADD_STORY &&
+        <div>Add story view</div>
+      }
+      {viewMode === ADD_NOTE &&
+        <div>Add note view</div>
+      }
+    </WrapperStyle>
+  );
+};
+
+export default StoryGroupWrapper;

--- a/packages/story-group-composer/components/StoryGroupWrapper/story.jsx
+++ b/packages/story-group-composer/components/StoryGroupWrapper/story.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { checkA11y } from 'storybook-addon-a11y';
+import StoryGroupWrapper from './index';
+
+storiesOf('StoryGroup', module)
+  .addDecorator(checkA11y)
+  .add('story group wrapper', () => (
+    <StoryGroupWrapper />
+  ));

--- a/packages/story-group-composer/index.js
+++ b/packages/story-group-composer/index.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import { actions as modalsActions } from '@bufferapp/publish-modals';
+import StoryGroupPopover from './components/StoryGroupPopover';
+
+export default connect(
+  state => ({}),
+  dispatch => ({
+    onOverlayClick: () => {
+      // TO-DO: will need to add HIDE_COMPOSER logic in the stories queue once completed
+      // We'll need to add the stories tab case in the close-composer-confirmation-modal middleware
+      dispatch(modalsActions.showCloseComposerConfirmationModal());
+    },
+  }),
+)(StoryGroupPopover);

--- a/packages/story-group-composer/package.json
+++ b/packages/story-group-composer/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@bufferapp/publish-story-group-composer",
+  "version": "2.0.0",
+  "description": "story group composer",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint . --ignore-pattern coverage node_modules"
+  },
+  "author": "amylee@buffer.com",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "eslint": "^5.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Add popover and storyGroup wrapper with two view modes. 
https://buffer.atlassian.net/browse/PUB-1907
<!--- Describe your changes in detail. -->

## Context & Notes
- Added dummy text for where the SG composer components will go to get us started.
- I tried out using hook state, however we can go back to using `this.state` if there's any added complexity with hook state. 
- I'll leave a comment in the sg queue cards around adding the composer_close logic. 
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
