### PR TITLE
Disable schedule button if story-group is a past reminder

### DIFF
--- a/packages/shared-components/CardHeader/index.jsx
+++ b/packages/shared-components/CardHeader/index.jsx
@@ -71,7 +71,7 @@ const CardHeader = ({
 };
 
 CardHeader.propTypes = {
-  creatorName: PropTypes.string.isRequired,
+  creatorName: PropTypes.string,
   avatarUrl: PropTypes.string.isRequired,
   createdAt: PropTypes.string.isRequired,
   onPreviewClick: PropTypes.func,
@@ -79,6 +79,7 @@ CardHeader.propTypes = {
 
 CardHeader.defaultProps = {
   onPreviewClick: null,
+  creatorName: null,
 };
 
 export default CardHeader;

--- a/packages/stories/components/StoryGroups/index.jsx
+++ b/packages/stories/components/StoryGroups/index.jsx
@@ -180,7 +180,7 @@ StoryGroups.propTypes = {
   userData: PropTypes.shape({
     id: PropTypes.string,
     email: PropTypes.string,
-    tags: PropTypes.arrayOf(PropTypes.strings),
+    tags: PropTypes.arrayOf(PropTypes.string),
   }),
   translations: PropTypes.shape({
     inputPlaceholder: PropTypes.string.isRequired,

--- a/packages/story-group-composer/components/AddNote/index.jsx
+++ b/packages/story-group-composer/components/AddNote/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Button } from '@bufferapp/ui';
 import NoteSection from '../NoteSection';
+import { translationsPropTypes } from '../../utils/commonPropTypes';
 
 const FooterBar = styled.div`
   padding: 13px 0px 0px;
@@ -26,7 +27,6 @@ const AddNote = ({
   onSaveNoteClick,
   onCancelClick,
   translations,
-  // dummy data until we get uploading/adding story done
   story,
 }) => {
   const [note, setNote] = useState(story ? story.note : null);
@@ -79,11 +79,7 @@ AddNote.propTypes = {
     order: PropTypes.number,
     type: PropTypes.oneOf(['image', 'video', 'gif']),
   }).isRequired,
-  translations: PropTypes.shape({
-    saveNoteButton: PropTypes.string,
-    cancelNoteButton: PropTypes.string,
-    noteImageAlt: PropTypes.string,
-  }).isRequired,
+  translations: translationsPropTypes, // eslint-disable-line react/require-default-props,,
 };
 
 export default AddNote;

--- a/packages/story-group-composer/components/AddStoryFooter/index.jsx
+++ b/packages/story-group-composer/components/AddStoryFooter/index.jsx
@@ -1,8 +1,10 @@
 import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Text } from '@bufferapp/ui';
+import { isInThePast } from '@bufferapp/publish-server/formatters/src';
 import DateTimeSlotPickerWrapper from '../DateTimeSlotPickerWrapper';
 import { getReadableDateFormat, getMomentTime } from '../../utils/AddStory';
+import { storyGroupPropTypes, translationsPropTypes, selectedProfilePropTypes } from '../../utils/commonPropTypes';
 import {
   FooterBar,
   ButtonStyle,
@@ -39,13 +41,19 @@ const AddStoryFooter = ({
   editMode,
   emptySlotData,
   selectedProfile,
+  isPastDue,
 }) => {
   const [scheduledAt, setScheduledAt] = useState(storyGroup ? storyGroup.scheduledAt : null);
   const [showDatePicker, setShowDatePicker] = useState(false);
 
+  /* this covers the case if a story group has a share failure and a user edits it
+   without updating the scheduled_at. Now the schedule button will be disabled until
+   date is updated. */
+  const isScheduledAtPastDue = isPastDue && isInThePast(scheduledAt);
+
   const storiesLength = storyGroup.stories.length;
   const uploadsCompleted = storyGroup.stories.filter(card => card.processing || card.uploading).length === 0;
-  const isScheduleDisabled = storiesLength < 1 || !uploadsCompleted || isScheduleLoading;
+  const isScheduleDisabled = storiesLength < 1 || !uploadsCompleted || isScheduleLoading || isScheduledAtPastDue;
   const isPreviewDisabled = storiesLength < 1 || !uploadsCompleted;
 
   const { stories, storyGroupId } = storyGroup;

--- a/packages/story-group-composer/components/AddStoryFooter/index.jsx
+++ b/packages/story-group-composer/components/AddStoryFooter/index.jsx
@@ -62,7 +62,6 @@ const AddStoryFooter = ({
 
   const onScheduleClick = () => {
     if (editMode) {
-      const { storyGroupId } = storyGroup;
       onUpdateStoryGroup({
         scheduledAt,
         stories,
@@ -142,23 +141,17 @@ AddStoryFooter.propTypes = {
   ...DateTimeSlotPickerWrapper.propTypes,
   isScheduleLoading: PropTypes.bool.isRequired,
   onUpdateStoryGroup: PropTypes.func.isRequired,
-  translations: PropTypes.shape({
-    scheduleLoadingButton: PropTypes.string,
-    scheduleButton: PropTypes.string,
-    previewButton: PropTypes.string,
-  }).isRequired,
-  storyGroup: PropTypes.shape({
-    storyDetails: PropTypes.shape({
-      stories: PropTypes.arrayOf(PropTypes.shape({
-        id: PropTypes.string,
-      })),
-    }),
-    scheduledAt: PropTypes.number,
-  }),
+  onCreateStoryGroup: PropTypes.func.isRequired,
+  onPreviewClick: PropTypes.func.isRequired,
+  translations: translationsPropTypes, // eslint-disable-line react/require-default-props,
+  storyGroup: storyGroupPropTypes, // eslint-disable-line react/require-default-props,
+  selectedProfile: selectedProfilePropTypes, // eslint-disable-line react/require-default-props,
+  isPastDue: PropTypes.bool,
 };
 
 AddStoryFooter.defaultProps = {
   storyGroup: {},
+  isPastDue: false,
 };
 
 export default AddStoryFooter;

--- a/packages/story-group-composer/components/Carousel/CardItem/index.jsx
+++ b/packages/story-group-composer/components/Carousel/CardItem/index.jsx
@@ -10,6 +10,7 @@ import CircularUploadIndicator
   from '@bufferapp/publish-composer/composer/components/progress-indicators/CircularUploadIndicator';
 import PropTypes from 'prop-types';
 import CarouselCardHover from '../CarouselCardHover';
+import { carouselCardPropTypes } from '../../../utils/commonPropTypes';
 import styles from './styles.css';
 
 import {
@@ -131,13 +132,7 @@ const CardItem = ({
 };
 
 CardItem.propTypes = {
-  card: PropTypes.shape({
-    order: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    type: PropTypes.string,
-    note: PropTypes.string,
-    asset_url: PropTypes.string,
-    thumbnail_url: PropTypes.string,
-  }),
+  card: carouselCardPropTypes, // eslint-disable-line react/require-default-props,
   notifyError: PropTypes.func,
   removeNotifications: PropTypes.func,
   createNewFile: PropTypes.func,

--- a/packages/story-group-composer/components/Carousel/CarouselCardHover/index.jsx
+++ b/packages/story-group-composer/components/Carousel/CarouselCardHover/index.jsx
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Text } from '@bufferapp/ui';
 import { getShortString } from '../../../utils/Carousel';
+import { carouselCardPropTypes } from '../../../utils/commonPropTypes';
 import {
   StyledTrashIcon,
   TrashIconWrapper,
@@ -62,20 +63,17 @@ const CarouselCardHover = ({
 );
 
 CarouselCardHover.propTypes = {
-  card: PropTypes.shape({
-    order: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    type: PropTypes.string,
-    note: PropTypes.string,
-    asset_url: PropTypes.string,
-    thumbnail_url: PropTypes.string,
-    empty: PropTypes.bool,
-    progress: PropTypes.number,
-  }).isRequired,
+  card: carouselCardPropTypes, // eslint-disable-line react/require-default-props,
   translations: PropTypes.shape({
     addNote: PropTypes.string.isRequired,
   }).isRequired,
-  onAddNoteClick: PropTypes.func.isRequired,
-  onDeleteStoryClick: PropTypes.func.isRequired,
+  onAddNoteClick: PropTypes.func,
+  onDeleteStoryClick: PropTypes.func,
+};
+
+CarouselCardHover.defaultProps = {
+  onAddNoteClick: () => {},
+  onDeleteStoryClick: () => {},
 };
 
 export default CarouselCardHover;

--- a/packages/story-group-composer/components/HeaderBar/index.jsx
+++ b/packages/story-group-composer/components/HeaderBar/index.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { SensitiveData } from '@bufferapp/publish-shared-components';
 import Avatar from '@bufferapp/ui/Avatar';
 import { Text } from '@bufferapp/ui';
+import { selectedProfilePropTypes } from '../../utils/commonPropTypes';
 
 const AvatarContainer = styled.div`
   display: flex;
@@ -42,11 +43,7 @@ const HeaderBar = ({
 );
 
 HeaderBar.propTypes = {
-  selectedProfile: PropTypes.shape({
-    avatar_https: PropTypes.string,
-    service: PropTypes.string,
-    handle: PropTypes.string,
-  }).isRequired,
+  selectedProfile: selectedProfilePropTypes, // eslint-disable-line react/require-default-props,,
 };
 
 export default HeaderBar;

--- a/packages/story-group-composer/components/NoteSection/index.jsx
+++ b/packages/story-group-composer/components/NoteSection/index.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { Text, TextArea } from '@bufferapp/ui';
 import { gray } from '@bufferapp/ui/style/colors';
 import { fontSize } from '@bufferapp/ui/style/fonts';
+import { translationsPropTypes } from '../../utils/commonPropTypes';
 
 const NoteWrapper = styled.div`
   display: flex;
@@ -43,10 +44,7 @@ const NoteSection = ({ note, setNote, translations }) => (
 NoteSection.propTypes = {
   note: PropTypes.string,
   setNote: PropTypes.func.isRequired,
-  translations: PropTypes.shape({
-    notePlaceholder: PropTypes.string,
-    noteSubText: PropTypes.string,
-  }).isRequired,
+  translations: translationsPropTypes, // eslint-disable-line react/require-default-props,,
 };
 
 NoteSection.defaultProps = {

--- a/packages/story-group-composer/components/StoryGroupPopover/index.jsx
+++ b/packages/story-group-composer/components/StoryGroupPopover/index.jsx
@@ -3,9 +3,6 @@ import PropTypes from 'prop-types';
 import { Popover } from '@bufferapp/components';
 import PreviewPopover from '@bufferapp/publish-story-preview';
 import StoryGroupWrapper from '../StoryGroupWrapper';
-import DateTimeSlotPickerWrapper from '../DateTimeSlotPickerWrapper';
-import CarouselCardHover from '../Carousel/CarouselCardHover';
-import HeaderBar from '../HeaderBar';
 
 const StoryGroupPopover = ({
   onOverlayClick,
@@ -92,16 +89,12 @@ const StoryGroupPopover = ({
 
 StoryGroupPopover.propTypes = {
   onOverlayClick: PropTypes.func.isRequired,
-  saveNote: PropTypes.func.isRequired,
-  isScheduleLoading: PropTypes.bool.isRequired,
-  userData: PropTypes.shape({}).isRequired,
+  showStoryPreview: PropTypes.bool,
+  ...StoryGroupWrapper.propTypes,
 };
 
 StoryGroupPopover.defaultProps = {
-  ...DateTimeSlotPickerWrapper.propTypes,
-  ...HeaderBar.propTypes,
-  ...DateTimeSlotPickerWrapper.propTypes,
-  ...CarouselCardHover.propTypes,
+  showStoryPreview: false,
 };
 
 export default StoryGroupPopover;

--- a/packages/story-group-composer/components/StoryGroupWrapper/index.jsx
+++ b/packages/story-group-composer/components/StoryGroupWrapper/index.jsx
@@ -164,6 +164,7 @@ const StoryGroupWrapper = ({
               onPreviewClick={onPreviewClick}
               emptySlotData={emptySlotData}
               selectedProfile={selectedProfile}
+              isPastDue={storyGroup.isPastDue}
             />
           </React.Fragment>
         )}

--- a/packages/story-group-composer/components/StoryGroupWrapper/index.jsx
+++ b/packages/story-group-composer/components/StoryGroupWrapper/index.jsx
@@ -4,12 +4,12 @@ import styled from 'styled-components';
 import Carousel, { CarouselCard, getCardSizes } from '@bufferapp/publish-shared-components/Carousel';
 import { fontSizeMini, fontWeight, fontWeightMedium, fontFamily } from '@bufferapp/components/style/font';
 import { red } from '@bufferapp/components/style/color';
-import DateTimeSlotPickerWrapper from '../DateTimeSlotPickerWrapper';
 import HeaderBar from '../HeaderBar';
 import AddNote from '../AddNote';
 import CarouselCards from '../Carousel/CarouselCards';
 import CardItem from '../Carousel/CardItem';
 import AddStoryFooter from '../AddStoryFooter';
+import { selectedProfilePropTypes } from '../../utils/commonPropTypes';
 
 const ADD_STORY = 'addStory';
 const ADD_NOTE = 'addNote';
@@ -90,7 +90,6 @@ const StoryGroupWrapper = ({
   const hasReachedMaxStories = (maxStories - cards.length) <= 0;
   const totalStoriesInCarousel = hasReachedMaxStories ? maxStories + 1 : maxStories;
   const { cardWidth, cardHeight } = getCardSizes(true);
-
   return (
     <Fragment>
       <WrapperStyle>
@@ -184,18 +183,22 @@ const StoryGroupWrapper = ({
   );
 };
 
+
 StoryGroupWrapper.propTypes = {
   saveNote: PropTypes.func.isRequired,
   isScheduleLoading: PropTypes.bool.isRequired,
   userData: PropTypes.shape({}).isRequired,
+  uses24hTime: PropTypes.bool.isRequired,
+  weekStartsMonday: PropTypes.bool.isRequired,
+  selectedProfile: selectedProfilePropTypes, // eslint-disable-line react/require-default-props
+  timezone: PropTypes.string.isRequired,
+  editMode: PropTypes.bool,
+  maxStories: PropTypes.number.isRequired,
   ...CardItem.propTypes,
 };
 
 StoryGroupWrapper.defaultProps = {
-  ...HeaderBar.PropTypes,
-  ...DateTimeSlotPickerWrapper.propTypes,
-  ...AddStoryFooter.propTypes,
-  ...CardItem.defaultProps,
+  editMode: false,
 };
 
 export default StoryGroupWrapper;

--- a/packages/story-group-composer/middleware.js
+++ b/packages/story-group-composer/middleware.js
@@ -179,6 +179,7 @@ export default ({ getState, dispatch }) => next => (action) => {
           stories: editingStoryGroup.storyDetails.stories,
           storyGroupId: editingStoryGroup.id,
           scheduledAt: editingStoryGroup.scheduledAt,
+          isPastDue: editingStoryGroup.isPastDue,
         }));
       }
       const channel = getState().profileSidebar.selectedProfile;

--- a/packages/story-group-composer/reducer.js
+++ b/packages/story-group-composer/reducer.js
@@ -135,6 +135,7 @@ export default (state, action) => {
           stories: action.stories,
           scheduledAt: action.scheduledAt,
           storyGroupId: action.storyGroupId,
+          isPastDue: action.isPastDue,
         },
       };
     }
@@ -355,11 +356,12 @@ export const actions = {
   handleClosePreviewClick: () => ({
     type: actionTypes.CLOSE_PREVIEW,
   }),
-  setStoryGroup: ({ scheduledAt, stories, storyGroupId }) => ({
+  setStoryGroup: ({ scheduledAt, stories, storyGroupId, isPastDue }) => ({
     type: actionTypes.SET_STORY_GROUP,
     scheduledAt,
     stories,
     storyGroupId,
+    isPastDue,
   }),
   updateStoryUploadProgress: ({
     id, uploaderInstance, progress, file, complete,

--- a/packages/story-group-composer/utils/commonPropTypes.js
+++ b/packages/story-group-composer/utils/commonPropTypes.js
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+import moment from 'moment-timezone';
+
+export const selectedProfilePropTypes = PropTypes.shape({
+  avatar_https: PropTypes.string,
+  service: PropTypes.string,
+  handle: PropTypes.string,
+}).isRequired;
+
+export const translationsPropTypes = PropTypes.shape({
+  scheduleLoadingButton: PropTypes.string,
+  scheduleButton: PropTypes.string,
+  previewButton: PropTypes.string,
+  addNote: PropTypes.string.isRequired,
+  notePlaceholder: PropTypes.string,
+  noteSubText: PropTypes.string,
+  saveNoteButton: PropTypes.string,
+  cancelNoteButton: PropTypes.string,
+  noteImageAlt: PropTypes.string,
+}).isRequired;
+
+export const carouselCardPropTypes = PropTypes.shape({
+  order: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  type: PropTypes.string,
+  note: PropTypes.string,
+  asset_url: PropTypes.string,
+  thumbnail_url: PropTypes.string,
+  empty: PropTypes.bool,
+  progress: PropTypes.number,
+});
+
+export const storyGroupPropTypes = PropTypes.shape({
+  storyDetails: PropTypes.shape({
+    stories: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.string,
+    })),
+  }),
+  scheduledAt: PropTypes.number,
+}).isRequired;

--- a/packages/story-group-composer/utils/commonPropTypes.test.js
+++ b/packages/story-group-composer/utils/commonPropTypes.test.js
@@ -1,0 +1,28 @@
+import {
+  selectedProfilePropTypes,
+  translationsPropTypes,
+  carouselCardPropTypes,
+  storyGroupPropTypes,
+} from './commonPropTypes';
+
+describe('commonPropTypes', () => {
+  it('has selectedProfilePropTypes', () => {
+    expect(selectedProfilePropTypes).toBeDefined();
+    expect(typeof selectedProfilePropTypes).toBe('function');
+  });
+
+  it('has translationsPropTypes', () => {
+    expect(translationsPropTypes).toBeDefined();
+    expect(typeof translationsPropTypes).toBe('function');
+  });
+
+  it('has carouselCardPropTypes', () => {
+    expect(carouselCardPropTypes).toBeDefined();
+    expect(typeof carouselCardPropTypes).toBe('function');
+  });
+
+  it('has storyGroupPropTypes', () => {
+    expect(storyGroupPropTypes).toBeDefined();
+    expect(typeof storyGroupPropTypes).toBe('function');
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Disable schedule button if user is editing story-group with a past reminder. (This case could happen if story-group share failed and still in queue). 

- Clean up prop-types in story-group composer
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
