### PR TITLE
[PUB-1920] Open Preview in Story Composer

### DIFF
--- a/packages/shared-components/DiscontinuousProgressBar/index.jsx
+++ b/packages/shared-components/DiscontinuousProgressBar/index.jsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import uuid from 'uuid/v4';
 import styled from 'styled-components';
 import { white } from '@bufferapp/ui/style/colors';
 
@@ -27,9 +28,9 @@ const renderBars = (numberOfBarsFilled, totalNumberOfBars) => {
   const bars = [];
   for (let i = 0; i < totalNumberOfBars; i += 1) {
     if (i < numberOfBarsFilled) {
-      bars.push(<ProgressBarFilled />);
+      bars.push(<ProgressBarFilled key={uuid()} />);
     } else {
-      bars.push(<ProgressBar />);
+      bars.push(<ProgressBar key={uuid()} />);
     }
   }
 

--- a/packages/story-group-composer/components/AddStoryFooter/index.jsx
+++ b/packages/story-group-composer/components/AddStoryFooter/index.jsx
@@ -21,6 +21,7 @@ const AddStoryFooter = ({
   storyGroup,
   onUpdateStoryGroup,
   onCreateStoryGroup,
+  onPreviewClick,
   editMode,
 }) => {
   const [scheduledAt, setScheduledAt] = useState(storyGroup ? storyGroup.scheduledAt : null);
@@ -79,7 +80,7 @@ const AddStoryFooter = ({
           <Button
             type="secondary"
             label={translations.previewButton}
-            onClick={() => {}}
+            onClick={() => onPreviewClick(storyGroup.stories)}
           />
         </ButtonStyle>
         <Button

--- a/packages/story-group-composer/components/StoryGroupPopover/index.jsx
+++ b/packages/story-group-composer/components/StoryGroupPopover/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Popover } from '@bufferapp/components';
+import PreviewPopover from '@bufferapp/publish-story-preview';
 import StoryGroupWrapper from '../StoryGroupWrapper';
 import DateTimeSlotPickerWrapper from '../DateTimeSlotPickerWrapper';
 import CarouselCardHover from '../Carousel/CarouselCardHover';
@@ -31,38 +32,51 @@ const StoryGroupPopover = ({
   storyGroup,
   editMode,
   onUploadFinished,
+  showStoryPreview,
+  onClosePreviewClick,
+  onPreviewClick,
 }) => (
-  <Popover
-    width="100%"
-    top="5rem"
-    onOverlayClick={onOverlayClick}
-  >
-    <StoryGroupWrapper
-      uses24hTime={uses24hTime}
-      timezone={timezone}
-      weekStartsMonday={weekStartsMonday}
-      selectedProfile={selectedProfile}
-      saveNote={saveNote}
-      translations={translations}
-      isScheduleLoading={isScheduleLoading}
-      onCreateStoryGroup={onCreateStoryGroup}
-      onUpdateStoryGroup={onUpdateStoryGroup}
-      onDeleteStoryGroup={onDeleteStoryGroup}
-      onDeleteStory={onDeleteStory}
-      onCreateNewStoryCard={onCreateNewStoryCard}
-      onUploadFinished={onUploadFinished}
-      onComposerClick={onComposerClick}
-      onUpdateStoryUploadProgress={onUpdateStoryUploadProgress}
-      onVideoUploadProcessingStarted={onVideoUploadProcessingStarted}
-      onVideoUploadProcessingComplete={onVideoUploadProcessingComplete}
-      onMonitorUpdateProgress={onMonitorUpdateProgress}
-      onUploadImageComplete={onUploadImageComplete}
-      onUploadDraftFile={onUploadDraftFile}
-      userData={userData}
-      storyGroup={storyGroup}
-      editMode={editMode}
-    />
-  </Popover>
+  <React.Fragment>
+    {showStoryPreview && (
+      <PreviewPopover
+        onCloseClick={onClosePreviewClick}
+      />
+    )}
+    {!showStoryPreview && (
+      <Popover
+        width="100%"
+        top="5rem"
+        onOverlayClick={onOverlayClick}
+      >
+        <StoryGroupWrapper
+          uses24hTime={uses24hTime}
+          timezone={timezone}
+          weekStartsMonday={weekStartsMonday}
+          selectedProfile={selectedProfile}
+          saveNote={saveNote}
+          translations={translations}
+          isScheduleLoading={isScheduleLoading}
+          onCreateStoryGroup={onCreateStoryGroup}
+          onUpdateStoryGroup={onUpdateStoryGroup}
+          onDeleteStoryGroup={onDeleteStoryGroup}
+          onDeleteStory={onDeleteStory}
+          onCreateNewStoryCard={onCreateNewStoryCard}
+          onUploadFinished={onUploadFinished}
+          onComposerClick={onComposerClick}
+          onUpdateStoryUploadProgress={onUpdateStoryUploadProgress}
+          onVideoUploadProcessingStarted={onVideoUploadProcessingStarted}
+          onVideoUploadProcessingComplete={onVideoUploadProcessingComplete}
+          onMonitorUpdateProgress={onMonitorUpdateProgress}
+          onUploadImageComplete={onUploadImageComplete}
+          onUploadDraftFile={onUploadDraftFile}
+          onPreviewClick={onPreviewClick}
+          userData={userData}
+          storyGroup={storyGroup}
+          editMode={editMode}
+        />
+      </Popover>
+    )}
+  </React.Fragment>
 );
 
 StoryGroupPopover.propTypes = {

--- a/packages/story-group-composer/components/StoryGroupWrapper/index.jsx
+++ b/packages/story-group-composer/components/StoryGroupWrapper/index.jsx
@@ -45,6 +45,7 @@ const StoryGroupWrapper = ({
   onMonitorUpdateProgress,
   onUploadImageComplete,
   onUploadDraftFile,
+  onPreviewClick,
   userData,
   onUploadFinished,
   storyGroup,
@@ -98,6 +99,7 @@ const StoryGroupWrapper = ({
               editMode={editMode}
               onCreateStoryGroup={onCreateStoryGroup}
               onUpdateStoryGroup={onUpdateStoryGroup}
+              onPreviewClick={onPreviewClick}
             />
           </React.Fragment>
         )}

--- a/packages/story-group-composer/index.js
+++ b/packages/story-group-composer/index.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
+import { actions as previewActions } from '@bufferapp/publish-story-preview';
 import uuid from 'uuid/v4';
 import { actions } from './reducer';
 import StoryGroupPopover from './components/StoryGroupPopover';
@@ -16,6 +17,7 @@ export default connect(
       translations: state.i18n.translations['story-group-composer'],
       isScheduleLoading: state.storyGroupComposer.isScheduleLoading,
       storyGroup: state.storyGroupComposer.storyGroup,
+      showStoryPreview: state.storyGroupComposer.showStoryPreview,
       editMode: !!editingPostId,
       userData: state.appSidebar.user,
       editingPostId,
@@ -35,6 +37,14 @@ export default connect(
     },
     saveNote: ({ note, order }) => {
       dispatch(actions.handleSaveStoryNote({ note, order }));
+    },
+    onPreviewClick: (stories) => {
+      debugger;
+      dispatch(previewActions.handlePreviewClick(stories));
+      dispatch(actions.handlePreviewClick());
+    },
+    onClosePreviewClick: () => {
+      dispatch(actions.handleClosePreviewClick());
     },
     onCreateNewStoryCard: ({ id, uploaderInstance, file }) => {
       dispatch(actions.createNewStoryCard({ id, uploaderInstance, file }));

--- a/packages/story-group-composer/index.js
+++ b/packages/story-group-composer/index.js
@@ -39,7 +39,6 @@ export default connect(
       dispatch(actions.handleSaveStoryNote({ note, order }));
     },
     onPreviewClick: (stories) => {
-      debugger;
       dispatch(previewActions.handlePreviewClick(stories));
       dispatch(actions.handlePreviewClick());
     },

--- a/packages/story-group-composer/reducer.js
+++ b/packages/story-group-composer/reducer.js
@@ -15,6 +15,8 @@ export const actionTypes = keyWrapper('STORY_GROUP_COMPOSER', {
   UPDATE_STORY_VIDEO_PROCESSING_COMPLETE: 0,
   UPDATE_STORY_UPLOAD_IMAGE_COMPLETED: 0,
   DELETE_STORY: 0,
+  OPEN_PREVIEW: 0,
+  CLOSE_PREVIEW: 0,
   SET_STORY_GROUP: 0,
 });
 
@@ -41,6 +43,7 @@ export const initialState = {
     stories: [],
   },
   isScheduleLoading: false,
+  showStoryPreview: false,
 };
 
 const updateStoryNote = ({ stories = [], order, note }) => (
@@ -251,6 +254,16 @@ export default (state, action) => {
         },
       };
     }
+    case actionTypes.OPEN_PREVIEW:
+      return {
+        ...state,
+        showStoryPreview: true,
+      };
+    case actionTypes.CLOSE_PREVIEW:
+      return {
+        ...state,
+        showStoryPreview: false,
+      };
     default:
       return state;
   }
@@ -271,6 +284,12 @@ export const actions = {
     type: actionTypes.SAVE_STORY_NOTE,
     order,
     note,
+  }),
+  handlePreviewClick: () => ({
+    type: actionTypes.OPEN_PREVIEW,
+  }),
+  handleClosePreviewClick: () => ({
+    type: actionTypes.CLOSE_PREVIEW,
   }),
   setStoryGroup: ({ scheduledAt, stories, storyGroupId }) => ({
     type: actionTypes.SET_STORY_GROUP,

--- a/packages/story-preview/components/EditNote/index.jsx
+++ b/packages/story-preview/components/EditNote/index.jsx
@@ -103,7 +103,7 @@ EditNote.propTypes = {
   story: PropTypes.shape({
     note: PropTypes.string,
     type: PropTypes.oneOf(['image', 'video', 'gif']),
-    order: PropTypes.string,
+    order: PropTypes.number,
     asset_url: PropTypes.string,
     thumbnail_url: PropTypes.string,
   }).isRequired,

--- a/packages/story-preview/components/NoteWrapper/index.jsx
+++ b/packages/story-preview/components/NoteWrapper/index.jsx
@@ -55,7 +55,7 @@ NoteWrapper.propTypes = {
   story: PropTypes.shape({
     note: PropTypes.string,
     type: PropTypes.oneOf(['image', 'video', 'gif']),
-    order: PropTypes.string,
+    order: PropTypes.number,
     asset_url: PropTypes.string,
     thumbnail_url: PropTypes.string,
   }).isRequired,

--- a/packages/story-preview/components/PreviewMedia/index.jsx
+++ b/packages/story-preview/components/PreviewMedia/index.jsx
@@ -94,7 +94,7 @@ PreviewMedia.propTypes = {
   story: PropTypes.shape({
     note: PropTypes.string,
     type: PropTypes.oneOf(['image', 'video', 'gif']),
-    order: PropTypes.string,
+    order: PropTypes.number,
     asset_url: PropTypes.string,
     thumbnail_url: PropTypes.string,
   }).isRequired,

--- a/packages/story-preview/components/PreviewMedia/index.jsx
+++ b/packages/story-preview/components/PreviewMedia/index.jsx
@@ -57,7 +57,7 @@ const PreviewMedia = ({
       <Header>
         <DiscontinuousProgressBar
           totalNumberOfBars={numberOfStories}
-          numberOfBarsFilled={order}
+          numberOfBarsFilled={order + 1}
         />
         <AvatarContainer>
           <Avatar

--- a/packages/story-preview/components/PreviewPopover/index.jsx
+++ b/packages/story-preview/components/PreviewPopover/index.jsx
@@ -90,7 +90,7 @@ PreviewPopover.propTypes = {
     PropTypes.shape({
       note: PropTypes.string,
       type: PropTypes.oneOf(['image', 'video', 'gif']),
-      order: PropTypes.string,
+      order: PropTypes.number,
       asset_url: PropTypes.string,
       thumbnail_url: PropTypes.string,
     }),

--- a/packages/story-preview/components/ViewNote/index.jsx
+++ b/packages/story-preview/components/ViewNote/index.jsx
@@ -60,7 +60,7 @@ ViewNote.propTypes = {
   story: PropTypes.shape({
     note: PropTypes.string,
     type: PropTypes.oneOf(['image', 'video', 'gif']),
-    order: PropTypes.string,
+    order: PropTypes.number,
     asset_url: PropTypes.string,
     thumbnail_url: PropTypes.string,
   }).isRequired,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

- Open Preview in Story Composer

**Extras:**

- Change Proptypes validation for order (it's type number now instead of string)
- Add unique key to Discontinuous Progress Bar array

<!--- Describe your changes in detail. -->

## Context & Notes
[PUB-1920](https://buffer.atlassian.net/browse/PUB-1920)
Next PR: disable Preview button when resources are still loading or no stories.
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
