### PR TITLE
[PUB-1905] Reminder label and closing composer logic

### DIFF
--- a/packages/close-composer-confirmation-modal/middleware.js
+++ b/packages/close-composer-confirmation-modal/middleware.js
@@ -1,6 +1,7 @@
 import { actions as queueActions } from '@bufferapp/publish-queue';
 import { actions as draftsActions } from '@bufferapp/publish-drafts';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
+import { actions as storiesActions } from '@bufferapp/publish-stories';
 import { actionTypes } from './reducer';
 
 export default ({ dispatch, getState }) => next => (action) => {
@@ -10,6 +11,9 @@ export default ({ dispatch, getState }) => next => (action) => {
   switch (action.type) {
     case actionTypes.CLOSE_COMPOSER_AND_CONFIRMATION_MODAL:
       switch (tabId) {
+        case 'stories':
+          dispatch(storiesActions.handleCloseStoriesComposer());
+          break;
         case 'queue':
           dispatch(queueActions.handleComposerCreateSuccess());
           break;

--- a/packages/stories/components/StoryGroups/index.jsx
+++ b/packages/stories/components/StoryGroups/index.jsx
@@ -15,25 +15,25 @@ import { Text } from '@bufferapp/ui';
 
 const ErrorBoundary = getErrorBoundary(true);
 
-const composerStyle = {
-  marginBottom: '0.1rem',
-  flexGrow: '1',
-};
+const ContainerStyle = styled.div`
+  margin-right: 0.5rem;
+`;
 
-const topBarContainerStyle = {
-  display: 'flex',
-};
+const TopBarContainerStyle = styled.div`
+  display: flex;
+`;
 
-const loadingContainerStyle = {
-  width: '100%',
-  height: '100%',
-  textAlign: 'center',
-  paddingTop: '5rem',
-};
+const LoadingContainerStyle = styled.div`
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  padding-top: 5rem;
+`;
 
-const containerStyle = {
-  marginRight: '0.5rem',
-};
+const ComposerInputStyle = styled.div`
+  margin-bottom: 0.1rem;
+  flex-grow: 1;
+`;
 
 const ReminderTextWrapper = styled.div`
   display: flex;
@@ -64,9 +64,9 @@ const StoryGroups = ({
 }) => {
   if (loading) {
     return (
-      <div style={loadingContainerStyle}>
+      <LoadingContainerStyle>
         <BufferLoading size={64} />
-      </div>
+      </LoadingContainerStyle>
     );
   }
 
@@ -76,9 +76,9 @@ const StoryGroups = ({
 
   return (
     <ErrorBoundary>
-      <div className={containerStyle}>
-        <div style={topBarContainerStyle}>
-          <div style={composerStyle}>
+      <ContainerStyle>
+        <TopBarContainerStyle>
+          <ComposerInputStyle>
             {showStoriesComposer && !editMode && (
               <React.Fragment>
                 <StoryGroupPopover />
@@ -88,8 +88,8 @@ const StoryGroups = ({
               placeholder="What would you like to add to your Story?"
               onPlaceholderClick={onComposerPlaceholderClick}
             />
-          </div>
-        </div>
+          </ComposerInputStyle>
+        </TopBarContainerStyle>
         {showStoriesComposer && editMode && (
           <React.Fragment>
             <StoryGroupPopover />
@@ -115,16 +115,14 @@ const StoryGroups = ({
           hasFirstCommentFlip={hasFirstCommentFlip}
           isBusinessAccount={isBusinessAccount}
         />
-      </div>
+      </ContainerStyle>
     </ErrorBoundary>
   );
 };
 StoryGroups.propTypes = {
   loading: PropTypes.bool,
   editMode: PropTypes.bool,
-  moreToLoad: PropTypes.bool, // eslint-disable-line
-  isLockedProfile: PropTypes.bool, // eslint-disable-line
-  page: PropTypes.number, // eslint-disable-line
+  isLockedProfile: PropTypes.bool,
   storyGroups: PropTypes.arrayOf(
     PropTypes.shape({
       type: PropTypes.string,
@@ -144,10 +142,8 @@ StoryGroups.propTypes = {
 };
 
 StoryGroups.defaultProps = {
-  page: 1,
   loading: true,
   editMode: false,
-  moreToLoad: false,
   isLockedProfile: false,
   showStoriesComposer: false,
   hasFirstCommentFlip: false,

--- a/packages/stories/components/StoryGroups/index.jsx
+++ b/packages/stories/components/StoryGroups/index.jsx
@@ -1,18 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { WithFeatureLoader } from '@bufferapp/product-features';
 import getErrorBoundary from '@bufferapp/publish-web/components/ErrorBoundary';
 import LockedProfileNotification from '@bufferapp/publish-locked-profile-notification';
+import StoryGroupPopover from '@bufferapp/publish-story-group-composer';
 import {
   QueueItems,
   BufferLoading,
   ComposerInput,
 } from '@bufferapp/publish-shared-components';
+import { CircleInstReminderIcon } from '@bufferapp/components';
+import { Text } from '@bufferapp/ui';
 
 const ErrorBoundary = getErrorBoundary(true);
 
 const composerStyle = {
-  marginBottom: '1.5rem',
+  marginBottom: '0.1rem',
   flexGrow: '1',
 };
 
@@ -30,6 +34,16 @@ const loadingContainerStyle = {
 const containerStyle = {
   marginRight: '0.5rem',
 };
+
+const ReminderTextWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const ReminderTextStyle = styled(Text)`
+  margin-left: 0.5rem;
+  font-size: 12px;
+`;
 
 const StoryGroups = ({
   loading,
@@ -67,7 +81,7 @@ const StoryGroups = ({
           <div style={composerStyle}>
             {showStoriesComposer && !editMode && (
               <React.Fragment>
-                {/* TODO: add here <StoryGroupPopover /> */}
+                <StoryGroupPopover />
               </React.Fragment>
             )}
             <ComposerInput
@@ -78,9 +92,15 @@ const StoryGroups = ({
         </div>
         {showStoriesComposer && editMode && (
           <React.Fragment>
-            {/* TODO: add here <StoryGroupPopover /> */}
+            <StoryGroupPopover />
           </React.Fragment>
         )}
+        <ReminderTextWrapper>
+          <CircleInstReminderIcon color="instagram" />
+          <ReminderTextStyle type="p">
+            When it’s time to post your Story, we’ll send a Reminder to your mobile device.
+          </ReminderTextStyle>
+        </ReminderTextWrapper>
         <QueueItems
           items={storyGroups}
           onCancelConfirmClick={onCancelConfirmClick}

--- a/packages/stories/index.js
+++ b/packages/stories/index.js
@@ -44,6 +44,9 @@ export default connect(
     onComposerPlaceholderClick: () => {
       dispatch(actions.handleComposerPlaceholderClick());
     },
+    handleCloseStoriesComposer: () => {
+      dispatch(actions.handleCloseStoriesComposer());
+    },
   }),
 )(StoryGroups);
 

--- a/packages/stories/reducer.js
+++ b/packages/stories/reducer.js
@@ -4,6 +4,7 @@ import keyWrapper from '@bufferapp/keywrapper';
 
 export const actionTypes = keyWrapper('STORIES', {
   OPEN_STORIES_COMPOSER: 0,
+  HIDE_STORIES_COMPOSER: 0,
 });
 
 export const initialState = {
@@ -106,6 +107,13 @@ export default (state = initialState, action) => {
         emptySlotMode: action.emptySlotMode,
         emptySlotData: action.emptySlotData,
       };
+    case actionTypes.HIDE_STORIES_COMPOSER:
+      return {
+        ...state,
+        showStoriesComposer: false,
+        editMode: false,
+        emptySlotMode: false,
+      };
     default:
       return state;
   }
@@ -120,5 +128,8 @@ export const actions = {
   }),
   handleComposerPlaceholderClick: () => ({
     type: actionTypes.OPEN_STORIES_COMPOSER,
+  }),
+  handleCloseStoriesComposer: () => ({
+    type: actionTypes.HIDE_STORIES_COMPOSER,
   }),
 };

--- a/packages/story-group-composer/index.js
+++ b/packages/story-group-composer/index.js
@@ -11,8 +11,6 @@ export default connect(
   }),
   dispatch => ({
     onOverlayClick: () => {
-      // TO-DO: will need to add HIDE_COMPOSER logic in the stories queue once completed
-      // We'll need to add the stories tab case in the close-composer-confirmation-modal middleware
       dispatch(modalsActions.showCloseComposerConfirmationModal());
     },
     onDateTimeSlotPickerSubmit: (timestamp) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Added remaining features for Stories Groups tab.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
- Included StoryGroupPopover and close logic.
- Added reminder label.

## Screenshots
**Reminder Label**
<img width="881" alt="Image 2019-09-02 at 3 15 47 PM" src="https://user-images.githubusercontent.com/988972/64117117-9464d200-cd94-11e9-901f-536d9826f1cd.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
