### PR TITLE
PUB-2042 | Adding tracking for non conforming images (with aspect ratios not 9:16 or 16:9)

### DIFF
--- a/packages/analytics-middleware/transformers/publish/story.js
+++ b/packages/analytics-middleware/transformers/publish/story.js
@@ -93,6 +93,7 @@ dragged.propTypes = {
  * @param ctaVersion {string|null} What is the version number of the CTA? If setting the value for the first time, set to "1".
  * @param clientId {string|null} What was the unique identifier of the client the user was in when they uploaded a nonconforming image?
  * @param clientName {string|null} Which client was the user in when they uploaded a nonconforming image? IE, `publishIos`, `publishWeb`, `publishAndroid`.
+ * @param imageAspectRatio {string|null} The actual aspect ratio of the uploaded image.
  */
 export const nonConfirmingImageUploaded = ({
   storyGroupId = null,
@@ -109,6 +110,7 @@ export const nonConfirmingImageUploaded = ({
   ctaVersion = null,
   clientId = null,
   clientName = null,
+  imageAspectRatio = null,
 }) => {
   if (clientId === null && clientName === null) {
     notify('StoryNonConfirmingImageUploaded - clientName or clientId must be supplied');
@@ -128,6 +130,7 @@ export const nonConfirmingImageUploaded = ({
     ctaVersion,
     clientId,
     clientName,
+    imageAspectRatio,
   };
   return removeNullObjectKeys(nonConformingImageSegment);
 };
@@ -147,4 +150,5 @@ nonConfirmingImageUploaded.propTypes = {
   ctaVersion: PropTypes.string,
   clientId: PropTypes.string,
   clientName: PropTypes.string,
+  imageAspectRatio: PropTypes.string,
 };

--- a/packages/analytics-middleware/transformers/publish/story.js
+++ b/packages/analytics-middleware/transformers/publish/story.js
@@ -8,7 +8,7 @@ const notify = (...params) => {
 
 /**
  * removeNullObjectKeys
- * Function to remove null props from segment data object
+ * Function to remove null or undefined props from segment data object
  *
  * @param props {Object} Data you want to filter down to not null properties
  * @returns {Object} mapped object with null props filtered out
@@ -18,7 +18,7 @@ const removeNullObjectKeys = (data) => {
 
   if (data) {
     Object.keys(data)
-      .filter(key => data[key] !== null)
+      .filter(key => data[key] !== null && typeof data[key] !== 'undefined')
       .forEach((key) => {
         segmentData[key] = data[key];
       });
@@ -70,6 +70,81 @@ dragged.propTypes = {
   channel: PropTypes.string,
   channelId: PropTypes.string.isRequired,
   channelServiceId: PropTypes.string,
+  clientId: PropTypes.string,
+  clientName: PropTypes.string,
+};
+
+/**
+ * Story Nonconforming Image Uploaded
+ * When did the user upload an image to a story, where the image did not conform to the 9:16 ratio required by Instagram?
+ * https://github.com/bufferapp/tracking-plan/blob/master/tracking-plans/buffer-tracking-plan/events/product/publish/story-nonconforming-image-uploaded.yaml
+ *
+ * @param storyGroupId {string|null} The unique identifier for this story group in our production database.
+ * @param product {string} The product for which the story was created
+ * @param channel {string} The channel's service, ex. "facebook"
+ * @param channelId {string} The database id for the channel document
+ * @param channelServiceId {string} The service's own id for this channel
+ * @param scheduledAt {string|null} The time at which the reminder is scheduled to be sent.
+ * @param cta {string|null} Which call to action did the user click to get to the Story composer?
+ * @param ctaApp {string|null} Which product is the CTA located in? Examples would be either the product, like "publish" or "reply".
+ * @param ctaView {string|null} What app view is the CTA located in? Examples would be, "composer" or "analyticsOverview" for Publish.
+ * @param ctaLocation {string|null} {string} Where in the view is the CTA located? An example would be "menu" for the Pro trial CTA in Publish app shell menu.
+ * @param ctaButton {string|null} What is the name or action of the CTA? In many cases it makes sense to describe the intended result of the CTA, like `proTrial` or `publishPro`.
+ * @param ctaVersion {string|null} What is the version number of the CTA? If setting the value for the first time, set to "1".
+ * @param clientId {string|null} What was the unique identifier of the client the user was in when they uploaded a nonconforming image?
+ * @param clientName {string|null} Which client was the user in when they uploaded a nonconforming image? IE, `publishIos`, `publishWeb`, `publishAndroid`.
+ */
+export const nonConfirmingImageUploaded = ({
+  storyGroupId = null,
+  product = null,
+  channel = null,
+  channelId = null,
+  channelServiceId = null,
+  scheduledAt = null,
+  cta = null,
+  ctaApp = null,
+  ctaView = null,
+  ctaLocation = null,
+  ctaButton = null,
+  ctaVersion = null,
+  clientId = null,
+  clientName = null,
+}) => {
+  if (clientId === null && clientName === null) {
+    notify('StoryNonConfirmingImageUploaded - clientName or clientId must be supplied');
+  }
+  const nonConformingImageSegment = {
+    storyGroupId,
+    product,
+    channel,
+    channelId,
+    channelServiceId,
+    scheduledAt,
+    cta,
+    ctaApp,
+    ctaView,
+    ctaLocation,
+    ctaButton,
+    ctaVersion,
+    clientId,
+    clientName,
+  };
+  return removeNullObjectKeys(nonConformingImageSegment);
+};
+
+nonConfirmingImageUploaded.propTypes = {
+  storyGroupId: PropTypes.string,
+  product: PropTypes.string.isRequired,
+  channel: PropTypes.string.isRequired,
+  channelId: PropTypes.string.isRequired,
+  channelServiceId: PropTypes.string.isRequired,
+  scheduledAt: PropTypes.string,
+  cta: PropTypes.string,
+  ctaApp: PropTypes.string,
+  ctaView: PropTypes.string,
+  ctaLocation: PropTypes.string,
+  ctaButton: PropTypes.string,
+  ctaVersion: PropTypes.string,
   clientId: PropTypes.string,
   clientName: PropTypes.string,
 };

--- a/packages/analytics-middleware/transformers/publish/story.js
+++ b/packages/analytics-middleware/transformers/publish/story.js
@@ -18,7 +18,7 @@ const removeNullObjectKeys = (data) => {
 
   if (data) {
     Object.keys(data)
-      .filter(key => data[key] !== null && typeof data[key] !== 'undefined')
+      .filter(key => data[key] != null)
       .forEach((key) => {
         segmentData[key] = data[key];
       });

--- a/packages/composer/composer/utils/TrackingUtils.js
+++ b/packages/composer/composer/utils/TrackingUtils.js
@@ -65,4 +65,4 @@ const getSegmentMetadata = ({
   shareType: trackingShareTypeMap.get(queueingType) || null,
 });
 
-export { getComposerSource, getSegmentMetadata };
+export { getComposerSource, getSegmentMetadata, formatShareDate };

--- a/packages/constants/index.js
+++ b/packages/constants/index.js
@@ -48,6 +48,7 @@ const STORIES_UPDATE_STORY_GROUP = 'publish-stories-composer-updateStoryGroup-1'
 const STORIES_COMPOSER_ADD_NOTE = 'publish-stories-composer-addNote-1';
 const STORIES_PREVIEW_QUEUE_ADD_NOTE = 'publish-stories-queuePreview-addNote-1';
 const STORIES_PREVIEW_COMPOSER_ADD_NOTE = 'publish-stories-composerPreview-addNote-1';
+const STORIES_IMAGE_ASPECT_RATIO_UPLOADED = 'publish-stories-composer-imageAspectRatioUploaded-1';
 
 const UploadTypes = keyMirror({
   LINK_THUMBNAIL: null,
@@ -127,6 +128,7 @@ module.exports = {
     STORIES_COMPOSER_ADD_NOTE,
     STORIES_PREVIEW_COMPOSER_ADD_NOTE,
     STORIES_PREVIEW_QUEUE_ADD_NOTE,
+    STORIES_IMAGE_ASPECT_RATIO_UPLOADED,
   },
   MediaTypes,
   UploadTypes,

--- a/packages/story-group-composer/index.js
+++ b/packages/story-group-composer/index.js
@@ -43,12 +43,12 @@ export default connect(
       dispatch(actions.handleUpdateStoryGroup({ scheduledAt, stories, storyGroupId }));
     },
     saveNote: ({ note, order }) => {
+      dispatch(actions.handleSaveStoryNote({ note, order }));
       dispatch(actions.trackNote({
         cta: SEGMENT_NAMES.STORIES_COMPOSER_ADD_NOTE,
         note,
         order,
       }));
-      dispatch(actions.handleSaveStoryNote({ note, order }));
     },
     onPreviewClick: ({
       stories, profileId, id, scheduledAt, serviceId,
@@ -66,11 +66,11 @@ export default connect(
         ...counts,
         ...ctaProperties,
       };
-      dispatch(analyticsActions.trackEvent('Story Group Previewed', metadata));
       dispatch(previewActions.handlePreviewClick({
         stories, profileId, id, scheduledAt,
       }));
       dispatch(actions.handlePreviewClick());
+      dispatch(analyticsActions.trackEvent('Story Group Previewed', metadata));
     },
     onClosePreviewClick: () => {
       dispatch(actions.handleClosePreviewClick());
@@ -192,6 +192,12 @@ export default connect(
         file,
         stillGifUrl,
         contentType,
+      }));
+      dispatch(actions.trackAspectRatio({
+        width,
+        height,
+        cta: SEGMENT_NAMES.STORIES_IMAGE_ASPECT_RATIO_UPLOADED,
+        id,
       }));
     },
     onDropCard: (cardSource, cardTarget, end = false) => {

--- a/packages/story-group-composer/middleware.js
+++ b/packages/story-group-composer/middleware.js
@@ -9,6 +9,7 @@ import { actions as analyticsActions } from '@bufferapp/publish-analytics-middle
 import { SEGMENT_NAMES, CLIENT_NAME } from '@bufferapp/publish-constants';
 import { dragged, nonConfirmingImageUploaded } from '@bufferapp/publish-analytics-middleware/transformers/publish/story';
 import getCtaProperties from '@bufferapp/publish-analytics-middleware/utils/CtaStrings';
+import { formatShareDate } from '@bufferapp/publish-composer/composer/utils/TrackingUtils';
 import getAspectRatio, { InstagramStoriesAspectRatios } from './utils/aspectRatioFinder';
 import { getSGTrackingData, getStory, getNoteTrackingData } from './utils/Tracking';
 import { actionTypes, actions } from './reducer';
@@ -29,8 +30,7 @@ const getTrackingDataForOpenComposer = ({ channel = {} }) => ({
   clientId: null,
 });
 
-const shouldTrackAspectRatio = ({ width, height }) => {
-  const aspectRatio = getAspectRatio(width, height);
+const shouldTrackAspectRatio = (aspectRatio) => {
   return InstagramStoriesAspectRatios.indexOf(aspectRatio) <= 0;
 };
 
@@ -213,7 +213,8 @@ export default ({ getState, dispatch }) => next => (action) => {
     case actionTypes.TRACK_NON_CONFORMING_IMAGE_UPLOADED_STORY: {
       if (selectedProfileId) {
         const currentProfile = state.profileSidebar && state.profileSidebar.selectedProfile;
-        if (currentProfile && shouldTrackAspectRatio(action.args)) {
+        const imageAspectRatio = getAspectRatio(action.args);
+        if (currentProfile && shouldTrackAspectRatio(imageAspectRatio)) {
           const ctaProperties = getCtaProperties(action.args.cta);
           const currentStoriesProfile = state.stories.byProfileId[selectedProfileId];
           const { editingPostId } = state.stories;
@@ -227,7 +228,8 @@ export default ({ getState, dispatch }) => next => (action) => {
             channelId: currentProfile.id,
             channelServiceId: currentProfile.serviceId,
             clientName: CLIENT_NAME,
-            scheduledAt,
+            scheduledAt: formatShareDate(scheduledAt),
+            imageAspectRatio,
             ...ctaProperties,
           });
 

--- a/packages/story-group-composer/middleware.js
+++ b/packages/story-group-composer/middleware.js
@@ -222,7 +222,7 @@ export default ({ getState, dispatch }) => next => (action) => {
           const { scheduledAt } = editingStoryGroup || {};
 
           const metadata = nonConfirmingImageUploaded({
-            storyGroupId: editingPostId,
+            storyGroupId: editingStoryGroup ? editingPostId : null,
             channel: currentProfile.service,
             channelId: currentProfile.id,
             channelServiceId: currentProfile.serviceId,

--- a/packages/story-group-composer/reducer.js
+++ b/packages/story-group-composer/reducer.js
@@ -2,6 +2,7 @@ import clonedeep from 'lodash.clonedeep';
 import keyWrapper from '@bufferapp/keywrapper';
 import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import debounce from 'lodash.debounce';
+import getAspectRatio, { InstagramStoriesAspectRatios }  from './utils/aspectRatioFinder';
 
 export const actionTypes = keyWrapper('STORY_GROUP_COMPOSER', {
   SAVE_STORY_GROUP: 0,
@@ -25,6 +26,7 @@ export const actionTypes = keyWrapper('STORY_GROUP_COMPOSER', {
   HIDE_ERRORS: 0,
   TRACK_DRAG_AND_DROP_STORY: 0,
   TRACK_NOTE: 0,
+  TRACK_NON_CONFORMING_IMAGE_UPLOADED_STORY: 0,
 });
 
 const newStory = () => clonedeep({
@@ -197,7 +199,7 @@ export default (state, action) => {
           {
             id,
             progress,
-          }
+          },
         ],
       };
     }
@@ -374,7 +376,9 @@ export const actions = {
   handleClosePreviewClick: () => ({
     type: actionTypes.CLOSE_PREVIEW,
   }),
-  setStoryGroup: ({ scheduledAt, stories, storyGroupId, isPastDue }) => ({
+  setStoryGroup: ({
+    scheduledAt, stories, storyGroupId, isPastDue,
+  }) => ({
     type: actionTypes.SET_STORY_GROUP,
     scheduledAt,
     stories,
@@ -501,5 +505,14 @@ export const actions = {
     cta,
     note,
     order,
+  }),
+  trackAspectRatio: ({ cta, width, height, id }) => ({
+    type: actionTypes.TRACK_NON_CONFORMING_IMAGE_UPLOADED_STORY,
+    args: {
+      width,
+      height,
+      cta,
+      id,
+    },
   }),
 };

--- a/packages/story-group-composer/utils/aspectRatioFinder.js
+++ b/packages/story-group-composer/utils/aspectRatioFinder.js
@@ -1,0 +1,24 @@
+const getDivisor = (width, height) => (height ? getDivisor(height, width % height) : width);
+
+const getAspectRatio = (width, height) => {
+  if (
+    Number.isNaN(width)
+    || Number.isNaN(height)
+    || typeof width === 'undefined'
+    || typeof height === 'undefined'
+    || width === height
+  ) {
+    return '1:1';
+  }
+
+  const divisor = getDivisor(width, height);
+
+  return `${width / divisor}:${height / divisor}`;
+};
+
+export const InstagramStoriesAspectRatios = [
+  '9:16',
+  '16:9',
+];
+
+export default getAspectRatio;

--- a/packages/story-group-composer/utils/aspectRatioFinder.js
+++ b/packages/story-group-composer/utils/aspectRatioFinder.js
@@ -1,6 +1,6 @@
-const getDivisor = (width, height) => (height ? getDivisor(height, width % height) : width);
+const getDivisor = ({ width, height }) => (height ? getDivisor({ width: height, height: width % height }) : width);
 
-const getAspectRatio = (width, height) => {
+const getAspectRatio = ({ width, height }) => {
   if (
     Number.isNaN(width)
     || Number.isNaN(height)
@@ -11,7 +11,7 @@ const getAspectRatio = (width, height) => {
     return '1:1';
   }
 
-  const divisor = getDivisor(width, height);
+  const divisor = getDivisor({ width, height });
 
   return `${width / divisor}:${height / divisor}`;
 };

--- a/packages/story-group-composer/utils/aspectRatioFinder.js
+++ b/packages/story-group-composer/utils/aspectRatioFinder.js
@@ -1,6 +1,7 @@
 const getDivisor = ({ width, height }) => (height ? getDivisor({ width: height, height: width % height }) : width);
 
-const getAspectRatio = ({ width, height }) => {
+const getAspectRatio = (params = {}) => {
+  const { width, height } = params;
   if (
     Number.isNaN(width)
     || Number.isNaN(height)

--- a/packages/story-group-composer/utils/aspectRatioFinder.test.js
+++ b/packages/story-group-composer/utils/aspectRatioFinder.test.js
@@ -7,15 +7,15 @@ describe('aspectRatioFinder', () => {
   });
 
   it('converts aspect ratio correctly for 1920, 1080 to 16:9', () => {
-    expect(getAspectRatio(1920, 1080)).toBe('16:9');
+    expect(getAspectRatio({ width: 1920, height: 1080 })).toBe('16:9');
   });
 
   it('converts aspect ratio correctly for 1080, 1920 to 9:16', () => {
-    expect(getAspectRatio(1080, 1920)).toBe('9:16');
+    expect(getAspectRatio({ width: 1080, height: 1920 })).toBe('9:16');
   });
 
   it('converts aspect ratio correctly for 100, 100 to 1:1', () => {
-    expect(getAspectRatio(100, 100)).toBe('1:1');
+    expect(getAspectRatio({ width: 100, height: 100 })).toBe('1:1');
   });
 
   it('converts aspect ratio correctly for undefined, undefined to 1:1', () => {
@@ -23,6 +23,6 @@ describe('aspectRatioFinder', () => {
   });
 
   it('converts aspect ratio correctly for 1, undefined to 1:1', () => {
-    expect(getAspectRatio(1)).toBe('1:1');
+    expect(getAspectRatio({ width: 1 })).toBe('1:1');
   });
 });

--- a/packages/story-group-composer/utils/aspectRatioFinder.test.js
+++ b/packages/story-group-composer/utils/aspectRatioFinder.test.js
@@ -1,0 +1,28 @@
+import getAspectRatio from './aspectRatioFinder';
+
+describe('aspectRatioFinder', () => {
+  it('has getAspectRatio', () => {
+    expect(getAspectRatio).toBeDefined();
+    expect(typeof getAspectRatio).toBe('function');
+  });
+
+  it('converts aspect ratio correctly for 1920, 1080 to 16:9', () => {
+    expect(getAspectRatio(1920, 1080)).toBe('16:9');
+  });
+
+  it('converts aspect ratio correctly for 1080, 1920 to 9:16', () => {
+    expect(getAspectRatio(1080, 1920)).toBe('9:16');
+  });
+
+  it('converts aspect ratio correctly for 100, 100 to 1:1', () => {
+    expect(getAspectRatio(100, 100)).toBe('1:1');
+  });
+
+  it('converts aspect ratio correctly for undefined, undefined to 1:1', () => {
+    expect(getAspectRatio()).toBe('1:1');
+  });
+
+  it('converts aspect ratio correctly for 1, undefined to 1:1', () => {
+    expect(getAspectRatio(1)).toBe('1:1');
+  });
+});


### PR DESCRIPTION
## Description

PUB-2042 | Adding tracking for non conforming images (with aspect ratios not 9:16 or 16:9)

Adding tracking for segment.io for when composer uploads an image, to check whether users images are already in the expected aspect ratio or not.

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
