### PR TITLE
Handle batches of updates loading at the same time

### DIFF
--- a/packages/shared-components/Carousel/index.jsx
+++ b/packages/shared-components/Carousel/index.jsx
@@ -74,6 +74,22 @@ class Carousel extends React.Component {
     });
   };
 
+  shouldComponentUpdate (nextProps, nextState) {
+    const { totalStories, children } = this.props;
+    const { totalStories: nextTotalStories, children: nextChildren } = nextProps;
+    const { selectedItem } = this.state;
+    const { selectedItem: nextSelectedItem } = nextState;
+
+    if (
+      totalStories !== nextTotalStories
+      || selectedItem !== nextSelectedItem
+      || children !== nextChildren
+    ) {
+      return true;
+    }
+    return false;
+  }
+
   render () {
     const {
       totalCardsToShow,

--- a/packages/story-group-composer/components/Carousel/CardItem/index.jsx
+++ b/packages/story-group-composer/components/Carousel/CardItem/index.jsx
@@ -19,116 +19,152 @@ import {
   PlayIcon,
 } from './styles';
 
-const CardItem = ({
-  card,
-  cardHeight,
-  cardWidth,
-  userData,
-  largeCards,
-  uploadFormatsConfig,
-  maxAttachableMediaCount,
-  removeNotifications,
-  notifyError,
-  videoProcessingComplete,
-  uploadDraftFile,
-  updateUploadProgress,
-  monitorUpdateProgress,
-  createNewFile,
-  createImageThumbnail,
-  uploadImageComplete,
-  videoProcessingStarted,
-  onAddNoteClick,
-  onDeleteStoryClick,
-  isOver,
-  isDragging,
-  translations,
-}) => {
-  const notifiers = {
-    uploadStarted: props => createNewFile(props),
-    uploadedLinkThumbnail: props => createImageThumbnail(props),
-    uploadedDraftImage: props => uploadImageComplete({ ...props, contentType: 'image' }),
-    uploadedDraftVideo: props => videoProcessingStarted({ ...props, contentType: 'video' }),
-    draftGifUploaded: props => uploadImageComplete({ ...props, contentType: 'gif' }),
-    queueError: props => notifyError(props),
-    monitorFileUploadProgress: monitorUpdateProgress(updateUploadProgress),
+class CardItem extends React.Component {
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      isHovering: false,
+    };
+  }
+
+  setIsHovering = (isHovering) => {
+    this.setState({ isHovering });
   };
-  const [isHovering, setIsHovering] = useState(false);
 
-  return (
-    <CarouselCard
-      key={card.uploadTrackingId}
-      card={card}
-      cardHeight={cardHeight}
-      cardWidth={cardWidth}
-      largeCards={largeCards}
-      onMouseEnter={() => setIsHovering(true)}
-      onMouseLeave={() => setIsHovering(false)}
-      isTarget={isOver}
-    >
-      {card.empty && (
-      <div>
-        <UploadZone
-          uploadButton={({ onClick }) => (
-            <Button
-              type="primary"
-              label={translations.addMedia}
-              icon={<PlusIcon />}
-              onClick={onClick}
+  shouldComponentUpdate (nextProps, nextState, nextContext) {
+    const { card, isOver, isDragging } = this.props;
+    const { card: cardNext, isOver: isOverNext, isDragging: isDraggingNext } = nextProps;
+
+    const { isHovering } = this.state;
+    const { isHovering: isHoveringNext } = nextState;
+
+    if (
+      card.empty !== cardNext.empty
+      || card.thumbnail_url !== cardNext.thumbnail_url
+      || card.progress !== cardNext.progress
+      || card.uploading !== cardNext.uploading
+      || isHovering !== isHoveringNext
+      || isOver !== isOverNext
+      || isDragging !== isDraggingNext
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  render() {
+    const {
+      card,
+      cardHeight,
+      cardWidth,
+      userData,
+      largeCards,
+      uploadFormatsConfig,
+      maxAttachableMediaCount,
+      removeNotifications,
+      notifyError,
+      videoProcessingComplete,
+      uploadDraftFile,
+      updateUploadProgress,
+      monitorUpdateProgress,
+      createNewFile,
+      createImageThumbnail,
+      uploadImageComplete,
+      videoProcessingStarted,
+      onAddNoteClick,
+      onDeleteStoryClick,
+      isOver,
+      isDragging,
+      translations,
+    } = this.props;
+    const notifiers = {
+      uploadStarted: props => createNewFile(props),
+      uploadedLinkThumbnail: props => createImageThumbnail(props),
+      uploadedDraftImage: props => uploadImageComplete({ ...props, contentType: 'image' }),
+      uploadedDraftVideo: props => videoProcessingStarted({ ...props, contentType: 'video' }),
+      draftGifUploaded: props => uploadImageComplete({ ...props, contentType: 'gif' }),
+      queueError: props => notifyError(props),
+      monitorFileUploadProgress: monitorUpdateProgress(updateUploadProgress),
+    };
+    const { isHovering } = this.state;
+
+    return (
+      <CarouselCard
+        key={card.uploadTrackingId}
+        card={card}
+        cardHeight={cardHeight}
+        cardWidth={cardWidth}
+        largeCards={largeCards}
+        onMouseEnter={() => this.setIsHovering(true)}
+        onMouseLeave={() => this.setIsHovering(false)}
+        isTarget={isOver}
+      >
+        {card.empty && (
+          <div>
+            <UploadZone
+              uploadButton={({ onClick }) => (
+                <Button
+                  type="primary"
+                  label={translations.addMedia}
+                  icon={<PlusIcon />}
+                  onClick={onClick}
+                />
+              )}
+              classNames={styles}
+              supportsMixedMediaTypes
+              mixedMediaUnsupportedCallback={FileUploader.throwMixedMediaTypesError}
+              uploadDraftFile={uploadDraftFile({ userData, videoProcessingComplete })}
+              notifiers={notifiers}
+              removeAllNotifications={removeNotifications}
+              queueError={notifyError}
+              draftId={`${card.order}`}
+              uploadFormatsConfig={uploadFormatsConfig}
+              service={{
+                maxAttachableImagesCount: maxAttachableMediaCount,
+                canHaveMediaAttachmentType: () => true,
+              }}
+              uploadType={UploadTypes.MEDIA}
+              multiple
+              disabled={isOver}
             />
-          )}
-          classNames={styles}
-          supportsMixedMediaTypes
-          mixedMediaUnsupportedCallback={FileUploader.throwMixedMediaTypesError}
-          uploadDraftFile={uploadDraftFile({ userData, videoProcessingComplete })}
-          notifiers={notifiers}
-          removeAllNotifications={removeNotifications}
-          queueError={notifyError}
-          draftId={`${card.order}`}
-          uploadFormatsConfig={uploadFormatsConfig}
-          service={{
-            maxAttachableImagesCount: maxAttachableMediaCount,
-            canHaveMediaAttachmentType: () => true,
-          }}
-          uploadType={UploadTypes.MEDIA}
-          multiple
-          disabled={isOver}
-        />
-      </div>
-      )}
-      {!card.empty && card.progress !== null && card.uploading && (
-      <CircularUploadIndicator
-        classNames={{ container: styles.container }}
-        size={54}
-        progress={card.progress}
-        showText
-        finishingUpText="Finishing Upload..."
-      />
-      )}
+          </div>
+        )}
+        {!card.empty && card.progress !== null && card.uploading && (
+          <CircularUploadIndicator
+            classNames={{ container: styles.container }}
+            size={54}
+            progress={card.progress}
+            showText
+            finishingUpText="Finishing Upload..."
+          />
+        )}
 
-      {card.thumbnail_url && (
-        <StoryWrapper>
-          <CoverImage src={card.thumbnail_url} isTarget={isOver} />
-          {card.type === 'video' && <PlayIcon large={largeCards} />}
-          {isHovering && !isDragging && (
-            <CarouselCardHover
-              card={card}
-              translations={translations}
-              onAddNoteClick={onAddNoteClick}
-              onDeleteStoryClick={onDeleteStoryClick}
-            />
-          )}
-        </StoryWrapper>
-      )}
+        {card.thumbnail_url && (
+          <StoryWrapper>
+            <CoverImage src={card.thumbnail_url} isTarget={isOver} />
+            {card.type === 'video' && <PlayIcon large={largeCards} />}
+            {isHovering && !isDragging && (
+              <CarouselCardHover
+                card={card}
+                translations={translations}
+                onAddNoteClick={onAddNoteClick}
+                onDeleteStoryClick={onDeleteStoryClick}
+              />
+            )}
+          </StoryWrapper>
+        )}
 
-      {!card.empty && card.processing === true && (
-      <UploadingVideo>
-        <Text size="small">{translations.processingVideo}</Text>
-        <LoadingAnimation marginTop="0" />
-      </UploadingVideo>
-      )}
-    </CarouselCard>
-  );
-};
+        {!card.empty && card.processing === true && (
+          <UploadingVideo>
+            <Text size="small">{translations.processingVideo}</Text>
+            <LoadingAnimation marginTop="0" />
+          </UploadingVideo>
+        )}
+      </CarouselCard>
+    );
+  }
+}
 
 CardItem.propTypes = {
   card: PropTypes.shape({

--- a/packages/story-group-composer/index.js
+++ b/packages/story-group-composer/index.js
@@ -152,6 +152,7 @@ export default connect(
     onUpdateStoryUploadProgress: ({
       id, uploaderInstance, progress, file, complete,
     }) => {
+      actions.updateStoryPogress(dispatch);
       if (!complete) {
         dispatch(actions.updateStoryUploadProgress({
           id, uploaderInstance, progress, file, complete,

--- a/packages/story-group-composer/index.js
+++ b/packages/story-group-composer/index.js
@@ -152,18 +152,10 @@ export default connect(
     onUpdateStoryUploadProgress: ({
       id, uploaderInstance, progress, file, complete,
     }) => {
+      dispatch(actions.updateStoryUploadProgress({
+        id, uploaderInstance, progress, file, complete,
+      }));
       actions.updateStoryPogress(dispatch);
-      if (!complete) {
-        dispatch(actions.updateStoryUploadProgress({
-          id, uploaderInstance, progress, file, complete,
-        }));
-      } else {
-        setTimeout(() => {
-          dispatch(actions.updateStoryUploadProgress({
-            id, uploaderInstance, progress, file, complete,
-          }));
-        }, 500);
-      }
     },
     onMonitorUpdateProgress: updateUploadProgress => async ({ id, uploaderInstance, file }) => {
       const progressIterator = uploaderInstance.getProgressIterator();

--- a/packages/story-group-composer/reducer.js
+++ b/packages/story-group-composer/reducer.js
@@ -170,9 +170,7 @@ export default (state, action) => {
         ...state,
         storyGroup: {
           ...state.storyGroup,
-          stories: stories.map((filteredStory) => {
-            const story = clonedeep(filteredStory);
-
+          stories: clonedeep(stories).map((story) => {
             inProgress
               .filter(currentStory => story.uploadTrackingId === currentStory.id)
               .forEach(({ progress }) => {
@@ -383,7 +381,7 @@ export const actions = {
   }),
   updateStoryPogress: debounce(dispatch => dispatch({
     type: actionTypes.UPDATE_STORY_PROGRESS,
-  }), 200, { leading: false, trailing: true }),
+  }), 270, { leading: false, trailing: true }),
   updateStoryUploadProgress: ({
     id, uploaderInstance, progress, file, complete,
   }) => ({
@@ -431,6 +429,7 @@ export const actions = {
       file,
       stillGifUrl,
       contentType,
+
     },
   }),
   videoUploadProcessingStarted: ({


### PR DESCRIPTION
## Description

Handle batches of updates loading at the same time, and making the dom re-render and the ui non-interactive

## Context & Notes

I believe that this should fix the issues we are seeing around delayed interaction
We are batching updates to the ui, and processing as many as we can at the same time

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
