### PR TITLE
Add redundant check to ensure free users are not recorded in FullStory

### DIFF
--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -65,9 +65,11 @@ export default ({ dispatch, getState }) => next => (action) => {
             const {
               productFeatures: { planName },
             } = getState();
-            window.FS.identify(id, {
-              pricingPlan_str: planName,
-            });
+            if (planName !== 'free') {
+              window.FS.identify(id, {
+                pricingPlan_str: planName,
+              });
+            }
           }
         }
       }


### PR DESCRIPTION
## Description
Added a check to make sure we don't record users on free plans in FullStory.
## Context & Notes
Change is required because if free users are recorded, our quota is filled up quickly.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`