### PR TITLE
Revert "Revert "[PUB-2085] Open payment modal in Premium trialist banner CTA""

### DIFF
--- a/packages/analytics-middleware/utils/CtaStrings.test.js
+++ b/packages/analytics-middleware/utils/CtaStrings.test.js
@@ -3,16 +3,16 @@ import getCtaProperties from './CtaStrings';
 
 describe('CtaStrings Utils', () => {
   describe('returns correct cta properties', () => {
-    it('returns plans open modal cta properties', () => {
+    it('returns app shell pro trial cta properties', () => {
       const expectedProperties = {
-        cta: SEGMENT_NAMES.PLANS_OPEN_MODAL,
+        cta: SEGMENT_NAMES.APP_SHELL_PRO_TRIAL,
         ctaApp: 'publish',
-        ctaView: 'plans',
-        ctaLocation: 'subscribeButton',
-        ctaButton: 'openSwithPlansModal',
+        ctaView: 'appShell',
+        ctaLocation: 'menu',
+        ctaButton: 'proTrial',
         ctaVersion: '1',
       };
-      const properties = getCtaProperties(SEGMENT_NAMES.PLANS_OPEN_MODAL);
+      const properties = getCtaProperties(SEGMENT_NAMES.APP_SHELL_PRO_TRIAL);
       expect(properties).toEqual(expectedProperties);
     });
     it('returns only cta if cta string doesnt meet validation', () => {

--- a/packages/constants/index.js
+++ b/packages/constants/index.js
@@ -19,6 +19,9 @@ const ANALYTICS_OVERVIEW_SBP_TRIAL = 'publish-analyticsOverview-trialCard-sbpTri
 const ANALYTICS_OVERVIEW_BUSINESS_UPGRADE = 'publish-analyticsOverview-upgradeCard-businessUpgrade-1';
 const APP_SHELL_PRO_TRIAL = 'publish-appShell-menu-proTrial-1';
 const APP_SHELL_PRO_UPGRADE = 'publish-appShell-menu-proUpgrade-1';
+const CTA_BANNER_PREMIUM_UPGRADE = 'publish-app-ctaBanner-premiumUpgrade-1';
+const CTA_BANNER_SMALL_UPGRADE = 'publish-app-ctaBanner-smallUpgrade-1';
+const CTA_BANNER_PRO_UPGRADE = 'publish-app-ctaBanner-proUpgrade-1';
 const DRAFTS_SBP_TRIAL = 'publish-drafts-trialCard-sbpTrial-1';
 const DRAFTS_BUSINESS_UPGRADE = 'publish-drafts-upgradeCard-businessUpgrade-1';
 const EXPIRED_TRIAL_PRO_UPGRADE = 'publish-app-expiredTrialModal-proUpgrade-1';
@@ -40,7 +43,6 @@ const PLANS_PREMIUM_UPGRADE = 'publish-plans-switchPlansModal-premiumUpgrade-1';
 const PLANS_PREMIUM_DOWNGRADE = 'publish-plans-switchPlansModal-premiumDowngrade-1';
 const PLANS_SMALL_UPGRADE = 'publish-plans-switchPlansModal-smallUpgrade-1';
 const PLANS_SMALL_DOWNGRADE = 'publish-plans-switchPlansModal-smallDowngrade-1';
-const PLANS_OPEN_MODAL = 'publish-plans-subscribeButton-openSwithPlansModal-1';
 const STORIES_PROMO_MODAL = 'publish-storiesPromoModal-buttonBottom-Premium-1';
 const STORIES_PREVIEW_COMPOSER = 'publish-stories-composer-preview-1';
 const STORIES_PREVIEW_QUEUE = 'publish-stories-queue-preview-1';
@@ -115,6 +117,9 @@ module.exports = {
     ANALYTICS_OVERVIEW_BUSINESS_UPGRADE,
     APP_SHELL_PRO_TRIAL,
     APP_SHELL_PRO_UPGRADE,
+    CTA_BANNER_PREMIUM_UPGRADE,
+    CTA_BANNER_SMALL_UPGRADE,
+    CTA_BANNER_PRO_UPGRADE,
     DRAFTS_SBP_TRIAL,
     DRAFTS_BUSINESS_UPGRADE,
     EXPIRED_TRIAL_PRO_UPGRADE,
@@ -133,7 +138,6 @@ module.exports = {
     PLANS_PREMIUM_DOWNGRADE,
     PLANS_SMALL_UPGRADE,
     PLANS_SMALL_DOWNGRADE,
-    PLANS_OPEN_MODAL,
     STORIES_PROMO_MODAL,
     STORIES_PREVIEW_COMPOSER,
     STORIES_PREVIEW_QUEUE,

--- a/packages/cta-banner/index.test.js
+++ b/packages/cta-banner/index.test.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { Button } from '@bufferapp/ui';
+import translations from '@bufferapp/publish-i18n/translations/en-us.json';
+import CTABanner, {
+  reducer,
+  actions,
+  actionTypes,
+  middleware,
+} from './index';
+import BillingUpdateCTABanner from './components/BillingUpgradeCTABanner';
+
+describe('CtaBanner', () => {
+  describe('Component', () => {
+    let store;
+
+    beforeEach(() => {
+      const storeFake = state => ({
+        default: () => {},
+        subscribe: () => {},
+        dispatch: jest.fn(),
+        getState: () => ({ ...state }),
+      });
+
+      store = storeFake({
+        appSidebar: {
+          user: {
+            trial: {
+              onTrial: true, // user has to be on a trial for the Banner to be displayed
+            },
+            plan: 'premium_business',
+          },
+        },
+        ctaBanner: {
+          profileCount: 1,
+        },
+        i18n: {
+          translations: {
+            'billing-upgrade-cta-banner': translations['billing-upgrade-cta-banner'],
+          },
+        },
+        productFeatures: {
+          planName: 'business',
+          features: {},
+        },
+      });
+    });
+
+    it('renders', () => {
+      const wrapper = mount(
+        <Provider store={store}>
+          <CTABanner />
+        </Provider>,
+      );
+      expect(wrapper.find(BillingUpdateCTABanner).length)
+        .toBe(1);
+      wrapper.unmount();
+    });
+
+    it('dispatches a handleStartSubscription action when user clicks on start subscription', () => {
+      const wrapper = mount(
+        <Provider store={store}>
+          <CTABanner />
+        </Provider>,
+      );
+
+      // User clicks to start subscription in the trial banner
+      wrapper.find(BillingUpdateCTABanner).find(Button).at(0)
+        .simulate('click');
+
+      expect(store.dispatch).toHaveBeenCalledWith(actions.handleStartSubscription());
+      wrapper.unmount();
+    });
+  });
+
+  it('exports reducer', () => {
+    expect(reducer)
+      .toBeDefined();
+  });
+
+  it('exports actions', () => {
+    expect(actions)
+      .toBeDefined();
+  });
+
+  it('exports actionTypes', () => {
+    expect(actionTypes)
+      .toBeDefined();
+  });
+
+  it('exports middleware', () => {
+    expect(middleware)
+      .toBeDefined();
+  });
+});

--- a/packages/cta-banner/middleware.js
+++ b/packages/cta-banner/middleware.js
@@ -8,10 +8,14 @@ export default ({ getState, dispatch }) => next => (action) => { // eslint-disab
 
   switch (action.type) {
     case actionTypes.START_SUBSCRIPTION:
-      if (user && user.is_business_user) {
+      if (user && user.plan === 'premium_business') {
+        dispatch(modalsActions.showSwitchPlanModal({ source: 'cta_banner_upgrade_premium', plan: 'premium_business' }));
+      } else if (user && user.plan === 'small') {
+        dispatch(modalsActions.showSwitchPlanModal({ source: 'cta_banner_upgrade_small', plan: 'small' }));
+      } else if (user && user.is_business_user) {
         openBillingWindow();
       } else {
-        dispatch(modalsActions.showSwitchPlanModal({ source: 'cta_banner_upgrade', plan: 'pro' }));
+        dispatch(modalsActions.showSwitchPlanModal({ source: 'cta_banner_upgrade_pro', plan: 'pro' }));
       }
       break;
     default:

--- a/packages/cta-banner/middleware.test.js
+++ b/packages/cta-banner/middleware.test.js
@@ -1,0 +1,87 @@
+import { actionTypes as modalActionTypes } from '@bufferapp/publish-modals/reducer';
+import middleware from './middleware';
+import { actionTypes } from './reducer';
+
+describe('middleware', () => {
+  const next = jest.fn();
+
+  it('exports middleware', () => {
+    expect(middleware)
+      .toBeDefined();
+  });
+
+  it('opens Premium Switch Plan Modal when Premium Trialist START_SUBSCRIPTION', () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        appSidebar: {
+          user: {
+            plan: 'premium_business',
+          },
+        },
+      }),
+    };
+    const action = {
+      type: actionTypes.START_SUBSCRIPTION,
+    };
+    middleware(store)(next)(action);
+    expect(next)
+      .toBeCalledWith(action);
+    expect(store.dispatch)
+      .toBeCalledWith({
+        type: modalActionTypes.SHOW_SWITCH_PLAN_MODAL,
+        source: 'cta_banner_upgrade_premium',
+        plan: 'premium_business',
+      });
+  });
+
+  it('opens small Switch Plan Modal when Small Business Trialist START_SUBSCRIPTION', () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        appSidebar: {
+          user: {
+            plan: 'small',
+          },
+        },
+      }),
+    };
+    const action = {
+      type: actionTypes.START_SUBSCRIPTION,
+    };
+    middleware(store)(next)(action);
+    expect(next)
+      .toBeCalledWith(action);
+    expect(store.dispatch)
+      .toBeCalledWith({
+        type: modalActionTypes.SHOW_SWITCH_PLAN_MODAL,
+        source: 'cta_banner_upgrade_small',
+        plan: 'small',
+      });
+  });
+
+  it('opens pro Switch Plan Modal when Pro Trialist START_SUBSCRIPTION', () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        appSidebar: {
+          user: {
+            plan: 'pro',
+          },
+        },
+      }),
+    };
+    const action = {
+      type: actionTypes.START_SUBSCRIPTION,
+    };
+    middleware(store)(next)(action);
+    expect(next)
+      .toBeCalledWith(action);
+    expect(store.dispatch)
+      .toBeCalledWith({
+        type: modalActionTypes.SHOW_SWITCH_PLAN_MODAL,
+        source: 'cta_banner_upgrade_pro',
+        plan: 'pro',
+      });
+  });
+});

--- a/packages/cta-banner/reducer.test.js
+++ b/packages/cta-banner/reducer.test.js
@@ -1,0 +1,51 @@
+import deepFreeze from 'deep-freeze';
+import reducer, { actions, initialState, actionTypes } from './reducer';
+
+describe('reducer', () => {
+  // Tests the default case in the reducer switch statement
+  it('should initialize default state', () => {
+    const action = {
+      type: '',
+    };
+    // Protects state and actions from mutation
+    deepFreeze(initialState);
+    deepFreeze(action);
+
+    // When state is undefined, it's supposed to return initial state
+    expect(reducer(undefined, action))
+      .toEqual(initialState);
+  });
+
+  it('handles user_FETCH_SUCCESS action type and updates profileCount', () => {
+    const stateBefore = {
+      ...initialState,
+      profileCount: 0,
+    };
+    const stateAfter = {
+      ...initialState,
+      profileCount: 2,
+    };
+    const action = {
+      type: 'user_FETCH_SUCCESS',
+      result: {
+        profileCount: 2,
+      },
+    };
+
+    deepFreeze(stateBefore);
+    deepFreeze(action);
+
+    expect(reducer(stateBefore, action))
+      .toEqual(stateAfter);
+  });
+
+  // Test action creators:
+  describe('action creators', () => {
+    it('creates a START_SUBSCRIPTION action', () => {
+      const expectedAction = {
+        type: actionTypes.START_SUBSCRIPTION,
+      };
+      expect(actions.handleStartSubscription()).toEqual(expectedAction);
+    });
+  });
+});

--- a/packages/modals/middleware.js
+++ b/packages/modals/middleware.js
@@ -5,6 +5,10 @@ import {
 import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
 import { actionTypes as lockedProfileActionTypes } from '@bufferapp/publish-locked-profile-notification/reducer';
 import { actionTypes as thirdPartyActionTypes } from '@bufferapp/publish-thirdparty/reducer';
+import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
+import getCtaProperties from '@bufferapp/publish-analytics-middleware/utils/CtaStrings';
+import getCtaFromSource from '@bufferapp/publish-switch-plan-modal/utils/tracking';
+import { getPlanId } from '@bufferapp/publish-plans/utils/plans';
 import { actions, actionTypes } from './reducer';
 import {
   shouldShowSwitchPlanModal,
@@ -164,6 +168,21 @@ export default ({ dispatch, getState }) => next => (action) => {
         dispatch(actions.showSwitchPlanModal({ source: 'queue_limit', plan: 'pro' }));
       }
       break;
+
+    case actionTypes.SHOW_SWITCH_PLAN_MODAL: {
+      const { source, plan } = action;
+      const ctaName = getCtaFromSource(source);
+      const ctaProperties = getCtaProperties(ctaName);
+
+      const metadata = {
+        planName: plan,
+        planId: getPlanId(plan),
+        ...ctaProperties,
+      };
+
+      dispatch(analyticsActions.trackEvent('Modal Payment Opened', metadata));
+      break;
+    }
     default:
       break;
   }

--- a/packages/modals/middleware.test.js
+++ b/packages/modals/middleware.test.js
@@ -7,6 +7,7 @@ import {
   actionTypes as thirdPartyActionTypes,
 } from '@bufferapp/publish-thirdparty';
 import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
+import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
 
 import middleware from './middleware';
 import {
@@ -202,6 +203,36 @@ describe('middleware', () => {
       .toBeCalledWith(action);
     expect(dispatch)
       .toBeCalledWith(nextAction);
+  });
+
+  it('tracks a Modal Payment Opened event when the payment modal opens', () => {
+    const next = jest.fn();
+    const dispatch = jest.fn();
+    analyticsActions.trackEvent = jest.fn();
+
+    const action = {
+      type: modalsActionTypes.SHOW_SWITCH_PLAN_MODAL,
+      plan: 'premium_business',
+      source: 'cta_banner_upgrade_premium',
+    };
+
+    const expectedMetadata = {
+      cta: 'publish-app-ctaBanner-premiumUpgrade-1',
+      ctaApp: 'publish',
+      ctaButton: 'premiumUpgrade',
+      ctaLocation: 'ctaBanner',
+      ctaVersion: '1',
+      ctaView: 'app',
+      planId: '9',
+      planName: 'premium_business',
+    };
+    middleware({ dispatch })(next)(action);
+
+    expect(next)
+      .toBeCalledWith(action);
+
+    expect(analyticsActions.trackEvent)
+      .toBeCalledWith('Modal Payment Opened', expectedMetadata);
   });
 
   it('should ignore other actions', () => {

--- a/packages/plans/index.js
+++ b/packages/plans/index.js
@@ -3,11 +3,7 @@ import { push } from 'connected-react-router';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
 import { generateProfilePageRoute } from '@bufferapp/publish-routes';
 import { actions as profileSidebarActions } from '@bufferapp/publish-profile-sidebar/reducer';
-import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
-import { SEGMENT_NAMES } from '@bufferapp/publish-constants';
-import getCtaProperties from '@bufferapp/publish-analytics-middleware/utils/CtaStrings';
 import Plans from './components/Plans';
-import { getPlanId } from './utils/plans';
 
 import { actions } from './reducer';
 
@@ -27,16 +23,9 @@ export default connect(
       dispatch(actions.setSelectedPlan({ selectedPlan }));
     },
     onChoosePlanClick: ({ source, plan, soloPlanSelected }) => {
-      const ctaProperties = getCtaProperties(SEGMENT_NAMES.PLANS_OPEN_MODAL);
       if (plan === 'premium_business' && soloPlanSelected) {
         plan = 'solo_premium_business';
       }
-      const metadata = {
-        planName: plan,
-        planId: getPlanId(plan),
-        ...ctaProperties,
-      };
-      dispatch(analyticsActions.trackEvent('Modal Payment Opened', metadata));
       dispatch(modalsActions.showSwitchPlanModal({ source, plan }));
     },
     onBackToDashboardClick: ({ selectedProfileId, profiles }) => {

--- a/packages/server/rpc/switchPlan/index.js
+++ b/packages/server/rpc/switchPlan/index.js
@@ -1,12 +1,12 @@
 const { method, createError } = require('@bufferapp/buffer-rpc');
 const rp = require('request-promise');
 
-const getCtaFromSource = require('@bufferapp/publish-switch-plan-modal/utils/tracking');
-
 module.exports = method(
   'switchPlan',
   'switch user plan',
-  async ({ cycle, paymentMethodId, source, plan }, { session }) => {
+  async ({
+    cycle, paymentMethodId, source, plan,
+  }, { session }) => {
     let result;
     try {
       result = await rp({
@@ -17,7 +17,7 @@ module.exports = method(
         form: {
           cycle,
           payment_method_id: paymentMethodId,
-          cta: getCtaFromSource(source),
+          cta: source,
           access_token: session.publish.accessToken,
           product: 'publish',
           plan,

--- a/packages/server/rpc/switchPlan/index.js
+++ b/packages/server/rpc/switchPlan/index.js
@@ -1,28 +1,7 @@
 const { method, createError } = require('@bufferapp/buffer-rpc');
 const rp = require('request-promise');
 
-const { SEGMENT_NAMES } = require('@bufferapp/publish-constants');
-
-const sourceCtaMap = new Map([
-  ['app_shell', SEGMENT_NAMES.APP_SHELL_PRO_UPGRADE],
-  ['app_header', SEGMENT_NAMES.HEADER_PRO_UPGRADE],
-  ['queue_limit', SEGMENT_NAMES.QUEUE_LIMIT_PRO_UPGRADE],
-  ['profile_limit', SEGMENT_NAMES.PROFILE_LIMIT_PRO_UPGRADE],
-  ['pinterest', SEGMENT_NAMES.PINTEREST_PRO_UPGRADE],
-  ['org_admin', SEGMENT_NAMES.PLAN_OVERVIEW_PRO_UPGRADE],
-  ['locked_profile', SEGMENT_NAMES.LOCKED_PROFILE_PRO_UPGRADE],
-  ['pro_trial_expired', SEGMENT_NAMES.EXPIRED_TRIAL_PRO_UPGRADE],
-  ['b4b_trial_expired', SEGMENT_NAMES.EXPIRED_TRIAL_BUSINESS_UPGRADE],
-  ['plans_pro_upgrade', SEGMENT_NAMES.PLANS_PRO_UPGRADE],
-  ['plans_pro_downgrade', SEGMENT_NAMES.PLANS_PRO_DOWNGRADE],
-  ['plans_premium_upgrade', SEGMENT_NAMES.PLANS_PREMIUM_UPGRADE],
-  ['plans_premium_downgrade', SEGMENT_NAMES.PLANS_PREMIUM_DOWNGRADE],
-  ['plans_small_upgrade', SEGMENT_NAMES.PLANS_SMALL_UPGRADE],
-  ['plans_small_downgrade', SEGMENT_NAMES.PLANS_SMALL_DOWNGRADE],
-]);
-
-const getCtaFromSource = source =>
-  sourceCtaMap.get(source) || null;
+const getCtaFromSource = require('@bufferapp/publish-switch-plan-modal/utils/tracking');
 
 module.exports = method(
   'switchPlan',

--- a/packages/server/rpc/switchPlan/index.js
+++ b/packages/server/rpc/switchPlan/index.js
@@ -5,7 +5,7 @@ module.exports = method(
   'switchPlan',
   'switch user plan',
   async ({
-    cycle, paymentMethodId, source, plan,
+    cycle, paymentMethodId, cta, plan,
   }, { session }) => {
     let result;
     try {
@@ -17,7 +17,7 @@ module.exports = method(
         form: {
           cycle,
           payment_method_id: paymentMethodId,
-          cta: source,
+          cta,
           access_token: session.publish.accessToken,
           product: 'publish',
           plan,

--- a/packages/server/rpc/switchPlan/test.js
+++ b/packages/server/rpc/switchPlan/test.js
@@ -2,9 +2,7 @@
 jest.mock('micro-rpc-client');
 jest.mock('request-promise');
 import rp from 'request-promise';
-import RPCEndpoint from './';
-
-import { SEGMENT_NAMES } from '@bufferapp/publish-constants';
+import RPCEndpoint from '.';
 
 const accessToken = 'AN ACCESS TOKEN';
 const session = {
@@ -37,13 +35,7 @@ describe('rpc/switchPlan', () => {
   it('it sends the correct cta for specific upgrade paths', () => {
     rp.mockReturnValueOnce(Promise.resolve({}));
     switchPlan('queue_limit');
-    expect(rp.mock.calls[rp.mock.calls.length - 1][0].form.cta).toBe(SEGMENT_NAMES.QUEUE_LIMIT_PRO_UPGRADE);
-  });
-
-  it('it sends null for empty sources', () => {
-    rp.mockReturnValueOnce(Promise.resolve({}));
-    switchPlan();
-    expect(rp.mock.calls[rp.mock.calls.length - 1][0].form.cta).toBe(null);
+    expect(rp.mock.calls[rp.mock.calls.length - 1][0].form.cta).toBe('queue_limit');
   });
 
   it('an error response gets returned too', () => {

--- a/packages/server/rpc/switchPlan/test.js
+++ b/packages/server/rpc/switchPlan/test.js
@@ -11,11 +11,11 @@ const session = {
   },
 };
 
-const switchPlan = source =>
+const switchPlan = cta =>
   RPCEndpoint.fn({
     cycle: 'year',
     paymentMethodId: 'mock payment method id',
-    source,
+    cta,
   }, { session });
 
 describe('rpc/switchPlan', () => {

--- a/packages/stripe/middleware.js
+++ b/packages/stripe/middleware.js
@@ -1,6 +1,7 @@
 import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { actions as notification } from '@bufferapp/notifications';
 import { actions as asyncDataFetchActions, actionTypes as asyncDataFetchActionTypes } from '@bufferapp/async-data-fetch';
+import getCtaFromSource from '@bufferapp/publish-switch-plan-modal/utils/tracking';
 import { actions, actionTypes } from './reducer';
 
 export default ({ dispatch }) => next => (action) => {
@@ -13,7 +14,7 @@ export default ({ dispatch }) => next => (action) => {
         }),
       );
       break;
-    case actionTypes.HANDLE_SETUP_CARD_REQUEST:
+    case actionTypes.HANDLE_SETUP_CARD_REQUEST: {
       const {
         stripe,
         setupIntentClientSecret,
@@ -41,6 +42,7 @@ export default ({ dispatch }) => next => (action) => {
           }
         });
       break;
+    }
     case actionTypes.HANDLE_SETUP_CARD_SUCCESS: {
       const {
         cycle,
@@ -54,7 +56,7 @@ export default ({ dispatch }) => next => (action) => {
           name: 'switchPlan',
           args: {
             cycle,
-            source,
+            source: getCtaFromSource(source),
             plan,
             paymentMethodId,
           },

--- a/packages/stripe/middleware.js
+++ b/packages/stripe/middleware.js
@@ -56,7 +56,7 @@ export default ({ dispatch }) => next => (action) => {
           name: 'switchPlan',
           args: {
             cycle,
-            source: getCtaFromSource(source),
+            cta: getCtaFromSource(source),
             plan,
             paymentMethodId,
           },

--- a/packages/stripe/middleware.test.js
+++ b/packages/stripe/middleware.test.js
@@ -4,15 +4,15 @@ import {
   actions as asyncDataFetchActions,
   actionTypes as asyncDataFetchActionTypes,
 } from '@bufferapp/async-data-fetch';
+import { SEGMENT_NAMES } from '@bufferapp/publish-constants';
 
 import middleware from './middleware';
 import { actions, actionTypes } from './reducer';
 
 describe('middleware', () => {
-  const dispatch = jest.fn();
-  const next = jest.fn();
-
   it('should trigger a createSetupIntent request', () => {
+    const dispatch = jest.fn();
+    const next = jest.fn();
     const action = {
       type: actionTypes.CREATE_SETUP_INTENT_REQUEST,
     };
@@ -25,11 +25,13 @@ describe('middleware', () => {
   });
 
   it('should trigger a switchPlan on handleCardSetupSuccess', () => {
+    const dispatch = jest.fn();
+    const next = jest.fn();
     const action = {
       type: actionTypes.HANDLE_SETUP_CARD_SUCCESS,
       cycle: 'year',
       plan: 'premium_business',
-      source: 'publish',
+      source: 'queue_limit',
       paymentMethodId: 'pm_0FEigk47hwqlaZWUt3rg5WTQ',
     };
 
@@ -40,13 +42,15 @@ describe('middleware', () => {
         args: {
           cycle: action.cycle,
           plan: action.plan,
-          source: action.source,
+          source: SEGMENT_NAMES.QUEUE_LIMIT_PRO_UPGRADE,
           paymentMethodId: action.paymentMethodId,
         },
       }));
   });
 
   it('should trigger a createSetupIntent success', () => {
+    const dispatch = jest.fn();
+    const next = jest.fn();
     const action = {
       type: `createSetupIntent_${asyncDataFetchActionTypes.FETCH_SUCCESS}`,
       result: {

--- a/packages/stripe/middleware.test.js
+++ b/packages/stripe/middleware.test.js
@@ -42,7 +42,7 @@ describe('middleware', () => {
         args: {
           cycle: action.cycle,
           plan: action.plan,
-          source: SEGMENT_NAMES.QUEUE_LIMIT_PRO_UPGRADE,
+          cta: SEGMENT_NAMES.QUEUE_LIMIT_PRO_UPGRADE,
           paymentMethodId: action.paymentMethodId,
         },
       }));

--- a/packages/switch-plan-modal/components/PlanCycleSelect/index.jsx
+++ b/packages/switch-plan-modal/components/PlanCycleSelect/index.jsx
@@ -21,6 +21,7 @@ const getPlanCycleStyle = (selected, first) => ({
   background: selected ? '#2C4BFF' : 'white',
   border: selected ? '1px solid transparent' : '1px solid #ABB7FF',
   marginRight: first ? '25px' : 0,
+  transition: 'all 0.5s',
 });
 
 const checkmarkContainerStyle = {

--- a/packages/switch-plan-modal/components/SwitchPlanModal/index.jsx
+++ b/packages/switch-plan-modal/components/SwitchPlanModal/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Divider } from "@bufferapp/components";
+import { Divider } from '@bufferapp/components';
 import {
   Text,
   Modal,
@@ -90,7 +90,7 @@ class SwitchPlanModal extends React.Component {
         wide
         dismissible={dismissible}
       >
-        <div style={{ overflow: 'auto', height: 'auto' }}>
+        <div style={{ height: 'auto' }}>
           <div style={{ width: '600px', padding: '0px 20px 25px' }}>
             {isPro(plan) && <PlanDescriptors {...translations.proDescriptors} />}
             {isPremium(plan) && <PlanDescriptors {...translations.premiumDescriptors} />}
@@ -163,7 +163,6 @@ SwitchPlanModal.propTypes = {
   translations: PropTypes.object.isRequired, // eslint-disable-line
   cycle: PropTypes.string.isRequired,
   plan: PropTypes.string,
-  upgradePlan: PropTypes.func.isRequired,
   storeValue: PropTypes.func.isRequired,
   validating: PropTypes.bool.isRequired,
   selectCycle: PropTypes.func.isRequired,

--- a/packages/switch-plan-modal/index.js
+++ b/packages/switch-plan-modal/index.js
@@ -20,7 +20,6 @@ export default connect(
   }),
   dispatch => ({
     storeValue: (id, value) => dispatch(actions.storeValue(id, value)),
-    upgradePlan: () => dispatch(actions.upgrade()),
     selectCycle: cycle => dispatch(actions.selectCycle(cycle)),
     hideModal: () => dispatch(modalsActions.hideUpgradeModal()),
     cancelTrial: () => dispatch(actions.cancelTrial()),

--- a/packages/switch-plan-modal/middleware.js
+++ b/packages/switch-plan-modal/middleware.js
@@ -1,41 +1,18 @@
-import { trackAction } from '@bufferapp/publish-data-tracking';
 import {
   actionTypes as dataFetchActionTypes,
   actions as dataFetchActions,
 } from '@bufferapp/async-data-fetch';
 import { actions as notificationActions } from '@bufferapp/notifications';
-import { actionTypes as modalsActionTypes, actions as modalActions } from '@bufferapp/publish-modals/reducer';
+import { actions as modalActions } from '@bufferapp/publish-modals/reducer';
 import { actionTypes } from './reducer';
 
 export default ({ getState, dispatch }) => next => (action) => { // eslint-disable-line
-  const { source } = getState().switchPlanModal;
   next(action);
 
   switch (action.type) {
-    case actionTypes.UPGRADE: {
-      trackAction({
-        location: 'MODALS',
-        action: 'submit_upgrade_to_pro',
-        metadata: { source },
-      });
-      break;
-    }
-    case modalsActionTypes.SHOW_SWITCH_PLAN_MODAL: {
-      trackAction({
-        location: 'MODALS',
-        action: 'show_upgrade_to_pro',
-        metadata: { source: action.source },
-      });
-      break;
-    }
     case actionTypes.CANCEL_TRIAL: {
       dispatch(dataFetchActions.fetch({ name: 'cancelTrial' }));
       dispatch(modalActions.hideUpgradeModal());
-      trackAction({
-        location: 'MODALS',
-        action: 'cancel_expired_pro_trial',
-        metadata: { source },
-      });
       break;
     }
     case `cancelTrial_${dataFetchActionTypes.FETCH_FAIL}`: {
@@ -43,14 +20,6 @@ export default ({ getState, dispatch }) => next => (action) => { // eslint-disab
         notificationType: 'error',
         message: action.error,
       }));
-      break;
-    }
-    case modalsActionTypes.HIDE_SWITCH_PLAN_MODAL: {
-      trackAction({
-        location: 'MODALS',
-        action: 'hide_upgrade_to_pro',
-        metadata: { source },
-      });
       break;
     }
     default:

--- a/packages/switch-plan-modal/reducer.js
+++ b/packages/switch-plan-modal/reducer.js
@@ -4,7 +4,6 @@ import { actionTypes as stripeActionTypes } from '@bufferapp/stripe/reducer';
 
 export const actionTypes = keyWrapper('UPGRADE_MODAL', {
   STORE_VALUE: 0,
-  UPGRADE: 0,
   SELECT_CYCLE: 0,
   CANCEL_TRIAL: 0,
   CLEAR_CARD_INFO: 0,
@@ -76,9 +75,6 @@ export const actions = {
     type: actionTypes.STORE_VALUE,
     id,
     value,
-  }),
-  upgrade: () => ({
-    type: actionTypes.UPGRADE,
   }),
   selectCycle: cycle => ({
     type: actionTypes.SELECT_CYCLE,

--- a/packages/switch-plan-modal/utils/tracking.js
+++ b/packages/switch-plan-modal/utils/tracking.js
@@ -1,0 +1,26 @@
+const { SEGMENT_NAMES } = require('@bufferapp/publish-constants');
+
+const sourceCtaMap = new Map([
+  ['app_shell', SEGMENT_NAMES.APP_SHELL_PRO_UPGRADE],
+  ['app_header', SEGMENT_NAMES.HEADER_PRO_UPGRADE],
+  ['queue_limit', SEGMENT_NAMES.QUEUE_LIMIT_PRO_UPGRADE],
+  ['profile_limit', SEGMENT_NAMES.PROFILE_LIMIT_PRO_UPGRADE],
+  ['cta_banner_upgrade_premium', SEGMENT_NAMES.CTA_BANNER_PREMIUM_UPGRADE],
+  ['cta_banner_upgrade_small', SEGMENT_NAMES.CTA_BANNER_SMALL_UPGRADE],
+  ['cta_banner_upgrade_pro', SEGMENT_NAMES.CTA_BANNER_PRO_UPGRADE],
+  ['pinterest', SEGMENT_NAMES.PINTEREST_PRO_UPGRADE],
+  ['org_admin', SEGMENT_NAMES.PLAN_OVERVIEW_PRO_UPGRADE],
+  ['locked_profile', SEGMENT_NAMES.LOCKED_PROFILE_PRO_UPGRADE],
+  ['pro_trial_expired', SEGMENT_NAMES.EXPIRED_TRIAL_PRO_UPGRADE],
+  ['b4b_trial_expired', SEGMENT_NAMES.EXPIRED_TRIAL_BUSINESS_UPGRADE],
+  ['plans_pro_upgrade', SEGMENT_NAMES.PLANS_PRO_UPGRADE],
+  ['plans_pro_downgrade', SEGMENT_NAMES.PLANS_PRO_DOWNGRADE],
+  ['plans_premium_upgrade', SEGMENT_NAMES.PLANS_PREMIUM_UPGRADE],
+  ['plans_premium_downgrade', SEGMENT_NAMES.PLANS_PREMIUM_DOWNGRADE],
+  ['plans_small_upgrade', SEGMENT_NAMES.PLANS_SMALL_UPGRADE],
+  ['plans_small_downgrade', SEGMENT_NAMES.PLANS_SMALL_DOWNGRADE],
+]);
+
+const getCtaFromSource = source => sourceCtaMap.get(source) || null;
+
+module.exports = getCtaFromSource;

--- a/packages/switch-plan-modal/utils/tracking.js
+++ b/packages/switch-plan-modal/utils/tracking.js
@@ -23,4 +23,4 @@ const sourceCtaMap = new Map([
 
 const getCtaFromSource = source => sourceCtaMap.get(source) || null;
 
-module.exports = getCtaFromSource;
+export default getCtaFromSource;

--- a/packages/switch-plan-modal/utils/tracking.test.js
+++ b/packages/switch-plan-modal/utils/tracking.test.js
@@ -1,0 +1,11 @@
+import { SEGMENT_NAMES } from '@bufferapp/publish-constants';
+import getCtaFromSource from './tracking';
+
+describe('Switch Plan Tracking Utils', () => {
+  it('returns segment name that matches source', () => {
+    expect(getCtaFromSource('app_shell')).toEqual(SEGMENT_NAMES.APP_SHELL_PRO_UPGRADE);
+  });
+  it('returns null if there is no segment name that matches source', () => {
+    expect(getCtaFromSource('hello')).toEqual(null);
+  });
+});


### PR DESCRIPTION
Reverts bufferapp/buffer-publish#1027
Remove the import of switch-modal tracking utils from the switchModal rpc method, to avoid having to copy the package through the server.
Apply the parsing logic to stripe middleware instead, which fetches the switchModal rpc method.