### PR TITLE
Parsing stories order to int to prevent parseInt all over the code.

### DIFF
--- a/packages/server/parsers/src/storyGroupParser.js
+++ b/packages/server/parsers/src/storyGroupParser.js
@@ -6,6 +6,11 @@ const getStoryAction = ({ scheduledAt, timezone, options }) => {
   return `You will receive a reminder ${dateString} when it's time to post.`;
 };
 
+const parseStories = stories => stories.map((story) => {
+  story.order = parseInt(story.order, 10);
+  return story;
+});
+
 module.exports = (storyGroup) => {
   const isPastDue = isInThePast(storyGroup.scheduled_at);
 
@@ -27,7 +32,7 @@ module.exports = (storyGroup) => {
         twentyFourHourTime: storyGroup.twentyfour_hour_time,
       }),
       status: storyGroup.status,
-      stories: storyGroup.stories,
+      stories: parseStories(storyGroup.stories),
       twentyfourHourTime: storyGroup.twentyfour_hour_time,
       storyAction: getStoryAction({
         scheduledAt: storyGroup.scheduled_at,

--- a/packages/story-group-composer/reducer.js
+++ b/packages/story-group-composer/reducer.js
@@ -58,24 +58,22 @@ const updateStoryNote = ({ stories = [], order, note }) => (
 const reorderStories = (stories, sourceOrder, targetOrder) => {
   const draggedCard = stories.find(item => item.order === sourceOrder);
   const remainingCards = stories.filter(item => item.order !== sourceOrder);
-  const source = parseInt(sourceOrder, 10);
-  const target = parseInt(targetOrder, 10);
 
-  if (source < target) {
+  if (sourceOrder < targetOrder) {
     remainingCards.forEach((story) => {
-      if (story.order > source && story.order <= target) {
-        story.order = parseInt(story.order, 10) - 1;
+      if (story.order > sourceOrder && story.order <= targetOrder) {
+        story.order -= 1;
       }
     });
   }
-  if (source > target) {
+  if (sourceOrder > targetOrder) {
     remainingCards.forEach((story) => {
-      if (story.order < source && story.order >= target) {
-        story.order = parseInt(story.order, 10) + 1;
+      if (story.order < sourceOrder && story.order >= targetOrder) {
+        story.order += 1;
       }
     });
   }
-  draggedCard.order = target;
+  draggedCard.order = targetOrder;
 
   const result = [
     ...remainingCards,
@@ -88,15 +86,14 @@ const reorderStories = (stories, sourceOrder, targetOrder) => {
 const deleteStory = ({ stories, story }) => {
   const result = stories.filter(item => item.order !== story.order);
 
-  result.forEach((item) => {
+  return result.map((item) => {
     // If card is on the right of the deleted card,
     // change order one space to the left
     if (item.order > story.order) {
-      item.order = parseInt(item.order, 10) - 1;
+      item.order -= 1;
     }
+    return item;
   });
-
-  return result;
 };
 
 export default (state, action) => {

--- a/packages/story-group-composer/utils/Carousel.js
+++ b/packages/story-group-composer/utils/Carousel.js
@@ -2,7 +2,7 @@
 // TO-DO: Add tests for methods
 export const sortCards = cards => (
   cards.sort((a, b) => {
-    if (parseInt(a.order, 10) > parseInt(b.order, 10)) return 1;
+    if (a.order > b.order) return 1;
     return -1;
   })
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
When fetching the stories order from API is being handled as a string, which has been causing several problems for sorting the stories (on delete, drag and drop).
So I'm parsing the order to be an integer when fetching from the API to prevent adding parseInt everywhere.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
