### PR TITLE
Prevent Analyze 'profiles' api fetch from firing aswell as publish's

### DIFF
--- a/packages/profile-sidebar/middleware.js
+++ b/packages/profile-sidebar/middleware.js
@@ -39,6 +39,9 @@ export default ({ dispatch, getState }) => next => (action) => {
     case `user_${dataFetchActionTypes.FETCH_SUCCESS}`: {
       dispatch(dataFetchActions.fetch({
         name: 'profiles',
+        args: {
+          id: action.result.id,
+        },
       }));
       break;
     }

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -141,7 +141,8 @@ const configureStore = initialstate => {
         compareChartMiddleware,
         datePickerMiddleware,
         postsMiddleware,
-        profileLoaderMiddleware,
+        // Removing the Analyze profile loader middleware as it was causing a double load to occur
+        // profileLoaderMiddleware,
         profileSelectorMiddleware,
         summaryTableMiddleware,
         // These need to be the last middlewares in the chain


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Currently, profiles from api is getting fetched twice in new publish because a call gets triggered in the analyze profile-loader middleware. Removing the profile-loader middleware seems to fix it and analytics data seems to be coming in correctly. 
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
