### PR TITLE
Fix issue with 24 hour format in datepicker and remove creatorName in story header

### DIFF
--- a/packages/shared-components/CardHeader/index.jsx
+++ b/packages/shared-components/CardHeader/index.jsx
@@ -33,6 +33,10 @@ const TextWithStyles = styled(Text)`
   color: ${gray};
 `;
 
+const getCreatedText = creatorName => (
+  creatorName ? `${creatorName} created this ` : 'Created '
+);
+
 const CardHeader = ({
   creatorName,
   avatarUrl,
@@ -44,17 +48,18 @@ const CardHeader = ({
   return (
     <WrapperComponent>
       <ContentWrapper>
-        <AvatarWrapper>
-          <Image
-            src={avatarUrl}
-            border="circle"
-            height="1.25rem"
-            width="1.25rem"
-          />
-        </AvatarWrapper>
+        {creatorName && (
+          <AvatarWrapper>
+            <Image
+              src={avatarUrl}
+              border="circle"
+              height="1.25rem"
+              width="1.25rem"
+            />
+          </AvatarWrapper>
+        )}
         <TextWithStyles type="p">
-          {creatorName}
-          &nbsp;created this&nbsp;
+          {getCreatedText(creatorName)}
           {createdAt}
         </TextWithStyles>
       </ContentWrapper>

--- a/packages/shared-components/Story/index.jsx
+++ b/packages/shared-components/Story/index.jsx
@@ -31,7 +31,7 @@ const Story = ({
   const largeCards = false;
   const { cardWidth, cardHeight } = getCardSizes(largeCards);
   const {
-    stories, creatorName, avatarUrl, createdAt, storyAction, error, errorLink,
+    stories, avatarUrl, createdAt, storyAction, error, errorLink,
   } = storyDetails;
   const { tags } = userData;
   const hasStoriesMobileVersion = (
@@ -53,7 +53,6 @@ const Story = ({
         )
       }
       <CardHeader
-        creatorName={creatorName}
         avatarUrl={avatarUrl}
         createdAt={createdAt}
         onPreviewClick={() => onPreviewClick({
@@ -96,7 +95,6 @@ Story.propTypes = {
   profileId: PropTypes.string.isRequired,
   scheduledAt: PropTypes.number.isRequired,
   storyDetails: PropTypes.shape({
-    creatorName: PropTypes.string.isRequired,
     avatarUrl: PropTypes.string.isRequired,
     createdAt: PropTypes.string.isRequired,
     storyAction: PropTypes.string.isRequired,

--- a/packages/story-group-composer/components/AddStoryFooter/index.jsx
+++ b/packages/story-group-composer/components/AddStoryFooter/index.jsx
@@ -121,7 +121,7 @@ const AddStoryFooter = ({
       </FooterBar>
       {showDatePicker && (
         <DateTimeSlotPickerWrapper
-          shouldUse24hTime={uses24hTime}
+          uses24hTime={uses24hTime}
           timezone={timezone}
           weekStartsMonday={weekStartsMonday}
           editMode={editMode}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Fix issue with 24 hour format in datepicker not showing
- Remove creatorName temp in story cardHeader because we're not saving creator for storyGroup
<!--- Describe your changes in detail. -->

## Context & Notes
https://paper.dropbox.com/doc/Instagram-Stories-Internal-Testing--Al2bqve31_6ZnPSwEWyvBvQfAg-pLbGPRYnOTqbiVUVGAZtC
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
