### PR TITLE
Add LinkedIn banner for new permissions

### DIFF
--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -89,4 +89,5 @@ module.exports = userData => ({
   showReturnToClassic: userData.has_np_app_switcher,
   helpScoutConfig: userData.helpscout_beacon_params,
   isBusinessTeamMember: userData.is_business_team_member,
+  hasLinkedinProfiles: userData.has_linkedin_profiles,
 });

--- a/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
+++ b/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
@@ -25,7 +25,7 @@ class TemporaryDashboardBanner extends React.Component {
 
   render () {
     const { hidden } = this.state;
-    const { enabledApplicationModes } = this.props;
+    const { enabledApplicationModes, hasLinkedinProfiles } = this.props;
 
     if (!enabledApplicationModes) {
       return null;
@@ -34,17 +34,30 @@ class TemporaryDashboardBanner extends React.Component {
     const temporaryDashboard =
       this.getEnabledApplicationMode(dashboardBanner, enabledApplicationModes);
 
-    if (!temporaryDashboard) {
+    const shouldShowBanner = temporaryDashboard || hasLinkedinProfiles;
+
+    if (!shouldShowBanner) {
       return null;
     }
 
     return (
       <div style={getContainerStyle(hidden)}>
-        <Banner
-          themeColor="orange"
-          customHTML={{ __html: temporaryDashboard.content }}
-          onCloseBanner={() => this.setState({ hidden: true })}
-        />
+        {temporaryDashboard
+        && (
+          <Banner
+            themeColor="orange"
+            customHTML={{ __html: temporaryDashboard.content }}
+            onCloseBanner={() => this.setState({ hidden: true })}
+          />
+        )}
+        {hasLinkedinProfiles
+        && (
+          <Banner
+            themeColor="orange"
+            customHTML={{ __html: 'Due to a permissions update from LinkedIn, we’ll need to reconnect your account. Please take a moment to <a href="https://buffer.com/manage">reconnect</a> now.' }}
+            onCloseBanner={() => this.setState({ hidden: true })}
+          />
+        )}
       </div>
     );
   }
@@ -56,10 +69,12 @@ TemporaryDashboardBanner.propTypes = {
       PropTypes.string,
     ),
   ),
+  hasLinkedinProfiles: PropTypes.bool,
 };
 
 TemporaryDashboardBanner.defaultProps = {
   enabledApplicationModes: [],
+  hasLinkedinProfiles: false,
 };
 
 export default TemporaryDashboardBanner;

--- a/packages/temporary-banner/index.js
+++ b/packages/temporary-banner/index.js
@@ -5,5 +5,6 @@ import TemporaryDashboardBanner from './components/TemporaryDashboardBanner';
 export default connect(
   state => ({
     enabledApplicationModes: state.queue.enabledApplicationModes,
+    hasLinkedinProfiles: state.appSidebar.user.hasLinkedinProfiles,
   }),
 )(TemporaryDashboardBanner);


### PR DESCRIPTION
## Description
This is a temporary and hacky solution to show a banner to the users who have LI profiles. 

Related ticket: https://buffer.atlassian.net/browse/PUB-1996.

I'll add a JIRA ticket to remove it in 2 weeks.

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
