### PR TITLE
[PUB-1936] Change cta banner copy for Premium Trialists

### DIFF
--- a/packages/cta-banner/components/BillingUpgradeCTABanner/index.jsx
+++ b/packages/cta-banner/components/BillingUpgradeCTABanner/index.jsx
@@ -23,6 +23,7 @@ const textStyle = {
 const BillingUpgradeCTABanner = ({
   translations,
   trial,
+  isPremiumBusinessPlan,
   onClickStartSubscription,
   profileCount,
 }) => {
@@ -34,7 +35,7 @@ const BillingUpgradeCTABanner = ({
     <Text {...styles}>
       <FeatureLoader supportedPlans="free">Free</FeatureLoader>
       <FeatureLoader supportedPlans="pro">Pro</FeatureLoader>
-      <FeatureLoader supportedPlans="business">Business</FeatureLoader>
+      <FeatureLoader supportedPlans="business">{isPremiumBusinessPlan ? 'Premium' : 'Business'}</FeatureLoader>
     </Text>
   );
 
@@ -117,11 +118,13 @@ BillingUpgradeCTABanner.propTypes = {
     trialTimeRemaining: PropTypes.string,
   }),
   onClickStartSubscription: PropTypes.func.isRequired,
+  isPremiumBusinessPlan: PropTypes.bool,
   profileCount: PropTypes.number,
 };
 
 BillingUpgradeCTABanner.defaultProps = {
   profileCount: 0,
+  isPremiumBusinessPlan: false,
   trial: {
     hasCardDetails: false,
     hasTrialExtended: false,

--- a/packages/cta-banner/index.js
+++ b/packages/cta-banner/index.js
@@ -6,6 +6,7 @@ import BillingUpdateCTABanner from './components/BillingUpgradeCTABanner';
 export default connect(
   state => ({
     trial: state.appSidebar.user && state.appSidebar.user.trial,
+    isPremiumBusinessPlan: state.appSidebar.user.plan === 'premium_business',
     translations: state.i18n.translations['billing-upgrade-cta-banner'],
     profileCount: state.ctaBanner.profileCount,
   }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Replace Business plan name by Premium, when user is a Premium Business Trialist. 
<!--- Describe your changes in detail. -->

## Context & Notes
[PUB-1936](https://buffer.atlassian.net/browse/PUB-1936)
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
