### PR TITLE
Supporting multiple uploaders

### DIFF
--- a/packages/UploadZone/utils/Uploader.js
+++ b/packages/UploadZone/utils/Uploader.js
@@ -158,7 +158,11 @@ class Uploader {
 
   listenToProcessingEventsForVideos (response) {
     if (response.type === 'video') {
-      WebSocket.init({ userId: this.userId, notifiers: this.notifiers });
+      WebSocket.init({
+        userId: this.userId,
+        notifiers: this.notifiers,
+        appEnvironment: null,
+      });
     }
     return response;
   }

--- a/packages/UploadZone/utils/WebSocket.js
+++ b/packages/UploadZone/utils/WebSocket.js
@@ -77,11 +77,17 @@ class WebSocket {
 
   bind = ({ userId, notifiers }) => {
     this.eventHandlers = this.configureEventHandlers(notifiers);
+    let { pusher } = this;
 
-    Pusher.channel_auth_endpoint = PUSHER.AUTH_ENDPOINT;
-    const pusher = new Pusher(PUSHER.API_KEY, {
-      cluster: PUSHER.CLUSTER,
-    });
+    if (!pusher) {
+      Pusher.channel_auth_endpoint = PUSHER.AUTH_ENDPOINT;
+      pusher = new Pusher(PUSHER.API_KEY, {
+        cluster: PUSHER.CLUSTER,
+      });
+
+      this.pusher = pusher;
+    }
+
     const pusherInstance = pusher.subscribe(`private-updates-${userId}`);
     this.eventHandlers.forEach((handler, event) => pusherInstance.bind(event, handler));
     this.hasWebSocketConnectionOpen = true;

--- a/packages/UploadZone/utils/WebSocket.js
+++ b/packages/UploadZone/utils/WebSocket.js
@@ -17,18 +17,8 @@ class WebSocket {
 
   hasWebSocketConnectionOpen = false;
 
-  init = ({ userId, notifiers }) => {
-    if (this.hasWebSocketConnectionOpen) return;
-
-    this.eventHandlers = this.configureEventHandlers(notifiers);
-
-    Pusher.channel_auth_endpoint = PUSHER.AUTH_ENDPOINT;
-    const pusher = new Pusher(PUSHER.API_KEY, {
-      cluster: PUSHER.CLUSTER,
-    });
-    const pusherInstance = pusher.subscribe(`private-updates-${userId}`);
-    this.eventHandlers.forEach((handler, event) => pusherInstance.bind(event, handler));
-    this.hasWebSocketConnectionOpen = true;
+  init = ({ userId, notifiers, appEnvironment }) => {
+    this.rebind({ userId, notifiers, appEnvironment: false, });
   };
 
   configureEventHandlers = (notifiers) => {
@@ -76,6 +66,25 @@ class WebSocket {
       ['edited_profile_group', handleEditedProfileGroup],
       ['deleted_profile_group', handleDeletedProfileGroup],
     ]);
+  };
+
+  rebind = ({ userId, notifiers, appEnvironment }) => {
+    if (this.hasWebSocketConnectionOpen) {
+      this.cleanUp(appEnvironment);
+    }
+    this.bind({ userId, notifiers });
+  };
+
+  bind = ({ userId, notifiers }) => {
+    this.eventHandlers = this.configureEventHandlers(notifiers);
+
+    Pusher.channel_auth_endpoint = PUSHER.AUTH_ENDPOINT;
+    const pusher = new Pusher(PUSHER.API_KEY, {
+      cluster: PUSHER.CLUSTER,
+    });
+    const pusherInstance = pusher.subscribe(`private-updates-${userId}`);
+    this.eventHandlers.forEach((handler, event) => pusherInstance.bind(event, handler));
+    this.hasWebSocketConnectionOpen = true;
   };
 
   cleanUp = (appEnvironment) => {

--- a/packages/composer/composer/action-creators/AppActionCreators.js
+++ b/packages/composer/composer/action-creators/AppActionCreators.js
@@ -496,7 +496,12 @@ const AppActionCreators = {
   },
 
   listenToChangeEventsForGroups: () => {
-    WebSocket.init({userId: AppStore.getUserData().id, notifiers: ServerActionCreators});
+    const { appEnvironment } = AppStore.getMetaData();
+    WebSocket.init({
+      userId: AppStore.getUserData().id,
+      notifiers: ServerActionCreators,
+      appEnvironment,
+    });
   },
 
   resetSelectedProfiles: (profilesData) => {

--- a/packages/composer/composer/components/ComposerSection.jsx
+++ b/packages/composer/composer/components/ComposerSection.jsx
@@ -190,6 +190,7 @@ class ComposerSection extends React.Component {
         {!isOmniboxEnabled
         && enabledDrafts.map((draft, index) => (
           <ComposerComponent
+            key={draft.id}
             {
               ...{
                 state: this.state,

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -208,6 +208,7 @@ QueuedPosts.propTypes = {
 };
 
 QueuedPosts.defaultProps = {
+  postLists: [],
   loading: true,
   moreToLoad: false,
   page: 1,


### PR DESCRIPTION
## Description

Providing support for multiple composers with different uploading / downloading behaviour.

## Context & Notes

Providing support for multiple composers with different uploading / downloading behaviour, as there was an issue when using the websocket library, that if you tried to configure new pusher events, it wouldn't set them up correctly because the pusher events would take the initial creator value, and so further events bound later would never re-bind new events to the composer.

This means that when uploading files in the composer, then switching to the stories composer, progress for uploading a video would never result in a new video asset being completed, or vice versa.

This changes that

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
