### PR TITLE
Displaying play icon when media type is a video

### DIFF
--- a/packages/shared-components/Story/index.jsx
+++ b/packages/shared-components/Story/index.jsx
@@ -38,7 +38,7 @@ const Story = ({
             largeCards={largeCards}
           >
             {card.thumbnail_url && <CoverImage src={card.thumbnail_url} />}
-            {card.type === 'video' && <PlayIcon />}
+            {card.type === 'video' && <PlayIcon large={false} />}
           </CarouselCard>
         ))}
       </Carousel>

--- a/packages/story-group-composer/components/Carousel/CardItem/index.jsx
+++ b/packages/story-group-composer/components/Carousel/CardItem/index.jsx
@@ -12,7 +12,12 @@ import PropTypes from 'prop-types';
 import CarouselCardHover from '../CarouselCardHover';
 import styles from './styles.css';
 
-import { CoverImage, UploadingVideo, StoryWrapper } from './styles';
+import {
+  CoverImage,
+  UploadingVideo,
+  StoryWrapper,
+  PlayIcon,
+} from './styles';
 
 const CardItem = ({
   card,
@@ -101,6 +106,7 @@ const CardItem = ({
       {card.thumbnail_url && (
         <StoryWrapper>
           <CoverImage src={card.thumbnail_url} />
+          {card.type === 'video' && <PlayIcon large={largeCards} />}
           {isHovering && (
             <CarouselCardHover
               card={card}

--- a/packages/story-group-composer/components/Carousel/CardItem/styles.jsx
+++ b/packages/story-group-composer/components/Carousel/CardItem/styles.jsx
@@ -2,17 +2,31 @@ import styled from 'styled-components';
 import { CirclePlayIcon } from '@bufferapp/components';
 import { grayLighter } from '@bufferapp/ui/style/colors';
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const IconWrapper = styled(CirclePlayIcon)`
+const IconWrapper = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
   display: flex;
   opacity: 0.8;
+  align-items: center;
+  justify-content: center;
 `;
 
-export const PlayIcon = () => (
+export const PlayIcon = ({ large }) => (
   <IconWrapper>
-    <CirclePlayIcon color={grayLighter} size={{ width: '40px' }} />
+    <CirclePlayIcon color={grayLighter} size={{ width: large ? '60px' : '40px' }} />
   </IconWrapper>
 );
+
+PlayIcon.propTypes = {
+  large: PropTypes.bool,
+};
+
+PlayIcon.defaultProps = {
+  large: false,
+};
 
 export const UploadingVideo = styled.div`
   display: flex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Displaying play icon when media type is a video in the queue and the composer.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
With the changes in the images positioning, the PlayIcon wasn't being displayed, it was below the image, this PR fixes that.
Also, we didn't have the PlayIcon in the composer.

## Screenshots
<img width="877" alt="Image 2019-09-17 at 1 38 34 PM" src="https://user-images.githubusercontent.com/988972/65038561-7e3c4180-d950-11e9-9be2-87212c86efb2.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
