### PR TITLE
Reset story group data on composer close and other small refactors

### DIFF
--- a/packages/close-composer-confirmation-modal/middleware.js
+++ b/packages/close-composer-confirmation-modal/middleware.js
@@ -2,6 +2,7 @@ import { actions as queueActions } from '@bufferapp/publish-queue';
 import { actions as draftsActions } from '@bufferapp/publish-drafts';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
 import { actions as storiesActions } from '@bufferapp/publish-stories';
+import { actions as storyGroupComposerActions } from '@bufferapp/publish-story-group-composer';
 import { actionTypes } from './reducer';
 
 export default ({ dispatch, getState }) => next => (action) => {
@@ -12,6 +13,7 @@ export default ({ dispatch, getState }) => next => (action) => {
     case actionTypes.CLOSE_COMPOSER_AND_CONFIRMATION_MODAL:
       switch (tabId) {
         case 'stories':
+          dispatch(storyGroupComposerActions.resetStoryGroupState());
           dispatch(storiesActions.handleCloseStoriesComposer());
           break;
         case 'queue':

--- a/packages/stories/index.js
+++ b/packages/stories/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { formatPostLists } from '@bufferapp/publish-queue/util';
 import { actions as previewActions } from '@bufferapp/publish-story-preview';
+import { actions as storyGroupComposerActions } from '@bufferapp/publish-story-group-composer';
 
 import { actions } from './reducer';
 import StoryGroups from './components/StoryGroups';

--- a/packages/story-group-composer/components/AddStoryFooter/index.jsx
+++ b/packages/story-group-composer/components/AddStoryFooter/index.jsx
@@ -21,14 +21,13 @@ const AddStoryFooter = ({
   storyGroup,
   onUpdateStoryGroup,
   onCreateStoryGroup,
-  onSetShowDatePicker,
-  showDatePicker,
   editMode,
 }) => {
   const [scheduledAt, setScheduledAt] = useState(storyGroup ? storyGroup.scheduledAt : null);
+  const [showDatePicker, setShowDatePicker] = useState(false);
 
   const onDateTimeSlotPickerSubmit = (timestamp) => {
-    onSetShowDatePicker(false);
+    setShowDatePicker(false);
     if (editMode) {
       setScheduledAt(timestamp);
     } else {
@@ -45,13 +44,19 @@ const AddStoryFooter = ({
         storyGroupId,
       });
     } else {
-      onSetShowDatePicker(true);
+      setShowDatePicker(true);
+    }
+  };
+
+  const onFooterClick = () => {
+    if (showDatePicker) {
+      setShowDatePicker(false);
     }
   };
 
   return (
     <Fragment>
-      <FooterBar>
+      <FooterBar onClick={onFooterClick}>
         {editMode && (
           <EditStoryStyle>
             <EditTextStyle>
@@ -66,7 +71,7 @@ const AddStoryFooter = ({
               label="Edit"
               type="secondary"
               size="small"
-              onClick={() => onSetShowDatePicker(true)}
+              onClick={() => setShowDatePicker(true)}
             />
           </EditStoryStyle>
         )}
@@ -103,8 +108,6 @@ AddStoryFooter.propTypes = {
   ...DateTimeSlotPickerWrapper.propTypes,
   isScheduleLoading: PropTypes.bool.isRequired,
   onUpdateStoryGroup: PropTypes.func.isRequired,
-  onSetShowDatePicker: PropTypes.func.isRequired,
-  showDatePicker: PropTypes.bool.isRequired,
   translations: PropTypes.shape({
     scheduleLoadingButton: PropTypes.string,
     scheduleButton: PropTypes.string,

--- a/packages/story-group-composer/components/AddStoryFooter/index.jsx
+++ b/packages/story-group-composer/components/AddStoryFooter/index.jsx
@@ -1,8 +1,8 @@
 import React, { Fragment, useState } from 'react';
-import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import { Button, Text } from '@bufferapp/ui';
 import DateTimeSlotPickerWrapper from '../DateTimeSlotPickerWrapper';
+import { getReadableDateFormat } from '../../utils/AddStory';
 import {
   FooterBar,
   ButtonStyle,
@@ -11,11 +11,6 @@ import {
   EditDateStyle,
   StyledEditButton,
 } from './style';
-
-const getReadableDateFormat = ({ uses24hTime, scheduledAt }) => {
-  const readableFormat = uses24hTime ? 'MMM D, H:mm' : 'MMM D, h:mm A';
-  return moment.unix(scheduledAt).format(readableFormat);
-};
 
 const AddStoryFooter = ({
   timezone,

--- a/packages/story-group-composer/components/Carousel/CarouselCardHover/style.js
+++ b/packages/story-group-composer/components/Carousel/CarouselCardHover/style.js
@@ -47,7 +47,8 @@ export const EditNoteWrapper = styled.div`
 
 export const ButtonWrapper = styled.div`
   width: 90%;
-  margin: 5px;
+  margin: auto;
+  margin-bottom: 5px;
 `;
 
 export const DragDropWrapper = styled.div`

--- a/packages/story-group-composer/components/Carousel/CarouselCardWrapper/index.jsx
+++ b/packages/story-group-composer/components/Carousel/CarouselCardWrapper/index.jsx
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { FileUploadFormatsConfigs } from '@bufferapp/publish-composer/composer/AppConstants';
-import styled from 'styled-components';
-import { CirclePlayIcon, Text, LoadingAnimation } from '@bufferapp/components';
-import { grayLighter } from '@bufferapp/ui/style/colors';
+import { Text, LoadingAnimation } from '@bufferapp/components';
 import { CarouselCard, getCardSizes } from '@bufferapp/publish-shared-components/Carousel';
 import UploadZone from '@bufferapp/publish-upload-zone';
 import { Button } from '@bufferapp/ui';
@@ -126,7 +124,6 @@ const CarouselCardWrapper = ({
 
 CarouselCardWrapper.propTypes = {
   largeCards: PropTypes.bool,
-  editMode: PropTypes.bool,
   userData: PropTypes.shape({
     id: PropTypes.string,
     s3_upload_signature: PropTypes.shape({

--- a/packages/story-group-composer/components/StoryGroupPopover/index.jsx
+++ b/packages/story-group-composer/components/StoryGroupPopover/index.jsx
@@ -20,7 +20,6 @@ const StoryGroupPopover = ({
   onDeleteStoryGroup,
   onDeleteStory,
   onComposerClick,
-  onSetShowDatePicker,
   onCreateNewStoryCard,
   onUpdateStoryUploadProgress,
   onVideoUploadProcessingStarted,
@@ -28,7 +27,6 @@ const StoryGroupPopover = ({
   onMonitorUpdateProgress,
   onUploadImageComplete,
   onUploadDraftFile,
-  showDatePicker,
   userData,
   storyGroup,
   editMode,
@@ -54,14 +52,12 @@ const StoryGroupPopover = ({
       onCreateNewStoryCard={onCreateNewStoryCard}
       onUploadFinished={onUploadFinished}
       onComposerClick={onComposerClick}
-      onSetShowDatePicker={onSetShowDatePicker}
       onUpdateStoryUploadProgress={onUpdateStoryUploadProgress}
       onVideoUploadProcessingStarted={onVideoUploadProcessingStarted}
       onVideoUploadProcessingComplete={onVideoUploadProcessingComplete}
       onMonitorUpdateProgress={onMonitorUpdateProgress}
       onUploadImageComplete={onUploadImageComplete}
       onUploadDraftFile={onUploadDraftFile}
-      showDatePicker={showDatePicker}
       userData={userData}
       storyGroup={storyGroup}
       editMode={editMode}

--- a/packages/story-group-composer/components/StoryGroupWrapper/index.jsx
+++ b/packages/story-group-composer/components/StoryGroupWrapper/index.jsx
@@ -6,7 +6,6 @@ import DateTimeSlotPickerWrapper from '../DateTimeSlotPickerWrapper';
 import HeaderBar from '../HeaderBar';
 import AddNote from '../AddNote';
 import CarouselCards from '../Carousel/CarouselCards';
-import CarouselCardHover from '../Carousel/CarouselCardHover';
 import AddStoryFooter from '../AddStoryFooter';
 
 const ADD_STORY = 'addStory';
@@ -46,8 +45,6 @@ const StoryGroupWrapper = ({
   onMonitorUpdateProgress,
   onUploadImageComplete,
   onUploadDraftFile,
-  onSetShowDatePicker,
-  showDatePicker,
   userData,
   onUploadFinished,
   storyGroup,
@@ -92,7 +89,6 @@ const StoryGroupWrapper = ({
               />
             </Carousel>
             <AddStoryFooter
-              onClick={() => onComposerClick(showDatePicker)}
               timezone={timezone}
               weekStartsMonday={weekStartsMonday}
               uses24hTime={uses24hTime}
@@ -102,8 +98,6 @@ const StoryGroupWrapper = ({
               editMode={editMode}
               onCreateStoryGroup={onCreateStoryGroup}
               onUpdateStoryGroup={onUpdateStoryGroup}
-              onSetShowDatePicker={onSetShowDatePicker}
-              showDatePicker={showDatePicker}
             />
           </React.Fragment>
         )}

--- a/packages/story-group-composer/index.js
+++ b/packages/story-group-composer/index.js
@@ -15,7 +15,6 @@ export default connect(
       selectedProfile: state.profileSidebar.selectedProfile,
       translations: state.i18n.translations['story-group-composer'],
       isScheduleLoading: state.storyGroupComposer.isScheduleLoading,
-      showDatePicker: state.storyGroupComposer.showDatePicker,
       storyGroup: state.storyGroupComposer.storyGroup,
       editMode: !!editingPostId,
       userData: state.appSidebar.user,
@@ -36,12 +35,6 @@ export default connect(
     },
     saveNote: ({ note, order }) => {
       dispatch(actions.handleSaveStoryNote({ note, order }));
-    },
-    onSetShowDatePicker: (showDatePicker) => {
-      dispatch(actions.setShowDatePicker(showDatePicker));
-    },
-    onComposerClick: (showDatePicker) => {
-      if (showDatePicker) dispatch(actions.setShowDatePicker(false));
     },
     onCreateNewStoryCard: ({ id, uploaderInstance, file }) => {
       dispatch(actions.createNewStoryCard({ id, uploaderInstance, file }));

--- a/packages/story-group-composer/middleware.js
+++ b/packages/story-group-composer/middleware.js
@@ -63,7 +63,7 @@ export default ({ getState, dispatch }) => next => (action) => {
       }));
       break;
     case `createStoryGroup_${dataFetchActionTypes.FETCH_SUCCESS}`:
-      dispatch(actions.setScheduleLoading(false));
+      dispatch(actions.resetStoryGroupState());
       dispatch(storiesActions.handleCloseStoriesComposer());
       dispatch(notificationActions.createNotification({
         notificationType: 'success',
@@ -71,7 +71,7 @@ export default ({ getState, dispatch }) => next => (action) => {
       }));
       break;
     case `updateStoryGroup_${dataFetchActionTypes.FETCH_SUCCESS}`:
-      dispatch(actions.setScheduleLoading(false));
+      dispatch(actions.resetStoryGroupState());
       dispatch(storiesActions.handleCloseStoriesComposer());
       dispatch(notificationActions.createNotification({
         notificationType: 'success',

--- a/packages/story-group-composer/reducer.js
+++ b/packages/story-group-composer/reducer.js
@@ -36,13 +36,11 @@ const newStory = () => clonedeep({
 });
 
 export const initialState = {
-  // temporarily adding as dummy data until create is working
   storyGroup: {
     scheduledAt: null,
     stories: [],
   },
   isScheduleLoading: false,
-  showDatePicker: false,
 };
 
 const updateStoryNote = ({ stories = [], order, note }) => (
@@ -117,12 +115,6 @@ export default (state, action) => {
       return {
         ...state,
         isScheduleLoading: action.isLoading,
-      };
-    }
-    case actionTypes.SET_SHOW_DATE_PICKER: {
-      return {
-        ...state,
-        showDatePicker: action.showDatePicker,
       };
     }
     case actionTypes.UPDATE_STORY_UPLOAD_PROGRESS: {

--- a/packages/story-group-composer/reducer.js
+++ b/packages/story-group-composer/reducer.js
@@ -8,7 +8,7 @@ export const actionTypes = keyWrapper('STORY_GROUP_COMPOSER', {
   UPDATE_STORY_GROUP: 0,
   SET_SCHEDULE_LOADING: 0,
   SET_SHOW_DATE_PICKER: 0,
-  RESET_DRAFT_STATE: 0,
+  RESET_STORY_GROUP_STATE: 0,
   CREATE_NEW_STORY_CARD: 0,
   UPDATE_STORY_UPLOAD_PROGRESS: 0,
   UPDATE_STORY_VIDEO_PROCESSING_STARTED: 0,
@@ -72,7 +72,7 @@ export default (state, action) => {
       };
     }
     case `createStoryGroup_${dataFetchActionTypes.FETCH_SUCCESS}`:
-    case actionTypes.RESET_DRAFT_STATE: {
+    case actionTypes.RESET_STORY_GROUP_STATE: {
       return clonedeep(initialState);
     }
     case actionTypes.UPDATE_STORY_GROUP: {
@@ -302,12 +302,8 @@ export const actions = {
     type: actionTypes.SET_SCHEDULE_LOADING,
     isLoading,
   }),
-  setShowDatePicker: showDatePicker => ({
-    type: actionTypes.SET_SHOW_DATE_PICKER,
-    showDatePicker,
-  }),
-  resetDraftState: () => ({
-    type: actionTypes.RESET_DRAFT_STATE,
+  resetStoryGroupState: () => ({
+    type: actionTypes.RESET_STORY_GROUP_STATE,
   }),
   createNewStoryCard: ({ file, uploaderInstance, id }) => ({
     type: actionTypes.CREATE_NEW_STORY_CARD,

--- a/packages/story-group-composer/utils/AddStory.js
+++ b/packages/story-group-composer/utils/AddStory.js
@@ -1,0 +1,6 @@
+import moment from 'moment-timezone';
+
+export const getReadableDateFormat = ({ uses24hTime, scheduledAt }) => {
+  const readableFormat = uses24hTime ? 'MMM D, H:mm' : 'MMM D, h:mm A';
+  return moment.unix(scheduledAt).format(readableFormat);
+};

--- a/packages/story-group-composer/utils/Carousel.js
+++ b/packages/story-group-composer/utils/Carousel.js
@@ -28,7 +28,7 @@ export const getCardsToShow = ({ cards = [], totalCardsToShow }) => {
 
 export const getShortString = (string) => {
   if (string.length > 20) {
-    string = string.substring(0, 20);
+    string = `${string.substring(0, 20)}...`;
   }
-  return `${string}...`;
+  return string;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Reset story group state on composer close
- Remove ... for on hover note string if under 20 characters
- Set `showDatePicker` locally instead of in redux
- Center align add note button
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
