### PR TITLE
Delete unused delete footer props

### DIFF
--- a/packages/drafts/components/DraftList/index.jsx
+++ b/packages/drafts/components/DraftList/index.jsx
@@ -44,8 +44,6 @@ const DraftList = ({
   postLists,
   manager,
   onApproveClick,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onMoveToDraftsClick,
@@ -66,17 +64,18 @@ const DraftList = ({
   onComposerOverlayClick,
 }) => {
   if (features.isProUser()) {
-    const startTrial = () =>
-      window.location.assign(`${getURL.getStartTrialURL({
+    const startTrial = () => window.location.assign(
+      `${getURL.getStartTrialURL({
         trialType: 'small',
         cta: SEGMENT_NAMES.DRAFTS_SBP_TRIAL,
         nextUrl: 'https://publish.buffer.com',
-      })}`);
-    const goToBilling = () =>
-      window.location.assign(`${getURL.getBillingURL({
+      })}`,
+    );
+    const goToBilling = () => window.location.assign(
+      `${getURL.getBillingURL({
         cta: SEGMENT_NAMES.DRAFTS_BUSINESS_UPGRADE,
-      })
-    }`);
+      })}`,
+    );
     const trackAndGo = ({ location, action, afterTracked }) => {
       trackAction({
         location,
@@ -87,21 +86,25 @@ const DraftList = ({
       });
     };
     if (canStartBusinessTrial) {
-      return (<BusinessTrialOrUpgradeCard
+      return (
+        <BusinessTrialOrUpgradeCard
+          heading="Collaborate With Your Team"
+          body="Add your team to your Buffer account so you can collaborate and save even more time."
+          cta="Start a Free 14-Day Trial of the Business Plan"
+          onCtaClick={() => { trackAndGo({ location: 'drafts', action: 'collaborate_with_team_b4b_trial_start_click', afterTracked: startTrial }); }}
+          backgroundImage="squares"
+        />
+      );
+    }
+    return (
+      <BusinessTrialOrUpgradeCard
         heading="Collaborate With Your Team"
         body="Add your team to your Buffer account so you can collaborate and save even more time."
-        cta="Start a Free 14-Day Trial of the Business Plan"
-        onCtaClick={() => { trackAndGo({ location: 'drafts', action: 'collaborate_with_team_b4b_trial_start_click', afterTracked: startTrial }); }}
+        cta="Upgrade to Buffer for Business"
+        onCtaClick={() => { trackAndGo({ location: 'analytics', action: 'collaborate_with_team_b4b_upgrade_click', afterTracked: goToBilling }); }}
         backgroundImage="squares"
-      />);
-    }
-    return (<BusinessTrialOrUpgradeCard
-      heading="Collaborate With Your Team"
-      body="Add your team to your Buffer account so you can collaborate and save even more time."
-      cta="Upgrade to Buffer for Business"
-      onCtaClick={() => { trackAndGo({ location: 'analytics', action: 'collaborate_with_team_b4b_upgrade_click', afterTracked: goToBilling }); }}
-      backgroundImage="squares"
-    />);
+      />
+    );
   }
 
   if (loading) {
@@ -120,39 +123,43 @@ const DraftList = ({
     <ErrorBoundary>
       <div className={containerStyle}>
         <div style={topBarContainerStyle}>
-          {tabId === 'drafts' &&
-            <div style={composerStyle}>
-              {showComposer && !editMode &&
-                <ComposerPopover
-                  type={'drafts'}
-                  onSave={onComposerCreateSuccess}
-                  preserveComposerStateOnClose
-                  onComposerOverlayClick={onComposerOverlayClick}
-                  editMode={editMode}
+          {tabId === 'drafts'
+            && (
+              <div style={composerStyle}>
+                {showComposer && !editMode
+                  && (
+                    <ComposerPopover
+                      type="drafts"
+                      onSave={onComposerCreateSuccess}
+                      preserveComposerStateOnClose
+                      onComposerOverlayClick={onComposerOverlayClick}
+                      editMode={editMode}
+                    />
+                  )
+                }
+                <ComposerInput
+                  placeholder="Create a new draft..."
+                  onPlaceholderClick={onComposerPlaceholderClick}
                 />
-              }
-              <ComposerInput
-                placeholder={'Create a new draft...'}
-                onPlaceholderClick={onComposerPlaceholderClick}
-              />
-            </div>
+              </div>
+            )
           }
         </div>
-        {showComposer && editMode &&
-          <ComposerPopover
-            type={'drafts'}
-            onSave={onComposerCreateSuccess}
-            onComposerOverlayClick={onComposerOverlayClick}
-            editMode={editMode}
-          />
+        {showComposer && editMode
+          && (
+            <ComposerPopover
+              type="drafts"
+              onSave={onComposerCreateSuccess}
+              onComposerOverlayClick={onComposerOverlayClick}
+              editMode={editMode}
+            />
+          )
         }
-        {
-          postLists.length > 0 ?
+        {postLists.length > 0
+          ? (
             <QueueItems
               items={postLists}
               onApproveClick={onApproveClick}
-              onCancelConfirmClick={onCancelConfirmClick}
-              onDeleteClick={onDeleteClick}
               onDeleteConfirmClick={onDeleteConfirmClick}
               onEditClick={onEditClick}
               onMoveToDraftsClick={onMoveToDraftsClick}
@@ -163,13 +170,16 @@ const DraftList = ({
               onImageClickPrev={onImageClickPrev}
               onImageClose={onImageClose}
               draggable={false}
-              type={'drafts'}
+              type="drafts"
               hasFirstCommentFlip={hasFirstCommentFlip}
-            /> :
+            />
+          )
+          : (
             <Empty
               isManager={manager}
               view={tabId}
             />
+          )
         }
       </div>
     </ErrorBoundary>
@@ -187,8 +197,6 @@ DraftList.propTypes = {
   ),
   manager: PropTypes.bool.isRequired,
   onApproveClick: PropTypes.func.isRequired,
-  onCancelConfirmClick: PropTypes.func.isRequired,
-  onDeleteClick: PropTypes.func.isRequired,
   onDeleteConfirmClick: PropTypes.func.isRequired,
   onEditClick: PropTypes.func.isRequired,
   onMoveToDraftsClick: PropTypes.func.isRequired,

--- a/packages/drafts/index.js
+++ b/packages/drafts/index.js
@@ -20,7 +20,7 @@ const getPostActionString = ({
     });
     return `This ${isDraftsView ? 'draft' : 'post'} ${isPastDue ? 'was' : 'will be'}
       scheduled for ${dateString}${isPastDue ? '' : ' on approval'
-    }.`;
+}.`;
   } else if (draft.sharedNext) {
     return `This ${isDraftsView ? 'draft' : 'post'} will be added to the top of the queue on approval.`;
   }
@@ -35,7 +35,7 @@ const getDraftDetails = ({
   twentyFourHourTime,
   isDraftsView,
 }) => {
-  const createdAt = draft.createdAt;
+  const { createdAt } = draft;
   const servicesWithCommentFeature = ['instagram'];
   const createdAtString = getDateString(createdAt, profileTimezone, {
     createdAt,
@@ -70,7 +70,7 @@ const getDraftDetails = ({
 // Could export this to utils and then pull it in and pass tab depending on which package uses it
 const formatPostLists = (profile, drafts, user, tabId) => {
   const profileTimezone = profile.timezone;
-  const isManager = profile.isManager;
+  const { isManager } = profile;
   const twentyFourHourTime = user.twentyfour_hour_time;
   const orderedDrafts = Object.values(drafts).sort((a, b) => a.createdAt - b.createdAt);
 
@@ -104,8 +104,7 @@ const formatPostLists = (profile, drafts, user, tabId) => {
 
 export default connect(
   (state, ownProps) => {
-    const profileId = ownProps.profileId;
-    const tabId = ownProps.tabId;
+    const { profileId, tabId } = ownProps;
     const currentProfile = state.drafts.byProfileId[profileId];
     if (currentProfile) {
       return {
@@ -171,22 +170,6 @@ export default connect(
     onEditClick: (draft) => {
       dispatch(
         actions.handleEditClick({
-          draft: draft.draft,
-          profileId: ownProps.profileId,
-        }),
-      );
-    },
-    onDeleteClick: (draft) => {
-      dispatch(
-        actions.handleDeleteClick({
-          draft: draft.draft,
-          profileId: ownProps.profileId,
-        }),
-      );
-    },
-    onCancelConfirmClick: (draft) => {
-      dispatch(
-        actions.handleCancelConfirmClick({
           draft: draft.draft,
           profileId: ownProps.profileId,
         }),

--- a/packages/drafts/reducer.js
+++ b/packages/drafts/reducer.js
@@ -9,8 +9,6 @@ export const actionTypes = keyWrapper('DRAFTS', {
   DRAFT_APPROVED: 0,
   DRAFT_APPROVE: 0,
   DRAFT_NEEDS_APPROVAL: 0,
-  DRAFT_CLICKED_DELETE: 0,
-  DRAFT_CANCELED_DELETE: 0,
   DRAFT_CONFIRMED_DELETE: 0,
   OPEN_COMPOSER: 0,
   HIDE_COMPOSER: 0,
@@ -67,16 +65,6 @@ const draftReducer = (state, action) => {
         ...state,
         isConfirmingDelete: false,
         isDeleting: true,
-      };
-    case actionTypes.DRAFT_CLICKED_DELETE:
-      return {
-        ...state,
-        isConfirmingDelete: true,
-      };
-    case actionTypes.DRAFT_CANCELED_DELETE:
-      return {
-        ...state,
-        isConfirmingDelete: false,
       };
     case actionTypes.DRAFT_APPROVE:
       return {
@@ -140,8 +128,6 @@ const draftsReducer = (state = {}, action) => {
     case actionTypes.DRAFT_IMAGE_CLICKED_NEXT:
     case actionTypes.DRAFT_IMAGE_CLICKED_PREV:
     case actionTypes.DRAFT_CONFIRMED_DELETE:
-    case actionTypes.DRAFT_CANCELED_DELETE:
-    case actionTypes.DRAFT_CLICKED_DELETE:
     case actionTypes.DRAFT_APPROVE:
     case actionTypes.DRAFT_NEEDS_APPROVAL:
       return {
@@ -195,8 +181,6 @@ const profileReducer = (state = profileInitialState, action) => {
     case actionTypes.DRAFT_DELETED:
     case actionTypes.DRAFT_APPROVED:
     case actionTypes.DRAFT_CONFIRMED_DELETE:
-    case actionTypes.DRAFT_CANCELED_DELETE:
-    case actionTypes.DRAFT_CLICKED_DELETE:
     case actionTypes.DRAFT_APPROVE:
     case actionTypes.DRAFT_NEEDS_APPROVAL:
       return {
@@ -230,8 +214,6 @@ export default (state = initialState, action) => {
     case actionTypes.DRAFT_DELETED:
     case actionTypes.DRAFT_APPROVED:
     case actionTypes.DRAFT_CONFIRMED_DELETE:
-    case actionTypes.DRAFT_CANCELED_DELETE:
-    case actionTypes.DRAFT_CLICKED_DELETE:
     case actionTypes.DRAFT_APPROVE:
     case actionTypes.DRAFT_NEEDS_APPROVAL:
       profileId = getProfileId(action);
@@ -287,18 +269,6 @@ export const actions = {
     type: actionTypes.OPEN_COMPOSER,
     updateId: draft.id,
     editMode: true,
-    draft,
-    profileId,
-  }),
-  handleDeleteClick: ({ draft, profileId }) => ({
-    type: actionTypes.DRAFT_CLICKED_DELETE,
-    updateId: draft.id,
-    draft,
-    profileId,
-  }),
-  handleCancelConfirmClick: ({ draft, profileId }) => ({
-    type: actionTypes.DRAFT_CANCELED_DELETE,
-    updateId: draft.id,
     draft,
     profileId,
   }),

--- a/packages/drafts/reducer.test.js
+++ b/packages/drafts/reducer.test.js
@@ -172,7 +172,9 @@ describe('reducer', () => {
 
   // DRAFT_DELETED
   it('should handle DRAFT_DELETED action type', () => {
-    const draft = { id: '12345', text: 'i heart buffer', isConfirmingDelete: true, isDeleting: true };
+    const draft = {
+      id: '12345', text: 'i heart buffer', isConfirmingDelete: true, isDeleting: true,
+    };
     const stateBefore = {
       byProfileId: {
         [profileId]: {
@@ -233,9 +235,11 @@ describe('reducer', () => {
       .toEqual(stateAfter);
   });
 
-    // DRAFT_CONFIRMED_DELETE
+  // DRAFT_CONFIRMED_DELETE
   it('should handle DRAFT_CONFIRMED_DELETE action type', () => {
-    const draft = { id: '12345', text: 'i heart buffer', isConfirmingDelete: true, isDeleting: false };
+    const draft = {
+      id: '12345', text: 'i heart buffer', isConfirmingDelete: true, isDeleting: false,
+    };
     const draftAfter = { ...draft, isConfirmingDelete: false, isDeleting: true };
     const stateBefore = {
       byProfileId: {
@@ -263,82 +267,6 @@ describe('reducer', () => {
     };
     const action = {
       type: actionTypes.DRAFT_CONFIRMED_DELETE,
-      profileId,
-      draft: draftAfter,
-    };
-    deepFreeze(action);
-    expect(reducer(stateBefore, action))
-      .toEqual(stateAfter);
-  });
-
-    // DRAFT_CANCELED_DELETE
-  it('should handle DRAFT_CANCELED_DELETE action type', () => {
-    const draft = { id: '12345', text: 'i heart buffer', isConfirmingDelete: true, isDeleting: false };
-    const draftAfter = { ...draft, isConfirmingDelete: false, isDeleting: false };
-    const stateBefore = {
-      byProfileId: {
-        [profileId]: {
-          loading: true,
-          loadingMore: false,
-          moreToLoad: false,
-          page: 1,
-          drafts: { 12345: draft },
-          total: 1,
-        },
-      },
-    };
-    const stateAfter = {
-      byProfileId: {
-        [profileId]: {
-          loading: true,
-          loadingMore: false,
-          moreToLoad: false,
-          page: 1,
-          drafts: { 12345: draftAfter },
-          total: 1,
-        },
-      },
-    };
-    const action = {
-      type: actionTypes.DRAFT_CANCELED_DELETE,
-      profileId,
-      draft: draftAfter,
-    };
-    deepFreeze(action);
-    expect(reducer(stateBefore, action))
-      .toEqual(stateAfter);
-  });
-
-  // DRAFT_CLICKED_DELETE
-  it('should handle DRAFT_CLICKED_DELETE action type', () => {
-    const draft = { id: '12345', text: 'i heart buffer', isConfirmingDelete: false };
-    const draftAfter = { ...draft, isConfirmingDelete: true };
-    const stateBefore = {
-      byProfileId: {
-        [profileId]: {
-          loading: true,
-          loadingMore: false,
-          moreToLoad: false,
-          page: 1,
-          drafts: { 12345: draft },
-          total: 1,
-        },
-      },
-    };
-    const stateAfter = {
-      byProfileId: {
-        [profileId]: {
-          loading: true,
-          loadingMore: false,
-          moreToLoad: false,
-          page: 1,
-          drafts: { 12345: draftAfter },
-          total: 1,
-        },
-      },
-    };
-    const action = {
-      type: actionTypes.DRAFT_CLICKED_DELETE,
       profileId,
       draft: draftAfter,
     };
@@ -549,24 +477,6 @@ describe('reducer', () => {
       });
     });
 
-    it('handleDeleteClick triggers a DRAFT_CLICKED_DELETE action', () => {
-      expect(actions.handleDeleteClick({ draft, profileId })).toEqual({
-        type: actionTypes.DRAFT_CLICKED_DELETE,
-        updateId: draft.id,
-        draft,
-        profileId,
-      });
-    });
-
-    it('handleCancelConfirmClick triggers a DRAFT_CANCELED_DELETE action', () => {
-      expect(actions.handleCancelConfirmClick({ draft, profileId })).toEqual({
-        type: actionTypes.DRAFT_CANCELED_DELETE,
-        updateId: draft.id,
-        draft,
-        profileId,
-      });
-    });
-
     it('handleDeleteConfirmClick triggers a DRAFT_CONFIRMED_DELETE action', () => {
       expect(actions.handleDeleteConfirmClick({ draft, profileId })).toEqual({
         type: actionTypes.DRAFT_CONFIRMED_DELETE,
@@ -581,7 +491,7 @@ describe('reducer', () => {
         type: actionTypes.OPEN_COMPOSER,
       });
     });
-    
+
     it('handleComposerCreateSuccess triggers a HIDE_COMPOSER action', () => {
       expect(actions.handleComposerCreateSuccess()).toEqual({
         type: actionTypes.HIDE_COMPOSER,

--- a/packages/past-reminders/components/PastRemindersPosts/story.jsx
+++ b/packages/past-reminders/components/PastRemindersPosts/story.jsx
@@ -47,8 +47,6 @@ storiesOf('PastRemindersPosts', module)
       header={header}
       subHeader={subHeader}
       postLists={postLists}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -64,8 +62,6 @@ storiesOf('PastRemindersPosts', module)
       header={header}
       subHeader={subHeader}
       postLists={postLists}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -81,8 +77,6 @@ storiesOf('PastRemindersPosts', module)
       header={header}
       subHeader={subHeader}
       postLists={postLists}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -101,8 +95,6 @@ storiesOf('PastRemindersPosts', module)
       header={header}
       subHeader={subHeader}
       postLists={postLists}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}

--- a/packages/queue/components/QueueItems/index.jsx
+++ b/packages/queue/components/QueueItems/index.jsx
@@ -8,8 +8,6 @@ import {
   transitionAnimationTime,
   transitionAnimationType,
 } from '@bufferapp/components/style/animation';
-import { noScheduledDate } from '../../util';
-
 import {
   TextPost,
   ImagePost,
@@ -23,13 +21,13 @@ import {
 import PostEmptySlot from '@bufferapp/publish-shared-components/PostEmptySlot/dropTarget';
 import getErrorBoundary from '@bufferapp/publish-web/components/ErrorBoundary';
 import FailedPostComponent from '@bufferapp/publish-web/components/ErrorBoundary/failedPostComponent';
+import { noScheduledDate } from '../../util';
 
 const ErrorBoundary = getErrorBoundary(true);
 
 const listHeaderStyle = {
   marginBottom: '1rem',
   marginTop: '1rem',
-  // marginLeft: '0.5rem',
   display: 'flex',
   alignItems: 'center',
 };
@@ -78,9 +76,7 @@ const renderPost = ({
   post,
   index,
   subprofiles,
-  onCancelConfirmClick,
   onRequeueClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -99,8 +95,6 @@ const renderPost = ({
     index,
     postDetails: post.postDetails,
     subprofiles,
-    onCancelConfirmClick: () => onCancelConfirmClick({ post }),
-    onDeleteClick: () => onDeleteClick({ post }),
     onDeleteConfirmClick: () => onDeleteConfirmClick({ post }),
     onEditClick: () => onEditClick({ post }),
     onShareNowClick: () => onShareNowClick({ post }),
@@ -169,7 +163,7 @@ const renderPost = ({
   return (
     <div style={calculateStyles(defaultStyle, hiddenStyle)} key={post.id}>
       <ErrorBoundary
-        fallbackComponent={() =>
+        fallbackComponent={() => (
           <ErrorBoundary
             fallbackComponent={() => (
               <FailedPostComponent
@@ -181,7 +175,7 @@ const renderPost = ({
           >
             <PostComponent {...postWithEventHandlers} basic />
           </ErrorBoundary>
-        }
+        )}
       >
         <PostComponent {...postWithEventHandlers} />
       </ErrorBoundary>
@@ -219,20 +213,24 @@ const renderHeader = (
   <div style={listHeaderStyle} key={id}>
     <div style={headerTextStyle}>
       {(dayOfWeek && date)
-        ? (<React.Fragment>
-          <span style={headerTextDayOfWeekStyle}>{dayOfWeek}</span>
-          <span style={headerTextDateStyle}>{date}</span>
-        </React.Fragment>)
+        ? (
+          <React.Fragment>
+            <span style={headerTextDayOfWeekStyle}>{dayOfWeek}</span>
+            <span style={headerTextDateStyle}>{date}</span>
+          </React.Fragment>
+        )
         : <span style={headerTextDayOfWeekStyle}>{getText(text)}</span>
       }
     </div>
-    {showCalendarBtnGroup && (!features.isFreeUser() || isBusinessAccount) &&
-      <div style={{ marginLeft: 'auto' }}>
-        <QueueButtonGroup
-          buttons={calendarBtns}
-          onClick={type => onCalendarClick(type, `daily_view_type_buttons_click_${type}`)}
-        />
-      </div>
+    {showCalendarBtnGroup && (!features.isFreeUser() || isBusinessAccount)
+      && (
+        <div style={{ marginLeft: 'auto' }}>
+          <QueueButtonGroup
+            buttons={calendarBtns}
+            onClick={type => onCalendarClick(type, `daily_view_type_buttons_click_${type}`)}
+          />
+        </div>
+      )
     }
   </div>
 );
@@ -244,15 +242,13 @@ const renderSlot = ({ id, slot, profileService }, onEmptySlotClick) => (
     timestamp={slot.timestamp}
     day={slot.dayText}
     service={profileService}
-    onClick={() =>
-      onEmptySlotClick({
-        dueTime: slot.label,
-        profile_service: profileService,
-        scheduled_at: slot.timestamp,
-        due_at: slot.timestamp,
-        pinned: true,
-      })
-    }
+    onClick={() => onEmptySlotClick({
+      dueTime: slot.label,
+      profile_service: profileService,
+      scheduled_at: slot.timestamp,
+      due_at: slot.timestamp,
+      pinned: true,
+    })}
   />
 );
 
@@ -313,8 +309,6 @@ QueueItems.propTypes = {
     }),
   ),
   onCalendarClick: PropTypes.func,
-  onCancelConfirmClick: PropTypes.func,
-  onDeleteClick: PropTypes.func,
   onDeleteConfirmClick: PropTypes.func,
   onEditClick: PropTypes.func,
   onEmptySlotClick: PropTypes.func,

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -39,9 +39,7 @@ const QueuedPosts = ({
   postLists,
   onComposerPlaceholderClick,
   onComposerCreateSuccess,
-  onCancelConfirmClick,
   onRequeueClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onEmptySlotClick,
@@ -95,51 +93,55 @@ const QueuedPosts = ({
       <div>
         <div style={topBarContainerStyle}>
           <div style={composerStyle}>
-            {showComposer && !editMode &&
-              <ComposerPopover
-                onSave={onComposerCreateSuccess}
-                preserveComposerStateOnClose
-                type={'queue'}
-                onComposerOverlayClick={onComposerOverlayClick}
-                editMode={editMode}
-              />
+            {showComposer && !editMode
+              && (
+                <ComposerPopover
+                  onSave={onComposerCreateSuccess}
+                  preserveComposerStateOnClose
+                  type="queue"
+                  onComposerOverlayClick={onComposerOverlayClick}
+                  editMode={editMode}
+                />
+              )
             }
             <ComposerInput
               onPlaceholderClick={onComposerPlaceholderClick}
-              placeholder={'What would you like to share?'}
+              placeholder="What would you like to share?"
             />
           </div>
         </div>
-        {isInstagramProfile && !isInstagramBusiness &&
-          <InstagramDirectPostingBanner onDirectPostingClick={onDirectPostingClick} />
+        {isInstagramProfile && !isInstagramBusiness
+          && <InstagramDirectPostingBanner onDirectPostingClick={onDirectPostingClick} />
         }
-        {showInstagramDirectPostingModal &&
-          <InstagramDirectPostingModal />
+        {showInstagramDirectPostingModal
+          && <InstagramDirectPostingModal />
         }
         {!!paused && <QueuePausedBar isManager={isManager} handleClickUnpause={onUnpauseClick} />}
-        {showEmptyQueueMessage &&
-          <EmptyState
-            title="It looks like you haven't got any posts in your queue!"
-            subtitle="Click the box above to add a post to your queue :)"
-            heroImg="https://s3.amazonaws.com/buffer-publish/images/fresh-queue%402x.png"
-            heroImgSize={{ width: '229px', height: '196px' }}
-          />
+        {showEmptyQueueMessage
+          && (
+            <EmptyState
+              title="It looks like you haven't got any posts in your queue!"
+              subtitle="Click the box above to add a post to your queue :)"
+              heroImg="https://s3.amazonaws.com/buffer-publish/images/fresh-queue%402x.png"
+              heroImgSize={{ width: '229px', height: '196px' }}
+            />
+          )
         }
-        {showComposer && editMode &&
-          <ComposerPopover
-            onSave={onComposerCreateSuccess}
-            type={'queue'}
-            onComposerOverlayClick={onComposerOverlayClick}
-            editMode={editMode}
-          />
+        {showComposer && editMode
+          && (
+            <ComposerPopover
+              onSave={onComposerCreateSuccess}
+              type="queue"
+              onComposerOverlayClick={onComposerOverlayClick}
+              editMode={editMode}
+            />
+          )
         }
         <QueueItems
           items={postLists}
           subprofiles={subprofiles}
-          onCancelConfirmClick={onCancelConfirmClick}
           onCalendarClick={onCalendarClick}
           onRequeueClick={onRequeueClick}
-          onDeleteClick={onDeleteClick}
           onDeleteConfirmClick={onDeleteConfirmClick}
           onEditClick={onEditClick}
           onEmptySlotClick={onEmptySlotClick}
@@ -177,9 +179,7 @@ QueuedPosts.propTypes = {
   onComposerPlaceholderClick: PropTypes.func.isRequired,
   onComposerCreateSuccess: PropTypes.func.isRequired,
   onComposerOverlayClick: PropTypes.func.isRequired,
-  onCancelConfirmClick: PropTypes.func.isRequired,
   onRequeueClick: PropTypes.func.isRequired,
-  onDeleteClick: PropTypes.func.isRequired,
   onDeleteConfirmClick: PropTypes.func.isRequired,
   onEditClick: PropTypes.func.isRequired,
   onEmptySlotClick: PropTypes.func.isRequired,
@@ -211,10 +211,8 @@ QueuedPosts.defaultProps = {
   loading: true,
   moreToLoad: false,
   page: 1,
-  postLists: [],
   showComposer: false,
   showEmptyQueueMessage: false,
-  enabledApplicationModes: [],
   editMode: false,
   paused: false,
   subprofiles: [],

--- a/packages/queue/components/QueuedPosts/story.jsx
+++ b/packages/queue/components/QueuedPosts/story.jsx
@@ -69,8 +69,6 @@ storiesOf('QueuedPosts', module)
       total={10}
       loading={false}
       postLists={postLists}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -97,8 +95,6 @@ storiesOf('QueuedPosts', module)
       total={0}
       loading
       postLists={postLists}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -125,8 +121,6 @@ storiesOf('QueuedPosts', module)
       total={10}
       loading={false}
       postLists={postLists}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -153,8 +147,6 @@ storiesOf('QueuedPosts', module)
     <QueuedPosts
       total={10}
       loading={false}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -182,8 +174,6 @@ storiesOf('QueuedPosts', module)
       total={10}
       loading={false}
       postLists={postLists}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -74,20 +74,8 @@ export default connect(
         profileId: ownProps.profileId,
       }));
     },
-    onDeleteClick: (post) => {
-      dispatch(actions.handleDeleteClick({
-        post: post.post,
-        profileId: ownProps.profileId,
-      }));
-    },
     onDeleteConfirmClick: (post) => {
       dispatch(actions.handleDeleteConfirmClick({
-        post: post.post,
-        profileId: ownProps.profileId,
-      }));
-    },
-    onCancelConfirmClick: (post) => {
-      dispatch(actions.handleCancelConfirmClick({
         post: post.post,
         profileId: ownProps.profileId,
       }));

--- a/packages/queue/index.test.jsx
+++ b/packages/queue/index.test.jsx
@@ -56,8 +56,6 @@ describe('Queue', () => {
         <Queue
           profileId="abc"
           postLists={[]}
-          onCancelConfirmClick={jest.fn()}
-          onDeleteClick={jest.fn()}
           onDeleteConfirmClick={jest.fn()}
           onEditClick={jest.fn()}
           onRequeueClick={jest.fn()}

--- a/packages/queue/reducer.js
+++ b/packages/queue/reducer.js
@@ -9,9 +9,7 @@ export const actionTypes = keyWrapper('QUEUE', {
   POST_UPDATED: 0,
   POST_DELETED: 0,
   POST_SENT: 0,
-  POST_CLICKED_DELETE: 0,
   POST_CONFIRMED_DELETE: 0,
-  POST_CANCELED_DELETE: 0,
   POST_ERROR: 0,
   POST_SHARE_NOW: 0,
   POST_IMAGE_CLICKED: 0,
@@ -130,8 +128,6 @@ const postReducer = (state, action) => {
       return action.post;
     case actionTypes.POST_ERROR:
       return state;
-    case actionTypes.POST_CLICKED_DELETE:
-      return { ...state, isConfirmingDelete: true };
     case actionTypes.POST_CONFIRMED_DELETE:
       return {
         ...state,
@@ -142,11 +138,6 @@ const postReducer = (state, action) => {
       return {
         ...state,
         isWorking: true,
-      };
-    case actionTypes.POST_CANCELED_DELETE:
-      return {
-        ...state,
-        isConfirmingDelete: false,
       };
     case actionTypes.POST_IMAGE_CLICKED:
       return {
@@ -252,9 +243,7 @@ const postsReducer = (state = {}, action) => {
     case draftActionTypes.DRAFT_APPROVED:
     case actionTypes.POST_CREATED:
     case actionTypes.POST_UPDATED:
-    case actionTypes.POST_CLICKED_DELETE:
     case actionTypes.POST_CONFIRMED_DELETE:
-    case actionTypes.POST_CANCELED_DELETE:
     case actionTypes.POST_SHARE_NOW:
     case actionTypes.POST_IMAGE_CLICKED:
     case actionTypes.POST_IMAGE_CLOSED:
@@ -321,10 +310,8 @@ const profileReducer = (state = profileInitialState, action) => {
     case actionTypes.POST_ERROR:
     case actionTypes.POST_CREATED:
     case actionTypes.POST_UPDATED:
-    case actionTypes.POST_CLICKED_DELETE:
     case actionTypes.POST_CONFIRMED_DELETE:
     case actionTypes.POST_DELETED:
-    case actionTypes.POST_CANCELED_DELETE:
     case actionTypes.POST_IMAGE_CLICKED:
     case actionTypes.POST_IMAGE_CLOSED:
     case actionTypes.POST_IMAGE_CLICKED_NEXT:
@@ -357,10 +344,8 @@ export default (state = initialState, action) => {
     case `shuffleQueue_${dataFetchActionTypes.FETCH_SUCCESS}`:
     case actionTypes.POST_CREATED:
     case actionTypes.POST_UPDATED:
-    case actionTypes.POST_CLICKED_DELETE:
     case actionTypes.POST_CONFIRMED_DELETE:
     case actionTypes.POST_DELETED:
-    case actionTypes.POST_CANCELED_DELETE:
     case actionTypes.POST_ERROR:
     case actionTypes.POST_IMAGE_CLICKED:
     case actionTypes.POST_IMAGE_CLOSED:
@@ -440,20 +425,8 @@ export const actions = {
     emptySlotData,
     profileId,
   }),
-  handleDeleteClick: ({ post, profileId }) => ({
-    type: actionTypes.POST_CLICKED_DELETE,
-    updateId: post.id,
-    post,
-    profileId,
-  }),
   handleDeleteConfirmClick: ({ post, profileId }) => ({
     type: actionTypes.POST_CONFIRMED_DELETE,
-    updateId: post.id,
-    post,
-    profileId,
-  }),
-  handleCancelConfirmClick: ({ post, profileId }) => ({
-    type: actionTypes.POST_CANCELED_DELETE,
     updateId: post.id,
     post,
     profileId,

--- a/packages/queue/reducer.test.js
+++ b/packages/queue/reducer.test.js
@@ -1,6 +1,5 @@
 import deepFreeze from 'deep-freeze';
 import reducer, { initialState, actionTypes } from './reducer';
-import { postParser } from '@bufferapp/publish-server/parsers/src';
 
 const profileId = '123456';
 
@@ -291,44 +290,6 @@ describe('reducer', () => {
       .toEqual(stateAfter);
   });
 
-  // POST_CLICKED_DELETE
-  it('should handle POST_CLICKED_DELETE action type', () => {
-    const post = { id: '12345', text: 'i heart buffer', isConfirmingDelete: false };
-    const postAfter = { ...post, isConfirmingDelete: true };
-    const stateBefore = {
-      byProfileId: {
-        [profileId]: {
-          loading: true,
-          loadingMore: false,
-          moreToLoad: false,
-          page: 1,
-          posts: { 12345: post },
-          total: 1,
-        },
-      },
-    };
-    const stateAfter = {
-      byProfileId: {
-        [profileId]: {
-          loading: true,
-          loadingMore: false,
-          moreToLoad: false,
-          page: 1,
-          posts: { 12345: postAfter },
-          total: 1,
-        },
-      },
-    };
-    const action = {
-      type: actionTypes.POST_CLICKED_DELETE,
-      profileId,
-      post: postAfter,
-    };
-    deepFreeze(action);
-    expect(reducer(stateBefore, action))
-      .toEqual(stateAfter);
-  });
-
   // POST_CONFIRMED_DELETE
   it('should handle POST_CONFIRMED_DELETE action type', () => {
     const post = { id: '12345', text: 'i heart buffer', isConfirmingDelete: true, isDeleting: false };
@@ -369,7 +330,9 @@ describe('reducer', () => {
 
   // POST_DELETED
   it('should handle POST_DELETED action type', () => {
-    const post = { id: '12345', text: 'i heart buffer', isConfirmingDelete: true, isDeleting: true };
+    const post = {
+      id: '12345', text: 'i heart buffer', isConfirmingDelete: true, isDeleting: true,
+    };
     const stateBefore = {
       byProfileId: {
         [profileId]: {
@@ -398,44 +361,6 @@ describe('reducer', () => {
       type: actionTypes.POST_DELETED,
       profileId,
       post,
-    };
-    deepFreeze(action);
-    expect(reducer(stateBefore, action))
-      .toEqual(stateAfter);
-  });
-
-  // POST_CANCELED_DELETE
-  it('should handle POST_CANCELED_DELETE action type', () => {
-    const post = { id: '12345', text: 'i heart buffer', isConfirmingDelete: true, isDeleting: false };
-    const postAfter = { ...post, isConfirmingDelete: false, isDeleting: false };
-    const stateBefore = {
-      byProfileId: {
-        [profileId]: {
-          loading: true,
-          loadingMore: false,
-          moreToLoad: false,
-          page: 1,
-          posts: { 12345: post },
-          total: 1,
-        },
-      },
-    };
-    const stateAfter = {
-      byProfileId: {
-        [profileId]: {
-          loading: true,
-          loadingMore: false,
-          moreToLoad: false,
-          page: 1,
-          posts: { 12345: postAfter },
-          total: 1,
-        },
-      },
-    };
-    const action = {
-      type: actionTypes.POST_CANCELED_DELETE,
-      profileId,
-      post: postAfter,
     };
     deepFreeze(action);
     expect(reducer(stateBefore, action))

--- a/packages/shared-components/Draft/index.jsx
+++ b/packages/shared-components/Draft/index.jsx
@@ -94,8 +94,6 @@ const Draft = ({
   isPastDue,
   manager,
   onApproveClick,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onMoveToDraftsClick,
@@ -139,8 +137,6 @@ const Draft = ({
       manager={manager}
       scheduledAt={scheduledAt}
       onApproveClick={onApproveClick}
-      onCancelConfirmClick={onCancelConfirmClick}
-      onDeleteClick={onDeleteClick}
       onDeleteConfirmClick={onDeleteConfirmClick}
       onEditClick={onEditClick}
       onMoveToDraftsClick={onMoveToDraftsClick}
@@ -153,21 +149,27 @@ const Draft = ({
   </Card>
 );
 
-Draft.commonPropTypes = {
+Draft.propTypes = {
   hasPermission: PropTypes.bool.isRequired,
   isConfirmingDelete: PropTypes.bool,
   isDeleting: PropTypes.bool,
   isWorking: PropTypes.bool,
-  onCancelConfirmClick: PropTypes.func,
-  onRequeueClick: PropTypes.func,
-  onDeleteClick: PropTypes.func,
+  isMoving: PropTypes.bool,
+  isPastDue: PropTypes.bool,
+  manager: PropTypes.bool,
   onDeleteConfirmClick: PropTypes.func,
+  onApproveClick: PropTypes.func,
+  onMoveToDraftsClick: PropTypes.func,
+  onRequestApprovalClick: PropTypes.func,
+  onRescheduleClick: PropTypes.func,
   onEditClick: PropTypes.func,
-  onShareNowClick: PropTypes.func,
   draftDetails: PropTypes.shape({
     isRetweet: PropTypes.bool,
     postAction: PropTypes.string,
     error: PropTypes.string,
+    creatorName: PropTypes.string,
+    avatarUrl: PropTypes.string,
+    createdAt: PropTypes.string,
   }).isRequired,
   retweetProfile: PropTypes.shape({
     avatarUrl: PropTypes.string,
@@ -184,10 +186,6 @@ Draft.commonPropTypes = {
     }),
   ),
   hasFirstCommentFlip: PropTypes.bool,
-};
-
-Draft.propTypes = {
-  ...Draft.commonPropTypes,
   view: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
 };
@@ -196,6 +194,9 @@ Draft.defaultProps = {
   isConfirmingDelete: false,
   isDeleting: false,
   isWorking: false,
+  isMoving: false,
+  isPastDue: false,
+  manager: true,
   hasFirstCommentFlip: false,
 };
 

--- a/packages/shared-components/Draft/index.jsx
+++ b/packages/shared-components/Draft/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import {
   LinkifiedText,
   Text,
@@ -11,6 +12,15 @@ import DraftFooter from '../DraftFooter';
 import RetweetPanel from '../RetweetPanel';
 
 import RenderPostMetaBar from '../Post/RenderPostMetaBar';
+
+const RetweetCard = styled(Card)`
+  padding: 1rem;
+`;
+
+const RetweetCardContent = styled.span`
+  padding: 1rem;
+`;
+
 
 const postContentStyle = {
   padding: '1rem',
@@ -66,12 +76,14 @@ const renderContent = ({
     return (
       <div style={postContentStyle}>
         { retweetComment ? renderRetweetComment({ retweetComment, retweetCommentLinks, basic }) : '' }
-        <Card>
-          <div style={retweetProfileWrapperStyle}>
-            <RetweetPanel {...retweetProfile} />
-          </div>
-          { children }
-        </Card>
+        <RetweetCard>
+          <RetweetCardContent>
+            <div style={retweetProfileWrapperStyle}>
+              <RetweetPanel {...retweetProfile} />
+            </div>
+            { children }
+          </RetweetCardContent>
+        </RetweetCard>
       </div>
     );
   }

--- a/packages/shared-components/Draft/story.jsx
+++ b/packages/shared-components/Draft/story.jsx
@@ -235,6 +235,7 @@ storiesOf('Draft', module)
   .add('past due no permission', () => (
     <Draft
       hasPermission={false}
+      manager={false}
       draftDetails={pastDueDraftDetails}
       isPastDue
       onApproveClick={linkTo('Draft', 'isWorking')}
@@ -250,6 +251,7 @@ storiesOf('Draft', module)
   .add('no permission', () => (
     <Draft
       hasPermission={false}
+      manager={false}
       draftDetails={draftDetails}
       onApproveClick={linkTo('Draft', 'isWorking')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}

--- a/packages/shared-components/Draft/story.jsx
+++ b/packages/shared-components/Draft/story.jsx
@@ -59,7 +59,7 @@ const children = (
 );
 
 const childrenLineBreaks = (
-  <Text size={'mini'}>
+  <Text size="mini">
     {'I am a text-only \n test post \n with line breaks.'}
   </Text>
 );
@@ -71,8 +71,6 @@ storiesOf('Draft', module)
       hasPermission
       draftDetails={draftDetails}
       onApproveClick={linkTo('Draft', 'isWorking')}
-      onCancelConfirmClick={linkTo('Draft', 'hovered')}
-      onDeleteClick={linkTo('Draft', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}
       onEditClick={action('edit-click')}
       view={draftsView}
@@ -85,8 +83,6 @@ storiesOf('Draft', module)
       hasPermission
       draftDetails={draftDetails}
       onApproveClick={linkTo('Draft', 'isWorking')}
-      onCancelConfirmClick={linkTo('Draft', 'hovered')}
-      onDeleteClick={linkTo('Draft', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}
       onEditClick={action('edit-click')}
       view={draftsView}
@@ -99,8 +95,6 @@ storiesOf('Draft', module)
       hasPermission
       draftDetails={scheduledDraftDetails}
       onApproveClick={linkTo('Draft', 'isWorking')}
-      onCancelConfirmClick={linkTo('Draft', 'hovered')}
-      onDeleteClick={linkTo('Draft', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}
       onEditClick={action('edit-click')}
       scheduledAt={scheduledAt}
@@ -115,8 +109,6 @@ storiesOf('Draft', module)
       onMouseEnter={action('on-mouse-enter')}
       onMouseLeave={action('on-mouse-leave')}
       onApproveClick={linkTo('Draft', 'isWorkingManager')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       manager
@@ -131,8 +123,6 @@ storiesOf('Draft', module)
       hasPermission
       isConfirmingDelete
       onApproveClick={linkTo('Draft', 'isWorking')}
-      onCancelConfirmClick={linkTo('Draft', 'hovered')}
-      onDeleteClick={linkTo('Draft', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}
       onEditClick={action('edit-click')}
       draftDetails={draftDetails}
@@ -146,8 +136,6 @@ storiesOf('Draft', module)
       hasPermission
       isDeleting
       onApproveClick={linkTo('Draft', 'isWorking')}
-      onCancelConfirmClick={linkTo('Draft', 'hovered')}
-      onDeleteClick={linkTo('Draft', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}
       onEditClick={action('edit-click')}
       draftDetails={draftDetails}
@@ -161,8 +149,6 @@ storiesOf('Draft', module)
       hasPermission
       isWorking
       onApproveClick={linkTo('Draft', 'isWorking')}
-      onCancelConfirmClick={linkTo('Draft', 'hovered')}
-      onDeleteClick={linkTo('Draft', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}
       onEditClick={action('edit-click')}
       draftDetails={draftDetails}
@@ -176,8 +162,6 @@ storiesOf('Draft', module)
       hasPermission
       manager
       onApproveClick={linkTo('Draft', 'isWorking')}
-      onCancelConfirmClick={linkTo('Draft', 'hovered')}
-      onDeleteClick={linkTo('Draft', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}
       onEditClick={action('edit-click')}
       isWorking
@@ -193,8 +177,6 @@ storiesOf('Draft', module)
       isMoving
       isWorking
       onApproveClick={linkTo('Draft', 'isWorking')}
-      onCancelConfirmClick={linkTo('Draft', 'hovered')}
-      onDeleteClick={linkTo('Draft', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}
       onEditClick={action('edit-click')}
       draftDetails={draftDetails}
@@ -210,8 +192,6 @@ storiesOf('Draft', module)
       onMouseEnter={action('mouse-enter')}
       onMouseLeave={action('mous-leave')}
       onApproveClick={action('approve-click')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       retweetProfile={retweetProfile}
@@ -228,8 +208,6 @@ storiesOf('Draft', module)
       onMouseEnter={action('mouse-enter')}
       onMouseLeave={action('mous-leave')}
       onApproveClick={action('approve-click')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       retweetProfile={retweetProfile}
@@ -245,8 +223,6 @@ storiesOf('Draft', module)
       draftDetails={pastDueDraftDetails}
       isPastDue
       onApproveClick={linkTo('Draft', 'isWorking')}
-      onCancelConfirmClick={linkTo('Draft', 'hovered')}
-      onDeleteClick={linkTo('Draft', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}
       onEditClick={action('edit-click')}
       onRescheduleClick={action('reschedule-click')}
@@ -262,8 +238,6 @@ storiesOf('Draft', module)
       draftDetails={pastDueDraftDetails}
       isPastDue
       onApproveClick={linkTo('Draft', 'isWorking')}
-      onCancelConfirmClick={linkTo('Draft', 'hovered')}
-      onDeleteClick={linkTo('Draft', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}
       onEditClick={action('edit-click')}
       onRescheduleClick={action('reschedule-click')}
@@ -278,8 +252,6 @@ storiesOf('Draft', module)
       hasPermission={false}
       draftDetails={draftDetails}
       onApproveClick={linkTo('Draft', 'isWorking')}
-      onCancelConfirmClick={linkTo('Draft', 'hovered')}
-      onDeleteClick={linkTo('Draft', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Draft', 'isDeleting')}
       onEditClick={action('edit-click')}
       view={draftsView}

--- a/packages/shared-components/DraftFooter/index.jsx
+++ b/packages/shared-components/DraftFooter/index.jsx
@@ -63,6 +63,7 @@ const renderDraftsActionLabel = ({
 const DraftFooter = ({
   hasPermission,
   isDeleting,
+  isConfirmingDelete,
   isMoving,
   isWorking,
   isPastDue,
@@ -87,7 +88,7 @@ const DraftFooter = ({
   const hasRequestApprovalAction = draftsView && hasPermission;
 
   // Performing Actions
-  const deletingMessage = isDeleting && 'Deleting...';
+  const deletingMessage = (isDeleting || isConfirmingDelete) && 'Deleting...';
   const movingMessage = isMoving && approvalView && 'Moving...';
   const requestingMessage = isMoving && !approvalView && 'Requesting...';
   const approvingMessage = isWorking && manager && approvalView && 'Approving...';
@@ -127,6 +128,7 @@ const DraftFooter = ({
 DraftFooter.propTypes = {
   hasPermission: PropTypes.bool.isRequired,
   isDeleting: PropTypes.bool,
+  isConfirmingDelete: PropTypes.bool,
   isMoving: PropTypes.bool,
   isWorking: PropTypes.bool,
   isPastDue: PropTypes.bool,

--- a/packages/shared-components/DraftFooter/story.jsx
+++ b/packages/shared-components/DraftFooter/story.jsx
@@ -37,8 +37,6 @@ storiesOf('DraftFooter', module)
       hasPermission
       manager
       onApproveClick={linkTo('DraftFooter', 'drafts view: managerIsApproving')}
-      onCancelConfirmClick={linkTo('DraftFooter', 'manager')}
-      onDeleteClick={linkTo('DraftFooter', 'managerIsConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'managerIsDeleting')}
       onEditClick={action('edit-click')}
       draftDetails={draftDetailsScheduled}
@@ -51,8 +49,6 @@ storiesOf('DraftFooter', module)
       hasPermission
       manager
       onApproveClick={linkTo('DraftFooter', 'drafts view: managerIsApproving')}
-      onCancelConfirmClick={linkTo('DraftFooter', 'manager')}
-      onDeleteClick={linkTo('DraftFooter', 'managerIsConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'managerIsDeleting')}
       onEditClick={action('edit-click')}
       draftDetails={draftDetails}
@@ -65,8 +61,6 @@ storiesOf('DraftFooter', module)
       isPastDue
       manager
       onApproveClick={linkTo('DraftFooter', 'managerIsApproving')}
-      onCancelConfirmClick={linkTo('DraftFooter', 'manager')}
-      onDeleteClick={linkTo('DraftFooter', 'managerIsConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'managerIsDeleting')}
       onEditClick={action('edit-click')}
       onRescheduleClick={action('reschedule-click')}
@@ -78,8 +72,6 @@ storiesOf('DraftFooter', module)
   .add('drafts view: not manager', () => (
     <DraftFooter
       hasPermission
-      onCancelConfirmClick={linkTo('DraftFooter', 'default')}
-      onDeleteClick={linkTo('DraftFooter', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'isDeleting')}
       onEditClick={action('edit-click')}
       onRequestApprovalClick={linkTo('DraftFooter', 'drafts view: isWorking')}
@@ -91,8 +83,6 @@ storiesOf('DraftFooter', module)
     <DraftFooter
       hasPermission
       isPastDue
-      onCancelConfirmClick={linkTo('DraftFooter', 'default')}
-      onDeleteClick={linkTo('DraftFooter', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'isDeleting')}
       onEditClick={action('edit-click')}
       onRequestApprovalClick={linkTo('DraftFooter', 'drafts view: isWorking')}
@@ -105,8 +95,6 @@ storiesOf('DraftFooter', module)
   .add('drafts view: not manager, no permission', () => (
     <DraftFooter
       hasPermission={false}
-      onCancelConfirmClick={linkTo('DraftFooter', 'default')}
-      onDeleteClick={linkTo('DraftFooter', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'isDeleting')}
       onEditClick={action('edit-click')}
       onRequestApprovalClick={linkTo('DraftFooter', 'drafts view: isWorking')}
@@ -119,8 +107,6 @@ storiesOf('DraftFooter', module)
     <DraftFooter
       hasPermission={false}
       isPastDue
-      onCancelConfirmClick={linkTo('DraftFooter', 'default')}
-      onDeleteClick={linkTo('DraftFooter', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'isDeleting')}
       onEditClick={action('edit-click')}
       onRequestApprovalClick={linkTo('DraftFooter', 'drafts view: isWorking')}
@@ -134,8 +120,6 @@ storiesOf('DraftFooter', module)
       hasPermission
       manager
       onApproveClick={linkTo('DraftFooter', 'approval view: managerIsApproving')}
-      onCancelConfirmClick={linkTo('DraftFooter', 'manager')}
-      onDeleteClick={linkTo('DraftFooter', 'managerIsConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'managerIsDeleting')}
       onEditClick={action('edit-click')}
       onMoveToDraftsClick={linkTo('DraftFooter', 'approval view: manager moving to drafts')}
@@ -149,8 +133,6 @@ storiesOf('DraftFooter', module)
       isPastDue
       manager
       onApproveClick={linkTo('DraftFooter', 'managerIsApproving')}
-      onCancelConfirmClick={linkTo('DraftFooter', 'manager')}
-      onDeleteClick={linkTo('DraftFooter', 'managerIsConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'managerIsDeleting')}
       onEditClick={action('edit-click')}
       onRescheduleClick={action('reschedule-click')}
@@ -162,8 +144,6 @@ storiesOf('DraftFooter', module)
   .add('approval view: not a manager', () => (
     <DraftFooter
       hasPermission
-      onCancelConfirmClick={linkTo('DraftFooter', 'manager')}
-      onDeleteClick={linkTo('DraftFooter', 'managerIsConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'managerIsDeleting')}
       onEditClick={action('edit-click')}
       onMoveToDraftsClick={linkTo('DraftFooter', 'approval view: not manager moving to drafts')}
@@ -175,8 +155,6 @@ storiesOf('DraftFooter', module)
     <DraftFooter
       hasPermission
       isPastDue
-      onCancelConfirmClick={linkTo('DraftFooter', 'manager')}
-      onDeleteClick={linkTo('DraftFooter', 'managerIsConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'managerIsDeleting')}
       onEditClick={action('edit-click')}
       onRescheduleClick={action('reschedule-click')}
@@ -188,8 +166,6 @@ storiesOf('DraftFooter', module)
   .add('approval view: not manager, no permission', () => (
     <DraftFooter
       hasPermission={false}
-      onCancelConfirmClick={linkTo('DraftFooter', 'default')}
-      onDeleteClick={linkTo('DraftFooter', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'isDeleting')}
       onEditClick={action('edit-click')}
       onRequestApprovalClick={linkTo('DraftFooter', 'drafts view: isWorking')}
@@ -204,8 +180,6 @@ storiesOf('DraftFooter', module)
       isWorking
       manager
       onApproveClick={linkTo('DraftFooter', 'approval view: managerIsApproving')}
-      onCancelConfirmClick={linkTo('DraftFooter', 'manager')}
-      onDeleteClick={linkTo('DraftFooter', 'managerIsConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'managerIsDeleting')}
       onEditClick={action('edit-click')}
       onMoveToDraftsClick={action('move-to-drafts-click')}
@@ -218,8 +192,6 @@ storiesOf('DraftFooter', module)
       hasPermission
       isMoving
       isWorking
-      onCancelConfirmClick={linkTo('DraftFooter', 'default')}
-      onDeleteClick={linkTo('DraftFooter', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'isDeleting')}
       onEditClick={action('edit-click')}
       onMoveToDraftsClick={action('move-to-drafts-click')}
@@ -231,9 +203,7 @@ storiesOf('DraftFooter', module)
   .add('isDeleting', () => (
     <DraftFooter
       hasPermission
-      onDeleteClick={linkTo('DraftFooter', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'isDeleting')}
-      onCancelConfirmClick={linkTo('DraftFooter', 'default')}
       onEditClick={action('edit-click')}
       draftDetails={draftDetails}
       isDeleting
@@ -245,9 +215,7 @@ storiesOf('DraftFooter', module)
       hasPermission
       manager
       onApproveClick={action('approve-click')}
-      onDeleteClick={linkTo('DraftFooter', 'managerIsConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'isDeleting')}
-      onCancelConfirmClick={linkTo('DraftFooter', 'manager')}
       onEditClick={action('edit-click')}
       draftDetails={draftDetails}
       isWorking
@@ -259,9 +227,7 @@ storiesOf('DraftFooter', module)
       hasPermission
       manager
       onApproveClick={action('approve-click')}
-      onDeleteClick={linkTo('DraftFooter', 'managerIsConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'isDeleting')}
-      onCancelConfirmClick={linkTo('DraftFooter', 'manager')}
       onEditClick={action('edit-click')}
       draftDetails={draftDetails}
       isWorking
@@ -272,9 +238,7 @@ storiesOf('DraftFooter', module)
     <DraftFooter
       hasPermission
       onApproveClick={action('approve-click')}
-      onDeleteClick={linkTo('DraftFooter', 'managerIsConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'isDeleting')}
-      onCancelConfirmClick={linkTo('DraftFooter', 'manager')}
       onEditClick={action('edit-click')}
       draftDetails={draftDetails}
       isMoving
@@ -284,8 +248,6 @@ storiesOf('DraftFooter', module)
   .add('no permission', () => (
     <DraftFooter
       hasPermission={false}
-      onCancelConfirmClick={linkTo('DraftFooter', 'default')}
-      onDeleteClick={linkTo('DraftFooter', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('DraftFooter', 'isDeleting')}
       onEditClick={action('edit-click')}
       draftDetails={draftDetails}

--- a/packages/shared-components/ImageDraft/index.jsx
+++ b/packages/shared-components/ImageDraft/index.jsx
@@ -60,8 +60,6 @@ const ImageDraft = ({
   links,
   manager,
   onApproveClick,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onMoveToDraftsClick,
@@ -88,35 +86,36 @@ const ImageDraft = ({
   const children = (
     <div style={postContentStyle}>
       <span style={postContentTextStyle}>
-        {basic ?
-          <Text
-            color="black"
-            size="mini"
-          >
-            {text}
-          </Text> :
-          <LinkifiedText
-            color="black"
-            links={links}
-            size="mini"
-            newTab
-            unstyled
-          >
-            {text}
-          </LinkifiedText>
+        {basic
+          ? (
+            <Text color="black" size="mini">
+              {text}
+            </Text>
+          )
+          : (
+            <LinkifiedText
+              color="black"
+              links={links}
+              size="mini"
+              newTab
+              unstyled
+            >
+              {text}
+            </LinkifiedText>
+          )
         }
       </span>
       <div style={imageWrapperStyle} onClick={onImageClick}>
         <div style={thumbnailWrapperStyle}>
           <Image
             src={imageSrc}
-            width={'auto'}
-            height={'auto'}
-            maxWidth={'9rem'}
-            maxHeight={'9rem'}
-            minHeight={'7rem'}
-            minWidth={'7rem'}
-            objectFit={'cover'}
+            width="auto"
+            height="auto"
+            maxWidth="9rem"
+            maxHeight="9rem"
+            minHeight="7rem"
+            minWidth="7rem"
+            objectFit="cover"
           />
         </div>
         <Lightbox
@@ -145,8 +144,6 @@ const ImageDraft = ({
       links={links}
       manager={manager}
       onApproveClick={onApproveClick}
-      onCancelConfirmClick={onCancelConfirmClick}
-      onDeleteClick={onDeleteClick}
       onDeleteConfirmClick={onDeleteConfirmClick}
       onEditClick={onEditClick}
       onMoveToDraftsClick={onMoveToDraftsClick}

--- a/packages/shared-components/ImageDraft/story.jsx
+++ b/packages/shared-components/ImageDraft/story.jsx
@@ -52,8 +52,6 @@ storiesOf('ImageDraft', module)
       links={links}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -63,7 +61,7 @@ storiesOf('ImageDraft', module)
       onImageClickPrev={action('image-click-prev')}
       onImageClose={action('image-close')}
       isLightboxOpen={false}
-      view={'drafts'}
+      view="drafts"
     />
   ))
   .add('approval image draft', () => (
@@ -74,8 +72,6 @@ storiesOf('ImageDraft', module)
       links={links}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -84,7 +80,7 @@ storiesOf('ImageDraft', module)
       onImageClickPrev={action('image-click-prev')}
       onImageClose={action('image-close')}
       isLightboxOpen={false}
-      view={'approval'}
+      view="approval"
     />
   ))
   .add('square image', () => (
@@ -94,8 +90,6 @@ storiesOf('ImageDraft', module)
       links={links}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -105,7 +99,7 @@ storiesOf('ImageDraft', module)
       onImageClickPrev={action('image-click-prev')}
       onImageClose={action('image-close')}
       isLightboxOpen={false}
-      view={'drafts'}
+      view="drafts"
     />
   ))
   .add('tall image', () => (
@@ -115,8 +109,6 @@ storiesOf('ImageDraft', module)
       links={links}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -126,7 +118,7 @@ storiesOf('ImageDraft', module)
       onImageClickPrev={action('image-click-prev')}
       onImageClose={action('image-close')}
       isLightboxOpen={false}
-      view={'drafts'}
+      view="drafts"
     />
   ))
   .add('wide image', () => (
@@ -136,8 +128,6 @@ storiesOf('ImageDraft', module)
       links={links}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -147,7 +137,7 @@ storiesOf('ImageDraft', module)
       onImageClickPrev={action('image-click-prev')}
       onImageClose={action('image-close')}
       isLightboxOpen={false}
-      view={'drafts'}
+      view="drafts"
     />
   ))
   .add('retweet', () => (
@@ -157,8 +147,6 @@ storiesOf('ImageDraft', module)
       links={links}
       draftDetails={isARetweetDraftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -169,7 +157,7 @@ storiesOf('ImageDraft', module)
       onImageClickPrev={action('image-click-prev')}
       onImageClose={action('image-close')}
       isLightboxOpen={false}
-      view={'drafts'}
+      view="drafts"
     />
   ))
   .add('tag', () => (
@@ -179,9 +167,7 @@ storiesOf('ImageDraft', module)
       links={links}
       draftDetails={draftDetails}
       text={text}
-      tag={'GIF'}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
+      tag="GIF"
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -191,6 +177,6 @@ storiesOf('ImageDraft', module)
       onImageClickPrev={action('image-click-prev')}
       onImageClose={action('image-close')}
       isLightboxOpen={false}
-      view={'drafts'}
+      view="drafts"
     />
   ));

--- a/packages/shared-components/ImagePost/index.jsx
+++ b/packages/shared-components/ImagePost/index.jsx
@@ -55,8 +55,6 @@ const ImagePost = ({
   isWorking,
   imageSrc,
   links,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -97,38 +95,41 @@ const ImagePost = ({
   const children = (
     <div style={postContentStyle}>
       <span style={postContentTextStyle}>
-        {basic ?
-          <Text
-            color="black"
-            size="mini"
-            whitespace="pre-wrap"
-          >
-            {text}
-          </Text>
-          :
-          <LinkifiedText
-            color="black"
-            links={links}
-            size="mini"
-            whitespace="pre-wrap"
-            newTab
-            unstyled
-          >
-            {text}
-          </LinkifiedText>
+        {basic
+          ? (
+            <Text
+              color="black"
+              size="mini"
+              whitespace="pre-wrap"
+            >
+              {text}
+            </Text>
+          )
+          : (
+            <LinkifiedText
+              color="black"
+              links={links}
+              size="mini"
+              whitespace="pre-wrap"
+              newTab
+              unstyled
+            >
+              {text}
+            </LinkifiedText>
+          )
         }
       </span>
       <div style={imageWrapperStyle} onClick={onImageClick}>
         <div style={thumbnailWrapperStyle}>
           <Image
             src={imageSrc}
-            width={'auto'}
-            height={'auto'}
-            maxWidth={'9rem'}
-            maxHeight={'9rem'}
-            minHeight={'7rem'}
-            minWidth={'7rem'}
-            objectFit={'cover'}
+            width="auto"
+            height="auto"
+            maxWidth="9rem"
+            maxHeight="9rem"
+            minHeight="7rem"
+            minWidth="7rem"
+            objectFit="cover"
           />
         </div>
         <Lightbox
@@ -153,8 +154,6 @@ const ImagePost = ({
       isWorking={isWorking}
       imageSrc={imageSrc}
       links={links}
-      onCancelConfirmClick={onCancelConfirmClick}
-      onDeleteClick={onDeleteClick}
       onDeleteConfirmClick={onDeleteConfirmClick}
       onEditClick={onEditClick}
       onShareNowClick={onShareNowClick}

--- a/packages/shared-components/ImagePost/story.jsx
+++ b/packages/shared-components/ImagePost/story.jsx
@@ -80,8 +80,6 @@ storiesOf('ImagePost', module)
       links={links}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -99,8 +97,6 @@ storiesOf('ImagePost', module)
       links={multilineLinks}
       postDetails={postDetails}
       text={multilineText}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -118,8 +114,6 @@ storiesOf('ImagePost', module)
       links={links}
       postDetails={postDetailsSent}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -137,8 +131,6 @@ storiesOf('ImagePost', module)
       links={links}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -156,8 +148,6 @@ storiesOf('ImagePost', module)
       links={links}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -175,8 +165,6 @@ storiesOf('ImagePost', module)
       links={links}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -194,8 +182,6 @@ storiesOf('ImagePost', module)
       links={links}
       postDetails={isARetweetPostDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -214,8 +200,6 @@ storiesOf('ImagePost', module)
       links={links}
       postDetails={postDetailsError}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -233,9 +217,7 @@ storiesOf('ImagePost', module)
       links={links}
       postDetails={postDetails}
       text={text}
-      tag={'GIF'}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
+      tag="GIF"
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}

--- a/packages/shared-components/LinkDraft/index.jsx
+++ b/packages/shared-components/LinkDraft/index.jsx
@@ -51,8 +51,6 @@ const LinkDraft = ({
   linkAttachment,
   manager,
   onApproveClick,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onMoveToDraftsClick,
@@ -71,22 +69,23 @@ const LinkDraft = ({
   const children = (
     <div style={postContentStyle}>
       <div style={postContentTextStyle}>
-        {basic ?
-          <Text
-            color="black"
-            size="mini"
-          >
-            {text}
-          </Text> :
-          <LinkifiedText
-            color="black"
-            links={links}
-            size="mini"
-            newTab
-            unstyled
-          >
-            {text}
-          </LinkifiedText>
+        {basic
+          ? (
+            <Text color="black" size="mini">
+              {text}
+            </Text>
+          )
+          : (
+            <LinkifiedText
+              color="black"
+              links={links}
+              size="mini"
+              newTab
+              unstyled
+            >
+              {text}
+            </LinkifiedText>
+          )
         }
       </div>
       <div>
@@ -97,12 +96,12 @@ const LinkDraft = ({
             <div style={linkAttachmentContentStyle}>
               <Image
                 src={linkAttachment.thumbnailUrl}
-                width={'15rem'}
-                minWidth={'15rem'}
-                maxWidth={'15rem'}
-                height={'10rem'}
-                border={'rounded'}
-                objectFit={'cover'}
+                width="15rem"
+                minWidth="15rem"
+                maxWidth="15rem"
+                height="10rem"
+                border="rounded"
+                objectFit="cover"
               />
               <div style={linkAttachmentTextStyle}>
                 <div>
@@ -111,12 +110,12 @@ const LinkDraft = ({
                   </Text>
                 </div>
                 <div style={linkUrlStyle}>
-                  <Text size={'small'} color={'outerSpaceLight'}>
+                  <Text size="small" color="outerSpaceLight">
                     {linkAttachment.url}
                   </Text>
                 </div>
                 <div>
-                  <Text size={'small'}>
+                  <Text size="small">
                     {linkAttachment.description}
                   </Text>
                 </div>
@@ -139,8 +138,6 @@ const LinkDraft = ({
       links={links}
       manager={manager}
       onApproveClick={onApproveClick}
-      onCancelConfirmClick={onCancelConfirmClick}
-      onDeleteClick={onDeleteClick}
       onDeleteConfirmClick={onDeleteConfirmClick}
       onEditClick={onEditClick}
       onMoveToDraftsClick={onMoveToDraftsClick}

--- a/packages/shared-components/LinkDraft/story.jsx
+++ b/packages/shared-components/LinkDraft/story.jsx
@@ -46,8 +46,6 @@ storiesOf('LinkDraft', module)
       linkAttachment={linkAttachment}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -62,8 +60,6 @@ storiesOf('LinkDraft', module)
       linkAttachment={linkAttachment}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -78,8 +74,6 @@ storiesOf('LinkDraft', module)
       linkAttachment={{ ...linkAttachment, thumbnailUrl: squareImage }}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -94,8 +88,6 @@ storiesOf('LinkDraft', module)
       linkAttachment={{ ...linkAttachment, thumbnailUrl: tallImage }}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -110,8 +102,6 @@ storiesOf('LinkDraft', module)
       linkAttachment={{ ...linkAttachment, thumbnailUrl: wideImage }}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}

--- a/packages/shared-components/LinkPost/index.jsx
+++ b/packages/shared-components/LinkPost/index.jsx
@@ -46,8 +46,6 @@ const LinkPost = ({
   isWorking,
   links,
   linkAttachment,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -82,24 +80,28 @@ const LinkPost = ({
   const children = (
     <div style={postContentStyle}>
       <div style={postContentTextStyle}>
-        {basic ?
-          <Text
-            color="black"
-            size="mini"
-            whitespace="pre-wrap"
-          >
-            {text}
-          </Text> :
-          <LinkifiedText
-            color="black"
-            links={links}
-            size="mini"
-            whitespace="pre-wrap"
-            newTab
-            unstyled
-          >
-            {text}
-          </LinkifiedText>
+        {basic
+          ? (
+            <Text
+              color="black"
+              size="mini"
+              whitespace="pre-wrap"
+            >
+              {text}
+            </Text>
+          )
+          : (
+            <LinkifiedText
+              color="black"
+              links={links}
+              size="mini"
+              whitespace="pre-wrap"
+              newTab
+              unstyled
+            >
+              {text}
+            </LinkifiedText>
+          )
         }
       </div>
       <div>
@@ -110,12 +112,12 @@ const LinkPost = ({
             <div style={linkAttachmentContentStyle}>
               <Image
                 src={linkAttachment.thumbnailUrl}
-                width={'15rem'}
-                minWidth={'15rem'}
-                maxWidth={'15rem'}
-                height={'10rem'}
-                border={'rounded'}
-                objectFit={'cover'}
+                width="15rem"
+                minWidth="15rem"
+                maxWidth="15rem"
+                height="10rem"
+                border="rounded"
+                objectFit="cover"
               />
               <div style={linkAttachmentTextStyle}>
                 <div>
@@ -124,12 +126,12 @@ const LinkPost = ({
                   </Text>
                 </div>
                 <div style={linkUrlStyle}>
-                  <Text size={'small'} color={'outerSpaceLight'}>
+                  <Text size="small" color="outerSpaceLight">
                     {linkAttachment.url}
                   </Text>
                 </div>
                 <div>
-                  <Text size={'small'}>
+                  <Text size="small">
                     {linkAttachment.description}
                   </Text>
                 </div>
@@ -148,8 +150,6 @@ const LinkPost = ({
       isWorking={isWorking}
       links={links}
       linkAttachment={linkAttachment}
-      onCancelConfirmClick={onCancelConfirmClick}
-      onDeleteClick={onDeleteClick}
       onDeleteConfirmClick={onDeleteConfirmClick}
       onEditClick={onEditClick}
       onShareNowClick={onShareNowClick}

--- a/packages/shared-components/LinkPost/story.jsx
+++ b/packages/shared-components/LinkPost/story.jsx
@@ -72,8 +72,6 @@ storiesOf('LinkPost', module)
       linkAttachment={linkAttachment}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -86,8 +84,6 @@ storiesOf('LinkPost', module)
       linkAttachment={linkAttachment}
       postDetails={postDetails}
       text={multilineText}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -100,8 +96,6 @@ storiesOf('LinkPost', module)
       linkAttachment={linkAttachment}
       postDetails={postDetailsSent}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -114,8 +108,6 @@ storiesOf('LinkPost', module)
       linkAttachment={{ ...linkAttachment, thumbnailUrl: squareImage }}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -128,8 +120,6 @@ storiesOf('LinkPost', module)
       linkAttachment={{ ...linkAttachment, thumbnailUrl: tallImage }}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -142,8 +132,6 @@ storiesOf('LinkPost', module)
       linkAttachment={{ ...linkAttachment, thumbnailUrl: wideImage }}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -156,8 +144,6 @@ storiesOf('LinkPost', module)
       linkAttachment={linkAttachment}
       postDetails={postDetailsError}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}

--- a/packages/shared-components/MultipleImagesDraft/index.jsx
+++ b/packages/shared-components/MultipleImagesDraft/index.jsx
@@ -32,8 +32,6 @@ const MultipleImagesDraft = ({
   links,
   manager,
   onApproveClick,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onMoveToDraftsClick,
@@ -59,31 +57,35 @@ const MultipleImagesDraft = ({
   const children = (
     <div style={postContentStyle}>
       <span style={postContentTextStyle}>
-        {basic ?
-          <Text
-            color="black"
-            size="mini"
-            whitespace="pre-wrap"
-          >
-            {text}
-          </Text> :
-          <LinkifiedText
-            color="black"
-            links={links}
-            size="mini"
-            newTab
-            unstyled
-          >
-            {text}
-          </LinkifiedText>
+        {basic
+          ? (
+            <Text
+              color="black"
+              size="mini"
+              whitespace="pre-wrap"
+            >
+              {text}
+            </Text>
+          )
+          : (
+            <LinkifiedText
+              color="black"
+              links={links}
+              size="mini"
+              newTab
+              unstyled
+            >
+              {text}
+            </LinkifiedText>
+          )
         }
       </span>
       <div style={imagesWrapperStyle} onClick={onImageClick}>
         <MultipleImages
-          border={'rounded'}
-          height={'9rem'}
+          border="rounded"
+          height="9rem"
           urls={imageUrls}
-          width={'9rem'}
+          width="9rem"
         />
         <Lightbox
           images={images}
@@ -110,8 +112,6 @@ const MultipleImagesDraft = ({
       links={links}
       manager={manager}
       onApproveClick={onApproveClick}
-      onCancelConfirmClick={onCancelConfirmClick}
-      onDeleteClick={onDeleteClick}
       onDeleteConfirmClick={onDeleteConfirmClick}
       onEditClick={onEditClick}
       onMoveToDraftsClick={onMoveToDraftsClick}

--- a/packages/shared-components/MultipleImagesDraft/story.jsx
+++ b/packages/shared-components/MultipleImagesDraft/story.jsx
@@ -40,8 +40,6 @@ storiesOf('MultipleImagesDraft', module)
       draftDetails={draftDetails}
       links={links}
       imageUrls={imageUrls}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -52,7 +50,7 @@ storiesOf('MultipleImagesDraft', module)
       onImageClickPrev={action('image-click-prev')}
       onImageClose={action('image-close')}
       currentImage={0}
-      view={'drafts'}
+      view="drafts"
     />
   ))
   .add('sent multiple image post', () => (
@@ -62,8 +60,6 @@ storiesOf('MultipleImagesDraft', module)
       draftDetails={draftDetails}
       links={links}
       imageUrls={imageUrls}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -74,6 +70,6 @@ storiesOf('MultipleImagesDraft', module)
       onImageClickPrev={action('image-click-prev')}
       onImageClose={action('image-close')}
       currentImage={0}
-      view={'approval'}
+      view="approval"
     />
   ));

--- a/packages/shared-components/MultipleImagesPost/index.jsx
+++ b/packages/shared-components/MultipleImagesPost/index.jsx
@@ -28,8 +28,6 @@ const MultipleImagesPost = ({
   isDeleting,
   isWorking,
   links,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -70,32 +68,36 @@ const MultipleImagesPost = ({
   const children = (
     <div style={postContentStyle}>
       <span style={postContentTextStyle}>
-        {basic ?
-          <Text
-            color="black"
-            size="mini"
-            whitespace="pre-wrap"
-          >
-            {text}
-          </Text> :
-          <LinkifiedText
-            color="black"
-            links={links}
-            size="mini"
-            whitespace="pre-wrap"
-            newTab
-            unstyled
-          >
-            {text}
-          </LinkifiedText>
+        {basic
+          ? (
+            <Text
+              color="black"
+              size="mini"
+              whitespace="pre-wrap"
+            >
+              {text}
+            </Text>
+          )
+          : (
+            <LinkifiedText
+              color="black"
+              links={links}
+              size="mini"
+              whitespace="pre-wrap"
+              newTab
+              unstyled
+            >
+              {text}
+            </LinkifiedText>
+          )
         }
       </span>
       <div style={imagesWrapperStyle} onClick={onImageClick}>
         <MultipleImages
-          border={'rounded'}
-          height={'9rem'}
+          border="rounded"
+          height="9rem"
           urls={imageUrls}
-          width={'9rem'}
+          width="9rem"
         />
         <Lightbox
           images={images}
@@ -118,8 +120,6 @@ const MultipleImagesPost = ({
       isDeleting={isDeleting}
       isWorking={isWorking}
       links={links}
-      onCancelConfirmClick={onCancelConfirmClick}
-      onDeleteClick={onDeleteClick}
       onDeleteConfirmClick={onDeleteConfirmClick}
       onEditClick={onEditClick}
       onShareNowClick={onShareNowClick}

--- a/packages/shared-components/MultipleImagesPost/story.jsx
+++ b/packages/shared-components/MultipleImagesPost/story.jsx
@@ -67,8 +67,6 @@ storiesOf('MultipleImagesPost', module)
       postDetails={postDetails}
       links={links}
       imageUrls={imageUrls}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -86,8 +84,6 @@ storiesOf('MultipleImagesPost', module)
       postDetails={postDetails}
       links={multilineLinks}
       imageUrls={imageUrls}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -105,8 +101,6 @@ storiesOf('MultipleImagesPost', module)
       postDetails={postDetailsSent}
       links={links}
       imageUrls={imageUrls}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -124,8 +118,6 @@ storiesOf('MultipleImagesPost', module)
       postDetails={postDetailsError}
       links={links}
       imageUrls={imageUrls}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}

--- a/packages/shared-components/Post/index.jsx
+++ b/packages/shared-components/Post/index.jsx
@@ -61,25 +61,29 @@ const commentStyle = {
 const renderRetweetComment = ({
   retweetComment,
   retweetCommentLinks,
-  basic
+  basic,
 }) => (
   <div style={commentStyle}>
-    {basic ?
-      <Text
-        color="black"
-        size="mini"
-      >
-        {retweetComment}
-      </Text> :
-      <LinkifiedText
-        color="black"
-        links={retweetCommentLinks}
-        newTab
-        size="mini"
-        unstyled
-      >
-        {retweetComment}
-      </LinkifiedText>
+    {basic
+      ? (
+        <Text
+          color="black"
+          size="mini"
+        >
+          {retweetComment}
+        </Text>
+      )
+      : (
+        <LinkifiedText
+          color="black"
+          links={retweetCommentLinks}
+          newTab
+          size="mini"
+          unstyled
+        >
+          {retweetComment}
+        </LinkifiedText>
+      )
     }
   </div>
 );
@@ -98,7 +102,7 @@ const renderContent = ({
       <div style={getPostContentStyle({ draggable, dragging })}>
         { retweetComment ? renderRetweetComment({ retweetComment, retweetCommentLinks, basic }) : '' }
         <Card
-          color={'off-white'}
+          color="off-white"
           reducedPadding
         >
           <div style={retweetProfileWrapperStyle}>
@@ -154,8 +158,6 @@ const Post = ({
   isConfirmingDelete,
   isDeleting,
   isWorking,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -189,8 +191,8 @@ const Post = ({
   hasFirstCommentFlip,
   features,
   basic,
-}) =>
-  (<div style={getPostContainerStyle({ dragging, hovering, isOver })}>
+}) => (
+  <div style={getPostContainerStyle({ dragging, hovering, isOver })}>
     <div style={postStyle}>
       <BDSCard
         faded={isDeleting}
@@ -199,12 +201,14 @@ const Post = ({
         dragging={dragging}
         isOver={isOver}
       >
-        {postDetails && postDetails.error && postDetails.error.length > 0 &&
-          <PostErrorBanner
-            dragging={dragging}
-            error={postDetails.error}
-            errorLink={postDetails.errorLink}
-          />
+        {postDetails && postDetails.error && postDetails.error.length > 0
+          && (
+            <PostErrorBanner
+              dragging={dragging}
+              error={postDetails.error}
+              errorLink={postDetails.errorLink}
+            />
+          )
         }
         {renderContent({
           children,
@@ -230,8 +234,6 @@ const Post = ({
           isDeleting={isDeleting}
           isConfirmingDelete={isConfirmingDelete}
           isWorking={isWorking}
-          onCancelConfirmClick={onCancelConfirmClick}
-          onDeleteClick={onDeleteClick}
           onDeleteConfirmClick={onDeleteConfirmClick}
           onEditClick={onEditClick}
           onShareNowClick={onShareNowClick}
@@ -249,27 +251,27 @@ const Post = ({
           hasCommentEnabled={hasCommentEnabled}
           hasFirstCommentFlip={hasFirstCommentFlip}
         />
-        { (isBusinessAccount || !features.isFreeUser()) &&
-          isSent &&
-          !postDetails.isRetweet &&
-          <PostStats
-            showTwitterMentions={!features.isFreeUser() && !features.isProUser()}
-            statistics={statistics}
-            profileService={profileService}
-          />
+        { (isBusinessAccount || !features.isFreeUser())
+          && isSent && !postDetails.isRetweet
+          && (
+            <PostStats
+              showTwitterMentions={!features.isFreeUser() && !features.isProUser()}
+              statistics={statistics}
+              profileService={profileService}
+            />
+          )
         }
       </BDSCard>
     </div>
-  </div>);
+  </div>
+);
 
 Post.commonPropTypes = {
   isConfirmingDelete: PropTypes.bool,
   isDeleting: PropTypes.bool,
   isWorking: PropTypes.bool,
   isBusinessAccount: PropTypes.bool,
-  onCancelConfirmClick: PropTypes.func,
   onRequeueClick: PropTypes.func,
-  onDeleteClick: PropTypes.func,
   onDeleteConfirmClick: PropTypes.func,
   onEditClick: PropTypes.func,
   onShareNowClick: PropTypes.func,

--- a/packages/shared-components/Post/story.jsx
+++ b/packages/shared-components/Post/story.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import {
   action,
   linkTo,
@@ -7,7 +8,6 @@ import {
 import { checkA11y } from 'storybook-addon-a11y';
 import { Text } from '@bufferapp/components';
 import Post from './index';
-import { Provider } from 'react-redux';
 
 const storeFake = state => ({
   default: () => {},
@@ -20,7 +20,7 @@ const store = storeFake({
   productFeatures: {
     planName: 'free',
     features: {},
-  }
+  },
 });
 
 const postDetails = {
@@ -80,7 +80,7 @@ const subprofiles = [
 ];
 
 const children = (
-  <Text size={'mini'} color={'black'}>
+  <Text size="mini" color="black">
     {'Rubber baby buggy bumpers.'}
   </Text>
 );
@@ -95,8 +95,6 @@ storiesOf('Post', module)
   .add('queued post', () => (
     <Post
       postDetails={postDetails}
-      onCancelConfirmClick={linkTo('Post', 'hovered')}
-      onDeleteClick={linkTo('Post', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Post', 'isDeleting')}
       onShareNowClick={linkTo('Post', 'isWorking')}
       onEditClick={action('edit-click')}
@@ -108,8 +106,6 @@ storiesOf('Post', module)
   .add('sent', () => (
     <Post
       postDetails={sentPostDetails}
-      onCancelConfirmClick={linkTo('Post', 'hovered')}
-      onDeleteClick={linkTo('Post', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Post', 'isDeleting')}
       onEditClick={action('edit-click')}
       onShareNowClick={linkTo('Post', 'isWorking')}
@@ -123,8 +119,6 @@ storiesOf('Post', module)
     <Post
       onMouseEnter={action('on-mouse-enter')}
       onMouseLeave={action('on-mouse-leave')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={linkTo('Post', 'isWorking')}
@@ -137,8 +131,6 @@ storiesOf('Post', module)
   .add('isConfirmingDelete', () => (
     <Post
       isConfirmingDelete
-      onCancelConfirmClick={linkTo('Post', 'hovered')}
-      onDeleteClick={linkTo('Post', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Post', 'isDeleting')}
       onEditClick={action('edit-click')}
       onShareNowClick={linkTo('Post', 'isWorking')}
@@ -151,8 +143,6 @@ storiesOf('Post', module)
   .add('isDeleting', () => (
     <Post
       isDeleting
-      onCancelConfirmClick={linkTo('Post', 'hovered')}
-      onDeleteClick={linkTo('Post', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Post', 'isDeleting')}
       onEditClick={action('edit-click')}
       onShareNowClick={linkTo('Post', 'isWorking')}
@@ -165,8 +155,6 @@ storiesOf('Post', module)
   .add('isWorking', () => (
     <Post
       isWorking
-      onCancelConfirmClick={linkTo('Post', 'hovered')}
-      onDeleteClick={linkTo('Post', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Post', 'isDeleting')}
       onEditClick={action('edit-click')}
       onShareNowClick={linkTo('Post', 'isWorking')}
@@ -181,8 +169,6 @@ storiesOf('Post', module)
       postDetails={isARetweetPostDetails}
       onMouseEnter={action('mouse-enter')}
       onMouseLeave={action('mous-leave')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={linkTo('Post', 'isWorking')}
@@ -198,8 +184,6 @@ storiesOf('Post', module)
       retweetCommentLinks={links}
       onMouseEnter={action('mouse-enter')}
       onMouseLeave={action('mous-leave')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={linkTo('Post', 'isWorking')}
@@ -213,8 +197,6 @@ storiesOf('Post', module)
   .add('Instragram post with Location', () => (
     <Post
       postDetails={postDetails}
-      onCancelConfirmClick={linkTo('Post', 'hovered')}
-      onDeleteClick={linkTo('Post', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Post', 'isDeleting')}
       onShareNowClick={linkTo('Post', 'isWorking')}
       onEditClick={action('edit-click')}
@@ -228,8 +210,6 @@ storiesOf('Post', module)
   .add('Instragram post without Location', () => (
     <Post
       postDetails={postDetails}
-      onCancelConfirmClick={linkTo('Post', 'hovered')}
-      onDeleteClick={linkTo('Post', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Post', 'isDeleting')}
       onShareNowClick={linkTo('Post', 'isWorking')}
       onEditClick={action('edit-click')}
@@ -242,15 +222,13 @@ storiesOf('Post', module)
   .add('Pinterest post with board and source URL', () => (
     <Post
       postDetails={postDetails}
-      onCancelConfirmClick={linkTo('Post', 'hovered')}
-      onDeleteClick={linkTo('Post', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Post', 'isDeleting')}
       onShareNowClick={linkTo('Post', 'isWorking')}
       onEditClick={action('edit-click')}
       profileService="pinterest"
       subprofiles={subprofiles}
-      subprofileID={'5bbca83e94803d000e7dca35'}
-      sourceUrl={'http://google.com'}
+      subprofileID="5bbca83e94803d000e7dca35"
+      sourceUrl="http://google.com"
       isSent={false}
     >
       {children}
@@ -259,14 +237,12 @@ storiesOf('Post', module)
   .add('Pinterest post with board only', () => (
     <Post
       postDetails={postDetails}
-      onCancelConfirmClick={linkTo('Post', 'hovered')}
-      onDeleteClick={linkTo('Post', 'isConfirmingDelete')}
       onDeleteConfirmClick={linkTo('Post', 'isDeleting')}
       onShareNowClick={linkTo('Post', 'isWorking')}
       onEditClick={action('edit-click')}
       profileService="pinterest"
       subprofiles={subprofiles}
-      subprofileID={'5bbca83e94803d000e7dca34'}
+      subprofileID="5bbca83e94803d000e7dca34"
       isSent={false}
     >
       {children}

--- a/packages/shared-components/PostFooter/index.jsx
+++ b/packages/shared-components/PostFooter/index.jsx
@@ -20,6 +20,7 @@ const renderIcon = (hasError, isSent, isCustomScheduled, isInstagramReminder, is
 
 const PostFooter = ({
   isDeleting,
+  isConfirmingDelete,
   isWorking,
   onDeleteConfirmClick,
   onRequeueClick,
@@ -41,7 +42,7 @@ const PostFooter = ({
   const { isCustomScheduled, isInstagramReminder } = postDetails;
   const comment = { commentEnabled, commentText };
   const hideButtons = !isManager || isSent || isPastReminder;
-  const deletingMessage = isDeleting && 'Deleting...';
+  const deletingMessage = (isDeleting || isConfirmingDelete) && 'Deleting...';
   const submittingMessage = isWorking && 'Sharing...';
   const actionMessage = deletingMessage || submittingMessage || '';
 
@@ -70,6 +71,7 @@ const PostFooter = ({
 
 PostFooter.propTypes = {
   isDeleting: PropTypes.bool,
+  isConfirmingDelete: PropTypes.bool,
   isWorking: PropTypes.bool,
   onDeleteConfirmClick: PropTypes.func,
   onEditClick: PropTypes.func,

--- a/packages/shared-components/PostList/index.jsx
+++ b/packages/shared-components/PostList/index.jsx
@@ -42,8 +42,6 @@ const postTypeComponentMap = new Map([
 
 const renderPost = ({
   post,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -61,8 +59,6 @@ const renderPost = ({
   const postWithEventHandlers = {
     ...post,
     key: post.id,
-    onCancelConfirmClick: () => onCancelConfirmClick({ post }),
-    onDeleteClick: () => onDeleteClick({ post }),
     onDeleteConfirmClick: () => onDeleteConfirmClick({ post }),
     onEditClick: () => onEditClick({ post }),
     onShareNowClick: () => onShareNowClick({ post }),
@@ -88,8 +84,6 @@ const renderPost = ({
 const PostList = ({
   listHeader,
   posts,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -107,33 +101,31 @@ const PostList = ({
   isBusinessAccount,
   features,
   hasFirstCommentFlip,
-}) =>
+}) => (
   <div>
     <div style={listHeaderStyle}>
       <Text
-        color={'black'}
+        color="black"
       >
         {listHeader}
       </Text>
     </div>
     <List
-      items={posts.map(post =>
+      items={posts.map(post => (
         <div
           id={`update-${post.id}`}
           className={[
             'update',
             `post_${post.profile_service}`,
-            post.postDetails && post.postDetails.isRetweet ?
-              'is_retweet' :
-              'not_retweet',
+            post.postDetails && post.postDetails.isRetweet
+              ? 'is_retweet'
+              : 'not_retweet',
           ].join(' ')}
           style={postStyle}
         >
           {
             renderPost({
               post,
-              onCancelConfirmClick,
-              onDeleteClick,
               onDeleteConfirmClick,
               onEditClick,
               onShareNowClick,
@@ -150,43 +142,52 @@ const PostList = ({
               hasFirstCommentFlip,
             })
           }
-          {(!features.isFreeUser() || isBusinessAccount) && !isPastReminder &&
-            <div style={reBufferWrapperStyle}>
-              <Button
-                type="secondary"
-                label="Share Again"
-                onClick={() => { onShareAgainClick({ post }); }}
-              />
-            </div>
+          {(!features.isFreeUser() || isBusinessAccount) && !isPastReminder
+            && (
+              <div style={reBufferWrapperStyle}>
+                <Button
+                  type="secondary"
+                  label="Share Again"
+                  onClick={() => { onShareAgainClick({ post }); }}
+                />
+              </div>
+            )
           }
-          {isPastReminder &&
-            <div>
-              {(!features.isFreeUser() || isBusinessAccount) &&
-                <div style={reBufferWrapperStyle}>
-                  <Button
-                    fullWidth
-                    type="secondary"
-                    label="Share Again"
-                    onClick={() => { onShareAgainClick({ post }); }}
-                  />
-                </div>
+          {isPastReminder
+            && (
+              <div>
+                {(!features.isFreeUser() || isBusinessAccount)
+                  && (
+                    <div style={reBufferWrapperStyle}>
+                      <Button
+                        fullWidth
+                        type="secondary"
+                        label="Share Again"
+                        onClick={() => { onShareAgainClick({ post }); }}
+                      />
+                    </div>
+                  )
+                }
+                {isManager
+                && (
+                  <div style={reBufferWrapperStyle}>
+                    <Button
+                      fullWidth
+                      type="secondary"
+                      label="Send to Mobile"
+                      onClick={() => { onMobileClick({ post }); }}
+                    />
+                  </div>
+                )
               }
-              {isManager &&
-                <div style={reBufferWrapperStyle}>
-                  <Button
-                    fullWidth
-                    type="secondary"
-                    label="Send to Mobile"
-                    onClick={() => { onMobileClick({ post }); }}
-                  />
-                </div>
-              }
-            </div>
+              </div>
+            )
           }
-        </div>,
-      )}
+        </div>
+      ))}
     />
-  </div>;
+  </div>
+);
 
 PostList.propTypes = {
   listHeader: PropTypes.string,
@@ -195,8 +196,6 @@ PostList.propTypes = {
       text: PropTypes.string,
     }),
   ),
-  onCancelConfirmClick: PropTypes.func,
-  onDeleteClick: PropTypes.func,
   onDeleteConfirmClick: PropTypes.func,
   onEditClick: PropTypes.func,
   onShareNowClick: PropTypes.func,

--- a/packages/shared-components/PostList/story.jsx
+++ b/packages/shared-components/PostList/story.jsx
@@ -43,8 +43,6 @@ storiesOf('PostList', module)
     <PostList
       listHeader={listHeader}
       posts={posts}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -58,8 +56,6 @@ storiesOf('PostList', module)
     <PostList
       listHeader={listHeader}
       posts={sentPosts}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -74,8 +70,6 @@ storiesOf('PostList', module)
     <PostList
       listHeader={listHeader}
       posts={sentPosts}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -92,8 +86,6 @@ storiesOf('PostList', module)
     <PostList
       listHeader={listHeader}
       posts={pastRemindersPosts}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -111,8 +103,6 @@ storiesOf('PostList', module)
     <PostList
       listHeader={listHeader}
       posts={pastRemindersPosts}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -131,8 +121,6 @@ storiesOf('PostList', module)
     <PostList
       listHeader={listHeader}
       posts={pastRemindersPosts}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -151,8 +139,6 @@ storiesOf('PostList', module)
     <PostList
       listHeader={listHeader}
       posts={missingTypePosts}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -166,8 +152,6 @@ storiesOf('PostList', module)
     <PostList
       listHeader={listHeader}
       posts={linkPosts}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -181,8 +165,6 @@ storiesOf('PostList', module)
     <PostList
       listHeader={listHeader}
       posts={imagePosts}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -196,8 +178,6 @@ storiesOf('PostList', module)
     <PostList
       listHeader={listHeader}
       posts={multipleImagePosts}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -211,8 +191,6 @@ storiesOf('PostList', module)
     <PostList
       listHeader={listHeader}
       posts={videoPosts}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}

--- a/packages/shared-components/PostList/test.jsx
+++ b/packages/shared-components/PostList/test.jsx
@@ -28,8 +28,6 @@ describe('PostList', () => {
       <Provider store={store}>
         <PostList
           posts={posts}
-          onDeleteCancel={() => {}}
-          onDeleteClick={() => {}}
           onDeleteConfirmClick={() => {}}
           onEditClick={handleEditClick}
           onShareNowClick={() => {}}
@@ -53,8 +51,6 @@ describe('PostList', () => {
       <Provider store={store}>
         <PostList
           posts={posts}
-          onDeleteCancel={() => {}}
-          onDeleteClick={() => {}}
           onDeleteConfirmClick={() => {}}
           onEditClick={() => {}}
           onShareNowClick={handleShareNowClick}

--- a/packages/shared-components/PostLists/index.jsx
+++ b/packages/shared-components/PostLists/index.jsx
@@ -16,8 +16,6 @@ const postListStyle = {
 const renderPostList = ({
   index,
   postList,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -35,14 +33,12 @@ const renderPostList = ({
   isPastReminder,
   isBusinessAccount,
   hasFirstCommentFlip,
-}) =>
+}) => (
   <div style={postListStyle}>
     <PostList
       key={`postList-${index}`}
       listHeader={postList.listHeader}
       posts={postList.posts}
-      onCancelConfirmClick={onCancelConfirmClick}
-      onDeleteClick={onDeleteClick}
       onDeleteConfirmClick={onDeleteConfirmClick}
       onEditClick={onEditClick}
       onShareNowClick={onShareNowClick}
@@ -61,14 +57,13 @@ const renderPostList = ({
       isBusinessAccount={isBusinessAccount}
       hasFirstCommentFlip={hasFirstCommentFlip}
     />
-  </div>;
+  </div>
+);
 
 /* eslint-enable react/prop-types */
 
 const PostLists = ({
   postLists,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -86,14 +81,12 @@ const PostLists = ({
   isPastReminder,
   isBusinessAccount,
   hasFirstCommentFlip,
-}) =>
+}) => (
   <List
     items={postLists.map((postList, index) =>
       renderPostList({
         index,
         postList,
-        onCancelConfirmClick,
-        onDeleteClick,
         onDeleteConfirmClick,
         onEditClick,
         onShareNowClick,
@@ -114,7 +107,8 @@ const PostLists = ({
       }),
     )}
     fillContainer
-  />;
+  />
+);
 
 PostLists.propTypes = {
   postLists: PropTypes.arrayOf(
@@ -127,8 +121,6 @@ PostLists.propTypes = {
       ),
     }),
   ).isRequired,
-  onCancelConfirmClick: PropTypes.func,
-  onDeleteClick: PropTypes.func,
   onDeleteConfirmClick: PropTypes.func,
   onEditClick: PropTypes.func,
   onShareNowClick: PropTypes.func,
@@ -149,7 +141,6 @@ PostLists.propTypes = {
 };
 
 PostLists.defaultProps = {
-  postLists: [],
 };
 
 export default PostLists;

--- a/packages/shared-components/PostLists/story.jsx
+++ b/packages/shared-components/PostLists/story.jsx
@@ -32,8 +32,6 @@ storiesOf('PostLists', module)
   .add('default', () => (
     <PostLists
       postLists={postLists}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}

--- a/packages/shared-components/QueueItems/index.jsx
+++ b/packages/shared-components/QueueItems/index.jsx
@@ -1,8 +1,5 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Text,
-} from '@bufferapp/components';
 import { calculateStyles } from '@bufferapp/components/lib/utils';
 import {
   transitionAnimationTime,
@@ -80,9 +77,7 @@ const renderPost = ({
   post,
   index,
   isStory,
-  onCancelConfirmClick,
   onRequeueClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -103,8 +98,6 @@ const renderPost = ({
     key: post.id,
     index,
     postDetails: post.postDetails,
-    onCancelConfirmClick: () => onCancelConfirmClick({ post }),
-    onDeleteClick: () => onDeleteClick({ post }),
     onDeleteConfirmClick: () => onDeleteConfirmClick({ post }),
     onEditClick: () => onEditClick({ post }),
     onShareNowClick: () => onShareNowClick({ post }),
@@ -168,8 +161,6 @@ const renderPost = ({
 const renderDraft = ({
   draft,
   onApproveClick,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onMoveToDraftsClick,
@@ -185,8 +176,6 @@ const renderDraft = ({
     ...draft,
     key: draft.id,
     draftDetails: draft.draftDetails,
-    onCancelConfirmClick: () => onCancelConfirmClick({ draft }),
-    onDeleteClick: () => onDeleteClick({ draft }),
     onDeleteConfirmClick: () => onDeleteConfirmClick({ draft }),
     onEditClick: () => onEditClick({ draft }),
     onApproveClick: () => onApproveClick({ draft }),
@@ -301,8 +290,6 @@ QueueItems.propTypes = {
       type: PropTypes.string,
     }),
   ),
-  onCancelConfirmClick: PropTypes.func,
-  onDeleteClick: PropTypes.func,
   onDeleteConfirmClick: PropTypes.func,
   onEditClick: PropTypes.func,
   onShareNowClick: PropTypes.func,

--- a/packages/shared-components/QueueItems/story.jsx
+++ b/packages/shared-components/QueueItems/story.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import {
   storiesOf,
   action,
@@ -9,7 +10,6 @@ import {
   postLists,
   postListsNoHeaders,
 } from './postData';
-import { Provider } from 'react-redux';
 
 const storeFake = state => ({
   default: () => {},
@@ -22,7 +22,7 @@ const store = storeFake({
   productFeatures: {
     planName: 'free',
     features: {},
-  }
+  },
 });
 
 storiesOf('QueueItems', module)
@@ -35,9 +35,7 @@ storiesOf('QueueItems', module)
   .add('default queue', () => (
     <QueueItems
       items={postLists}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
       onRequeueClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -53,9 +51,7 @@ storiesOf('QueueItems', module)
   .add('no headers type drafts', () => (
     <QueueItems
       items={postListsNoHeaders}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
       onRequeueClick={action('onCancelConfirmClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onEditClick={action('onEditClick')}
       onShareNowClick={action('onShareNowClick')}
@@ -66,6 +62,6 @@ storiesOf('QueueItems', module)
       onDropPost={action('onDropPost')}
       onSwapPosts={action('onSwapPosts')}
       draggable={false}
-      type={'drafts'}
+      type="drafts"
     />
   ));

--- a/packages/shared-components/TextDraft/index.jsx
+++ b/packages/shared-components/TextDraft/index.jsx
@@ -26,8 +26,6 @@ const TextDraft = ({
   links,
   manager,
   onApproveClick,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onMoveToDraftsClick,
@@ -46,20 +44,22 @@ const TextDraft = ({
   const children = (
     <div style={postContentStyle}>
       <span style={postContentTextStyle}>
-        {basic ?
-          <Text
-            size="mini"
-          >
-            {text}
-          </Text> :
-          <LinkifiedText
-            links={links}
-            size="mini"
-            newTab
-            unstyled
-          >
-            {text}
-          </LinkifiedText>
+        {basic
+          ? (
+            <Text size="mini">
+              {text}
+            </Text>
+          )
+          : (
+            <LinkifiedText
+              links={links}
+              size="mini"
+              newTab
+              unstyled
+            >
+              {text}
+            </LinkifiedText>
+          )
         }
       </span>
     </div>
@@ -77,8 +77,6 @@ const TextDraft = ({
       links={links}
       manager={manager}
       onApproveClick={onApproveClick}
-      onCancelConfirmClick={onCancelConfirmClick}
-      onDeleteClick={onDeleteClick}
       onDeleteConfirmClick={onDeleteConfirmClick}
       onEditClick={onEditClick}
       onMoveToDraftsClick={onMoveToDraftsClick}

--- a/packages/shared-components/TextDraft/story.jsx
+++ b/packages/shared-components/TextDraft/story.jsx
@@ -145,6 +145,7 @@ storiesOf('TextDraft', module)
   .add('past due no permission', () => (
     <TextDraft
       hasPermission={false}
+      manager={false}
       links={links}
       draftDetails={draftDetailsPastDue}
       isPastDue
@@ -160,6 +161,7 @@ storiesOf('TextDraft', module)
   .add('no permission', () => (
     <TextDraft
       hasPermission={false}
+      manager={false}
       links={links}
       draftDetails={draftDetails}
       text={text}

--- a/packages/shared-components/TextDraft/story.jsx
+++ b/packages/shared-components/TextDraft/story.jsx
@@ -68,8 +68,6 @@ storiesOf('TextDraft', module)
       draftDetails={draftDetails}
       text={text}
       onApproveClick={action('approve-click')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       view={approvalView}
@@ -82,8 +80,6 @@ storiesOf('TextDraft', module)
       draftDetails={draftDetailsScheduled}
       text={text}
       onApproveClick={action('approve-click')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       scheduledAt={scheduledAt}
@@ -98,8 +94,6 @@ storiesOf('TextDraft', module)
       text={text}
       manager
       onApproveClick={action('approve-click')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       view={approvalView}
@@ -112,8 +106,6 @@ storiesOf('TextDraft', module)
       draftDetails={isARetweetDraftDetails}
       text={text}
       onApproveClick={action('approve-click')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       retweetProfile={retweetProfile}
@@ -127,8 +119,6 @@ storiesOf('TextDraft', module)
       draftDetails={isARetweetDraftDetails}
       text={text}
       onApproveClick={action('approve-click')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       retweetProfile={retweetProfile}
@@ -145,8 +135,6 @@ storiesOf('TextDraft', module)
       isPastDue
       text={text}
       onApproveClick={action('approve-click')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onRescheduleClick={action('reschedule-click')}
@@ -162,8 +150,6 @@ storiesOf('TextDraft', module)
       isPastDue
       text={text}
       onApproveClick={action('approve-click')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onRescheduleClick={action('reschedule-click')}
@@ -178,8 +164,6 @@ storiesOf('TextDraft', module)
       draftDetails={draftDetails}
       text={text}
       onApproveClick={action('approve-click')}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       view={approvalView}

--- a/packages/shared-components/TextPost/index.jsx
+++ b/packages/shared-components/TextPost/index.jsx
@@ -21,8 +21,6 @@ const TextPost = ({
   isWorking,
   imageSrc,
   links,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -60,25 +58,29 @@ const TextPost = ({
   const children = (
     <div style={postContentStyle}>
       <span style={postContentTextStyle}>
-        {basic ?
-          <Text
-            size="mini"
-            whitespace="pre-wrap"
-            color="black"
-          >
-            {text}
-          </Text> :
-          <LinkifiedText
-            color="black"
-            links={links}
-            size="mini"
-            whitespace="pre-wrap"
-            newTab
-            unstyled
-            basic={basic}
-          >
-            {text}
-          </LinkifiedText>
+        {basic
+          ? (
+            <Text
+              size="mini"
+              whitespace="pre-wrap"
+              color="black"
+            >
+              {text}
+            </Text>
+          )
+          : (
+            <LinkifiedText
+              color="black"
+              links={links}
+              size="mini"
+              whitespace="pre-wrap"
+              newTab
+              unstyled
+              basic={basic}
+            >
+              {text}
+            </LinkifiedText>
+          )
         }
       </span>
     </div>
@@ -91,8 +93,6 @@ const TextPost = ({
       isWorking={isWorking}
       imageSrc={imageSrc}
       links={links}
-      onCancelConfirmClick={onCancelConfirmClick}
-      onDeleteClick={onDeleteClick}
       onDeleteConfirmClick={onDeleteConfirmClick}
       onEditClick={onEditClick}
       onShareNowClick={onShareNowClick}

--- a/packages/shared-components/TextPost/story.jsx
+++ b/packages/shared-components/TextPost/story.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import {
   storiesOf,
   action,
 } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import TextPost from './index';
-import { Provider } from 'react-redux';
 
 const storeFake = state => ({
   default: () => {},
@@ -18,7 +18,7 @@ const store = storeFake({
   productFeatures: {
     planName: 'free',
     features: {},
-  }
+  },
 });
 
 const links = [{
@@ -82,8 +82,6 @@ storiesOf('TextPost', module)
       links={links}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -95,8 +93,6 @@ storiesOf('TextPost', module)
       links={multilineLinks}
       postDetails={postDetails}
       text={multilineText}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -108,8 +104,6 @@ storiesOf('TextPost', module)
       links={links}
       postDetails={postDetailsSent}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -121,8 +115,6 @@ storiesOf('TextPost', module)
       links={links}
       postDetails={isARetweetPostDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -135,8 +127,6 @@ storiesOf('TextPost', module)
       links={links}
       postDetails={isARetweetPostDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -151,8 +141,6 @@ storiesOf('TextPost', module)
       links={links}
       postDetails={postDetailsError}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}

--- a/packages/shared-components/VideoDraft/index.jsx
+++ b/packages/shared-components/VideoDraft/index.jsx
@@ -12,8 +12,6 @@ const VideoDraft = ({
   links,
   manager,
   onApproveClick,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onMoveToDraftsClick,
@@ -34,7 +32,7 @@ const VideoDraft = ({
   view,
   basic,
   hasFirstCommentFlip,
-}) =>
+}) => (
   <ImageDraft
     hasPermission={hasPermission}
     isConfirmingDelete={isConfirmingDelete}
@@ -46,8 +44,6 @@ const VideoDraft = ({
     links={links}
     manager={manager}
     onApproveClick={onApproveClick}
-    onCancelConfirmClick={onCancelConfirmClick}
-    onDeleteClick={onDeleteClick}
     onDeleteConfirmClick={onDeleteConfirmClick}
     onEditClick={onEditClick}
     onMoveToDraftsClick={onMoveToDraftsClick}
@@ -68,7 +64,8 @@ const VideoDraft = ({
     view={view}
     basic={basic}
     hasFirstCommentFlip={hasFirstCommentFlip}
-  />;
+  />
+);
 
 VideoDraft.propTypes = ImageDraft.propTypes;
 

--- a/packages/shared-components/VideoDraft/story.jsx
+++ b/packages/shared-components/VideoDraft/story.jsx
@@ -50,8 +50,6 @@ storiesOf('VideoDraft', module)
       links={links}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -71,8 +69,6 @@ storiesOf('VideoDraft', module)
       links={links}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -92,8 +88,6 @@ storiesOf('VideoDraft', module)
       links={links}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -113,8 +107,6 @@ storiesOf('VideoDraft', module)
       links={links}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -134,8 +126,6 @@ storiesOf('VideoDraft', module)
       links={links}
       draftDetails={draftDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -155,8 +145,6 @@ storiesOf('VideoDraft', module)
       links={links}
       draftDetails={isARetweetPostDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}

--- a/packages/shared-components/VideoPost/index.jsx
+++ b/packages/shared-components/VideoPost/index.jsx
@@ -7,8 +7,6 @@ const VideoPost = ({
   isWorking,
   imageSrc,
   links,
-  onCancelConfirmClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onEditClick,
   onShareNowClick,
@@ -45,7 +43,7 @@ const VideoPost = ({
   commentText,
   hasCommentEnabled,
   hasFirstCommentFlip,
-}) =>
+}) => (
   <ImagePost
     isConfirmingDelete={isConfirmingDelete}
     isDeleting={isDeleting}
@@ -55,8 +53,6 @@ const VideoPost = ({
     postDetails={postDetails}
     tag={tag}
     text={text}
-    onCancelConfirmClick={onCancelConfirmClick}
-    onDeleteClick={onDeleteClick}
     onDeleteConfirmClick={onDeleteConfirmClick}
     onEditClick={onEditClick}
     onShareNowClick={onShareNowClick}
@@ -90,7 +86,8 @@ const VideoPost = ({
     commentText={commentText}
     hasCommentEnabled={hasCommentEnabled}
     hasFirstCommentFlip={hasFirstCommentFlip}
-  />;
+  />
+);
 
 VideoPost.propTypes = ImagePost.propTypes;
 

--- a/packages/shared-components/VideoPost/story.jsx
+++ b/packages/shared-components/VideoPost/story.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import {
   storiesOf,
   action,
 } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import VideoPost from './index';
-import { Provider } from 'react-redux';
 
 const storeFake = state => ({
   default: () => {},
@@ -18,7 +18,7 @@ const store = storeFake({
   productFeatures: {
     planName: 'free',
     features: {},
-  }
+  },
 });
 
 const links = [{
@@ -37,11 +37,6 @@ const multilineText = 'What is a Product Designer? \n\nAn awesome story by @jgad
 const postDetails = {
   isRetweet: false,
   postAction: 'This post will be sent at 9:21 (GMT)',
-};
-
-const postDetailsSent = {
-  isRetweet: false,
-  postAction: 'This post was sent at 9:21 (GMT)',
 };
 
 const isARetweetPostDetails = {
@@ -78,8 +73,6 @@ storiesOf('VideoPost', module)
       links={links}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -97,8 +90,6 @@ storiesOf('VideoPost', module)
       links={multilineLinks}
       postDetails={postDetails}
       text={multilineText}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -116,8 +107,6 @@ storiesOf('VideoPost', module)
       links={links}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -135,8 +124,6 @@ storiesOf('VideoPost', module)
       links={links}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -154,8 +141,6 @@ storiesOf('VideoPost', module)
       links={links}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -173,8 +158,6 @@ storiesOf('VideoPost', module)
       links={links}
       postDetails={postDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -192,8 +175,6 @@ storiesOf('VideoPost', module)
       links={links}
       postDetails={isARetweetPostDetails}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}
@@ -212,8 +193,6 @@ storiesOf('VideoPost', module)
       links={links}
       postDetails={postDetailsError}
       text={text}
-      onCancelConfirmClick={action('cancel-confirm-click')}
-      onDeleteClick={action('delete-click')}
       onDeleteConfirmClick={action('delete-confirm-click')}
       onEditClick={action('edit-click')}
       onShareNowClick={action('share-now-click')}

--- a/packages/stories/components/StoryGroups/index.jsx
+++ b/packages/stories/components/StoryGroups/index.jsx
@@ -54,14 +54,12 @@ const StoryGroups = ({
   showStoriesComposer,
   onEmptySlotClick,
   onEditClick,
-  onDeleteClick,
   onDeleteConfirmClick,
   onComposerPlaceholderClick,
   hasFirstCommentFlip,
   isBusinessAccount,
   onShareNowClick,
   onCalendarClick,
-  onCancelConfirmClick,
   onPreviewClick,
   onClosePreviewClick,
   showStoryPreview,
@@ -113,9 +111,7 @@ const StoryGroups = ({
         </ReminderTextWrapper>
         <QueueItems
           items={storyGroups}
-          onCancelConfirmClick={onCancelConfirmClick}
           onCalendarClick={onCalendarClick}
-          onDeleteClick={onDeleteClick}
           onDeleteConfirmClick={onDeleteConfirmClick}
           onEditClick={onEditClick}
           onEmptySlotClick={onEmptySlotClick}
@@ -145,11 +141,9 @@ StoryGroups.propTypes = {
   isBusinessAccount: PropTypes.bool,
   onEmptySlotClick: PropTypes.func.isRequired,
   onEditClick: PropTypes.func,
-  onDeleteClick: PropTypes.func,
   onDeleteConfirmClick: PropTypes.func,
   onShareNowClick: PropTypes.func,
   onCalendarClick: PropTypes.func,
-  onCancelConfirmClick: PropTypes.func,
   onComposerPlaceholderClick: PropTypes.func,
   onPreviewClick: PropTypes.func,
   onClosePreviewClick: PropTypes.func,
@@ -170,11 +164,9 @@ StoryGroups.defaultProps = {
   storyGroups: [],
   showStoryPreview: false,
   onEditClick: () => {},
-  onDeleteClick: () => {},
   onDeleteConfirmClick: () => {},
   onShareNowClick: () => {},
   onCalendarClick: () => {},
-  onCancelConfirmClick: () => {},
   onComposerPlaceholderClick: () => {},
   onPreviewClick: () => {},
   onClosePreviewClick: () => {},

--- a/packages/stories/components/StoryGroups/story.jsx
+++ b/packages/stories/components/StoryGroups/story.jsx
@@ -59,11 +59,9 @@ storiesOf('StoryGroups', module)
       showStoriesComposer={action('showStoriesComposer')}
       onEmptySlotClick={action('onEmptySlotClick')}
       onEditClick={action('onEditClick')}
-      onDeleteClick={action('onDeleteClick')}
       onDeleteConfirmClick={action('onDeleteConfirmClick')}
       onComposerPlaceholderClick={action('onComposerPlaceholderClick')}
       onShareNowClick={action('onShareNowClick')}
-      onCancelConfirmClick={action('onCancelConfirmClick')}
       onCalendarClick={action('onCalendarClick')}
     />
   ));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

- Remove unused delete props (onCancelConfirmClick and onDeleteClick) from several Post and Drafts components
- Eslint tweaks in those files.
- Add missing padding to Drafts Retweets

<!--- Describe your changes in detail. -->

## Context & Notes
Related to [Use Card components in Drafts](https://github.com/bufferapp/buffer-publish/pull/920) and [Normalize Posts, Drafts & Stories footer](https://github.com/bufferapp/buffer-publish/pull/913)

**In a Future PR:**

- Refactor Posts/Drafts: There's a lot of prop drilling, as we can see by the amount of files where we had to delete these simple props. Also, each type of Post and Draft (Video, Text, Image, ...) is quite similar, so there's probably a way of optimizing the code.

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
