### PR TITLE
Add regex to exclude analytics node_modules from Storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -13,7 +13,8 @@ import { configure } from '@storybook/react';
  */
 
 function loadStories() {
-  const req = require.context(__PACKAGES__, true, /story\.jsx$/);
-  req.keys().forEach(filename => req(filename));
+	// Add all story.jsx files inside components directories except for the ones in node_modules
+	const req = require.context(__PACKAGES__, true, /^((?![\\/]node_modules[\\/]).)*components\/.*\/*story\.jsx$/);
+	req.keys().forEach(filename => req(filename));
 }
 configure(loadStories, module);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Add regex to exclude analytics node_modules from Storybook.
<!--- Describe your changes in detail. -->

## Context & Notes
We were excluding `root/node_modules` from Storybook. However, we were only excluding `root/packages/[somepackage]/node_modules` in the `config.js` file of `.storybookStoryshot` and not `.storybook`. What happened is that files `story.jsx` coming from analytics node_modules were being displayed in publish storybook.
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
