### PR TITLE
Moving the buffermetrics middleware

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -218,16 +218,7 @@ app.use('*', (req, res, next) => {
   next();
 });
 
-app.use(
-  setRequestSessionMiddleware({
-    production: isProduction,
-    sessionKeys: ['publish', 'global'],
-  }),
-);
-
 app.use(bodyParser.json());
-
-app.post('/rpc', checkToken, rpcHandler, errorMiddleware);
 
 app.use(
   bufferMetricsMiddleware({
@@ -236,6 +227,17 @@ app.use(
     trackVisits: true,
   }),
 );
+
+app.use(
+  setRequestSessionMiddleware({
+    production: isProduction,
+    sessionKeys: ['publish', 'global'],
+  }),
+);
+
+
+app.post('/rpc', checkToken, rpcHandler, errorMiddleware);
+
 
 /**
  * The composer expects this URL to exist and accept


### PR DESCRIPTION
Moving the buffermetrics middleware to before the session auth occurs to hopefully prevent cookies from being set when using buffermetrics

This needs to be tested against live to see whether the issue persists after this change or not, it may need to be reverted if it doesn't work