### PR TITLE
Track if a Publish user is on the Analyze + Publish bundle

### DIFF
--- a/packages/globalAccount/middleware.js
+++ b/packages/globalAccount/middleware.js
@@ -18,6 +18,8 @@ export default ({ dispatch, getState }) => next => (action) => {
       dispatch(analyticsActions.init(state.globalAccount._id, {
         name: state.appSidebar.user.name,
         email: state.globalAccount.email,
+        multiProductBundleName: state.globalAccount.isAnalyzePublishBundle
+          ? 'analyze_publish_eid_19' : null,
       }));
       break;
     default:

--- a/packages/globalAccount/middleware.test.js
+++ b/packages/globalAccount/middleware.test.js
@@ -34,6 +34,25 @@ describe('middleware', () => {
       .toHaveBeenCalledWith('foo1', {
         name: 'The Great Foo',
         email: 'foo@buffer.com',
+        multiProductBundleName: null,
       });
   });
+
+  it('it should send the bundle name information if the user is on an Analyze + Publish bundle', () => {
+    analyticsActions.init = jest.fn();
+    state.globalAccount.isAnalyzePublishBundle = true;
+
+    const action = {
+      type: `globalAccount_${fetchActions.FETCH_SUCCESS}`,
+    };
+
+    middleware(store)(next)(action);
+    expect(analyticsActions.init)
+      .toHaveBeenCalledWith('foo1', {
+        name: 'The Great Foo',
+        email: 'foo@buffer.com',
+        multiProductBundleName: 'analyze_publish_eid_19',
+      });
+  });
+
 });

--- a/packages/globalAccount/reducer.js
+++ b/packages/globalAccount/reducer.js
@@ -7,6 +7,7 @@ export default (state = {}, action) => {
         ...state,
         email: action.result.email,
         _id: action.result._id,
+        isAnalyzePublishBundle: action.result.isAnalyzePublishBundle,
       };
     default:
       return state;

--- a/packages/server/rpc/globalAccount/index.js
+++ b/packages/server/rpc/globalAccount/index.js
@@ -7,5 +7,18 @@ const getGlobalUser = accountId =>
 module.exports = method(
   'globalAccount',
   'fetch global account data',
-  async (_, req) => getGlobalUser(req.session.global.accountId),
+  async (_, req) => {
+    const user = await getGlobalUser(req.session.global.accountId);
+    try {
+      const organization = await authenticationService.getOrganization({
+        adminAccountId: req.session.global.accountId,
+      });
+      if (organization) {
+        user.isAnalyzePublishBundle = organization.metadata.account.isAnalyzePublishBundle;
+      }
+    } catch (e) {
+      console.log(e); // eslint-disable-line no-console
+    }
+    return user;
+  }
 );

--- a/packages/server/services/authenticationService.js
+++ b/packages/server/services/authenticationService.js
@@ -5,4 +5,5 @@ const client = process.env.AUTH_SVC_ADDR ? new RPCClient({ url: `${process.env.A
 
 module.exports = {
   getAccount: ({ accountId }) => client.call('getAccount', { _id: accountId }),
+  getOrganization: ({ adminAccountId }) => client.call('getOrganization', { adminAccountId }),
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

To be able to know if a given user on Publish is on the Analyze + Publish bundle experiment, we want to send `multiProductBundleName` with `analyze_publish_eid_19` to Segment.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
