### PR TITLE
[PUB-2016] Add STORY_SENT action from Pusher event

### DIFF
--- a/packages/pusher-sync/middleware.js
+++ b/packages/pusher-sync/middleware.js
@@ -112,10 +112,10 @@ export default ({ dispatch }) => {
         if (!channelsByProfileId[profileId]) {
           channelsByProfileId[profileId] = {
             updates: pusher.subscribe(`private-updates-${profileId}`),
-            storyGroups: pusher.subscribe(`private-story-groups-${profileId}`),
+            storyGroups: tabId === 'stories' ? pusher.subscribe(`private-story-groups-${profileId}`) : null,
           };
           bindProfileUpdateEvents(channelsByProfileId[profileId].updates, profileId, dispatch);
-          if (tabId === 'stories') {
+          if (channelsByProfileId[profileId].storyGroups) {
             bindProfileStoryGroupEvents(channelsByProfileId[profileId].storyGroups, profileId, dispatch);
           }
         }

--- a/packages/pusher-sync/middleware.js
+++ b/packages/pusher-sync/middleware.js
@@ -106,6 +106,7 @@ export default ({ dispatch }) => {
       const { profileId } = action;
       if (profileId) {
         if (!channelsByProfileId[profileId]) {
+          console.log(action);
           const channelName = `private-updates-${profileId}`;
           channelsByProfileId[profileId] = pusher.subscribe(channelName);
           bindProfileEvents(channelsByProfileId[profileId], profileId, dispatch);

--- a/packages/pusher-sync/middleware.js
+++ b/packages/pusher-sync/middleware.js
@@ -2,7 +2,8 @@ import Pusher from 'pusher-js';
 import { actionTypes as profileSidebarActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
 import { actionTypes as queueActionTypes } from '@bufferapp/publish-queue/reducer';
 import { actionTypes as draftActionTypes } from '@bufferapp/publish-drafts/reducer';
-import { postParser } from '@bufferapp/publish-server/parsers/src';
+import { actionTypes as storiesActionTypes } from '@bufferapp/publish-stories/reducer';
+import { postParser, storyGroupParser } from '@bufferapp/publish-server/parsers/src';
 
 const PUSHER_APP_KEY = 'bd9ba9324ece3341976e';
 
@@ -83,6 +84,13 @@ const bindProfileEvents = (channel, profileId, dispatch) => {
       type: profileSidebarActionTypes.PUSHER_PROFILE_PAUSED_STATE,
       paused,
       profileId,
+    });
+  });
+  channel.bind('sent_story_group', (data) => {
+    dispatch({
+      type: storiesActionTypes.STORY_SENT,
+      profileId,
+      storyGroup: storyGroupParser(data.story_group),
     });
   });
 };

--- a/packages/pusher-sync/middleware.js
+++ b/packages/pusher-sync/middleware.js
@@ -1,6 +1,5 @@
 import Pusher from 'pusher-js';
 import { actionTypes as profileSidebarActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
-import { actionTypes as tabsActionTypes } from '@bufferapp/publish-tabs/reducer';
 import { actionTypes as queueActionTypes } from '@bufferapp/publish-queue/reducer';
 import { actionTypes as draftActionTypes } from '@bufferapp/publish-drafts/reducer';
 import { actionTypes as storiesActionTypes } from '@bufferapp/publish-stories/reducer';
@@ -106,13 +105,14 @@ export default ({ dispatch }) => {
 
   return next => (action) => {
     next(action);
-    if (action.type === tabsActionTypes.SELECT_TAB) {
-      const { profileId, tabId } = action;
+    if (action.type === profileSidebarActionTypes.SELECT_PROFILE) {
+      const { profileId } = action;
+      const { service } = action.profile;
       if (profileId) {
         // If the profile is not subscribed to any channels, subscribes to private-updates channel:
         const newProfileChannels = channelsByProfileId[profileId] || { updates: pusher.subscribe(`private-updates-${profileId}`) };
-        // If on stories tab and profile is not subscribed to story-groups channel, subscribes to private-story-groups channel:
-        if (tabId === 'stories' && newProfileChannels.storyGroups === undefined) {
+        // If instagram profile and profile is not subscribed to story-groups channel, subscribes to private-story-groups channel:
+        if (service === 'instagram' && newProfileChannels.storyGroups === undefined) {
           newProfileChannels.storyGroups = pusher.subscribe(`private-story-groups-${profileId}`);
         }
         channelsByProfileId[profileId] = newProfileChannels;

--- a/packages/pusher-sync/middleware.test.js
+++ b/packages/pusher-sync/middleware.test.js
@@ -1,5 +1,5 @@
 import Pusher from 'pusher-js';
-import { actionTypes as profileSidebarActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
+import { actionTypes as tabsActionTypes } from '@bufferapp/publish-tabs/reducer';
 import { actionTypes as queueActionTypes } from '@bufferapp/publish-queue/reducer';
 import { postParser } from '@bufferapp/publish-server/parsers/src';
 
@@ -11,9 +11,16 @@ describe('middleware', () => {
     getState: () => ({ }),
   };
   const next = jest.fn();
-  const selectProfileAction = {
-    type: profileSidebarActionTypes.SELECT_PROFILE,
+  const selectTabAction = {
+    type: tabsActionTypes.SELECT_TAB,
     profileId: '12345',
+    tabId: 'stories',
+  };
+
+  const selectQueueTabAction = {
+    type: tabsActionTypes.SELECT_TAB,
+    profileId: '123456',
+    tabId: 'queue',
   };
 
   beforeEach(() => {
@@ -21,13 +28,13 @@ describe('middleware', () => {
   });
 
   it('should call next when running middleware', () => {
-    middleware(store)(next)(selectProfileAction);
+    middleware(store)(next)(selectTabAction);
     expect(next)
       .toBeCalled();
   });
 
   it('should create a new pusher instance', () => {
-    middleware(store)(next)(selectProfileAction);
+    middleware(store)(next)(selectTabAction);
     expect(Pusher)
       .toHaveBeenCalledWith(
         'bd9ba9324ece3341976e',
@@ -35,14 +42,24 @@ describe('middleware', () => {
       );
   });
 
-  it('should subscribe to private updates channel', () => {
-    middleware(store)(next)(selectProfileAction);
+  it('should subscribe to both private updates and private story groups channel', () => {
+    middleware(store)(next)(selectTabAction);
     expect(Pusher.subscribe)
       .toHaveBeenCalledWith('private-updates-12345');
+    expect(Pusher.subscribe)
+      .toHaveBeenCalledWith('private-story-groups-12345');
+  });
+
+  it('should subscribe to private updates but not private story groups channel', () => {
+    middleware(store)(next)(selectQueueTabAction);
+    expect(Pusher.subscribe)
+      .not.toHaveBeenCalledWith('private-story-groups-123456');
+    expect(Pusher.subscribe)
+      .toHaveBeenCalledWith('private-updates-123456');
   });
 
   it('should subscribe to update events', () => {
-    middleware(store)(next)(selectProfileAction);
+    middleware(store)(next)(selectTabAction);
     expect(Pusher.bind.mock.calls[0][0]).toEqual('private-updates-12345');
     expect(Pusher.bind.mock.calls[0][1]).toEqual('sent_update');
     expect(Pusher.bind.mock.calls[1][0]).toEqual('private-updates-12345');
@@ -59,13 +76,13 @@ describe('middleware', () => {
     expect(Pusher.bind.mock.calls[6][1]).toEqual('reordered_updates');
     expect(Pusher.bind.mock.calls[7][0]).toEqual('private-updates-12345');
     expect(Pusher.bind.mock.calls[7][1]).toEqual('queue_paused');
-    expect(Pusher.bind.mock.calls[8][0]).toEqual('private-updates-12345');
+    expect(Pusher.bind.mock.calls[8][0]).toEqual('private-story-groups-12345');
     expect(Pusher.bind.mock.calls[8][1]).toEqual('sent_story_group');
     expect(Pusher.bind).toHaveBeenCalledTimes(9);
   });
 
   it('should dispatch when a subscribed pusher event happens', () => {
-    middleware(store)(next)(selectProfileAction);
+    middleware(store)(next)(selectTabAction);
     const update = { id: '00012345', text: 'Hello, world.' };
     Pusher.simulate('private-updates-12345', 'added_update', { update });
     expect(store.dispatch).toHaveBeenCalledWith({

--- a/packages/pusher-sync/middleware.test.js
+++ b/packages/pusher-sync/middleware.test.js
@@ -59,7 +59,9 @@ describe('middleware', () => {
     expect(Pusher.bind.mock.calls[6][1]).toEqual('reordered_updates');
     expect(Pusher.bind.mock.calls[7][0]).toEqual('private-updates-12345');
     expect(Pusher.bind.mock.calls[7][1]).toEqual('queue_paused');
-    expect(Pusher.bind).toHaveBeenCalledTimes(8);
+    expect(Pusher.bind.mock.calls[8][0]).toEqual('private-updates-12345');
+    expect(Pusher.bind.mock.calls[8][1]).toEqual('sent_story_group');
+    expect(Pusher.bind).toHaveBeenCalledTimes(9);
   });
 
   it('should dispatch when a subscribed pusher event happens', () => {

--- a/packages/pusher-sync/middleware.test.js
+++ b/packages/pusher-sync/middleware.test.js
@@ -1,5 +1,5 @@
 import Pusher from 'pusher-js';
-import { actionTypes as tabsActionTypes } from '@bufferapp/publish-tabs/reducer';
+import { actionTypes as profileSidebarActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
 import { actionTypes as queueActionTypes } from '@bufferapp/publish-queue/reducer';
 import { postParser } from '@bufferapp/publish-server/parsers/src';
 
@@ -11,16 +11,20 @@ describe('middleware', () => {
     getState: () => ({ }),
   };
   const next = jest.fn();
-  const selectTabAction = {
-    type: tabsActionTypes.SELECT_TAB,
+  const selectProfileAction = {
+    type: profileSidebarActionTypes.SELECT_PROFILE,
     profileId: '12345',
-    tabId: 'stories',
+    profile: {
+      service: 'instagram',
+    },
   };
 
-  const selectQueueTabAction = {
-    type: tabsActionTypes.SELECT_TAB,
+  const selectIGProfileAction = {
+    type: profileSidebarActionTypes.SELECT_PROFILE,
     profileId: '123456',
-    tabId: 'queue',
+    profile: {
+      service: 'twitter',
+    },
   };
 
   beforeEach(() => {
@@ -28,13 +32,13 @@ describe('middleware', () => {
   });
 
   it('should call next when running middleware', () => {
-    middleware(store)(next)(selectTabAction);
+    middleware(store)(next)(selectProfileAction);
     expect(next)
       .toBeCalled();
   });
 
   it('should create a new pusher instance', () => {
-    middleware(store)(next)(selectTabAction);
+    middleware(store)(next)(selectProfileAction);
     expect(Pusher)
       .toHaveBeenCalledWith(
         'bd9ba9324ece3341976e',
@@ -43,7 +47,7 @@ describe('middleware', () => {
   });
 
   it('should subscribe to both private updates and private story groups channel', () => {
-    middleware(store)(next)(selectTabAction);
+    middleware(store)(next)(selectProfileAction);
     expect(Pusher.subscribe)
       .toHaveBeenCalledWith('private-updates-12345');
     expect(Pusher.subscribe)
@@ -51,7 +55,7 @@ describe('middleware', () => {
   });
 
   it('should subscribe to private updates but not private story groups channel', () => {
-    middleware(store)(next)(selectQueueTabAction);
+    middleware(store)(next)(selectIGProfileAction);
     expect(Pusher.subscribe)
       .not.toHaveBeenCalledWith('private-story-groups-123456');
     expect(Pusher.subscribe)
@@ -59,7 +63,7 @@ describe('middleware', () => {
   });
 
   it('should subscribe to update events', () => {
-    middleware(store)(next)(selectTabAction);
+    middleware(store)(next)(selectProfileAction);
     expect(Pusher.bind.mock.calls[0][0]).toEqual('private-updates-12345');
     expect(Pusher.bind.mock.calls[0][1]).toEqual('sent_update');
     expect(Pusher.bind.mock.calls[1][0]).toEqual('private-updates-12345');
@@ -82,7 +86,7 @@ describe('middleware', () => {
   });
 
   it('should dispatch when a subscribed pusher event happens', () => {
-    middleware(store)(next)(selectTabAction);
+    middleware(store)(next)(selectProfileAction);
     const update = { id: '00012345', text: 'Hello, world.' };
     Pusher.simulate('private-updates-12345', 'added_update', { update });
     expect(store.dispatch).toHaveBeenCalledWith({

--- a/packages/stories/middleware.js
+++ b/packages/stories/middleware.js
@@ -10,6 +10,7 @@ export default ({ dispatch, getState }) => next => (action) => {
   next(action);
   switch (action.type) {
     case profileActionTypes.SELECT_PROFILE:
+    case actionTypes.STORY_SENT:
       dispatch(dataFetchActions.fetch({
         name: 'getStoryGroups',
         args: {

--- a/packages/stories/middleware.js
+++ b/packages/stories/middleware.js
@@ -10,7 +10,6 @@ export default ({ dispatch, getState }) => next => (action) => {
   next(action);
   switch (action.type) {
     case profileActionTypes.SELECT_PROFILE:
-    case actionTypes.STORY_SENT:
       dispatch(dataFetchActions.fetch({
         name: 'getStoryGroups',
         args: {

--- a/packages/stories/middleware.js
+++ b/packages/stories/middleware.js
@@ -14,7 +14,7 @@ export default ({ dispatch, getState }) => next => (action) => {
       dispatch(dataFetchActions.fetch({
         name: 'getStoryGroups',
         args: {
-          profileId: action.profile.id,
+          profileId: action.profileId || action.profile.id,
         },
       }));
       break;

--- a/packages/stories/reducer.js
+++ b/packages/stories/reducer.js
@@ -9,6 +9,7 @@ export const actionTypes = keyWrapper('STORIES', {
   OPEN_PREVIEW: 0,
   STORY_GROUP_SHARE_NOW: 0,
   CLOSE_PREVIEW: 0,
+  STORY_SENT: 0,
 });
 
 export const initialState = {
@@ -76,6 +77,7 @@ const storyPostsReducer = (state = {}, action) => {
       return updates;
     }
     case actionTypes.DELETE_STORY_GROUP:
+    case actionTypes.STORY_SENT:
     case `shareStoryGroupNow_${dataFetchActionTypes.FETCH_SUCCESS}`: {
       const { [getStoryGroupId(action)]: deleted, ...currentState } = state;
       return currentState;
@@ -116,6 +118,7 @@ const profileReducer = (state = profileInitialState, action) => {
       };
     case actionTypes.STORY_GROUP_SHARE_NOW:
     case actionTypes.DELETE_STORY_GROUP:
+    case actionTypes.STORY_SENT:
     case `shareStoryGroupNow_${dataFetchActionTypes.FETCH_FAIL}`:
     case `shareStoryGroupNow_${dataFetchActionTypes.FETCH_SUCCESS}`:
     case `createStoryGroup_${dataFetchActionTypes.FETCH_SUCCESS}`:
@@ -142,6 +145,7 @@ export default (state = initialState, action) => {
     case profileSidebarActionTypes.SELECT_PROFILE:
     case actionTypes.STORY_GROUP_SHARE_NOW:
     case actionTypes.DELETE_STORY_GROUP:
+    case actionTypes.STORY_SENT:
     case `shareStoryGroupNow_${dataFetchActionTypes.FETCH_SUCCESS}`:
     case `shareStoryGroupNow_${dataFetchActionTypes.FETCH_FAIL}`:
     case `getStoryGroups_${dataFetchActionTypes.FETCH_START}`:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Dispatch `STORY_SENT` actionType when we receive a `sent_story_group` event from Pusher, that will update the stories queue.
<!--- Describe your changes in detail. -->

## Context & Notes
[PUB-2016](https://buffer.atlassian.net/browse/PUB-2016)
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
