### PR TITLE
Updating moment-timezone to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "micro-rpc-client": "0.1.4",
     "mini-css-extract-plugin": "^0.5.0",
     "moment": "2.22.2",
-    "moment-timezone": "0.5.13",
+    "moment-timezone": "^0.5.25",
     "object-path": "0.11.4",
     "postcss-calc": "5.2.0",
     "postcss-color-function": "2.0.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,7 +24,7 @@
     "micro": "9.3.3",
     "micro-rpc-client": "0.1.4",
     "moment": "2.22.2",
-    "moment-timezone": "0.5.23",
+    "moment-timezone": "^0.5.25",
     "multer": "^1.4.1",
     "node-dogstatsd": "0.0.6",
     "pusher": "1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11935,20 +11935,6 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
   integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
 
-moment-timezone@0.5.13:
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.13.tgz#99ce5c7d827262eb0f1f702044177f60745d7b90"
-  integrity sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=
-  dependencies:
-    moment ">= 2.9.0"
-
-moment-timezone@0.5.23:
-  version "0.5.23"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.23.tgz#7cbb00db2c14c71b19303cb47b0fb0a6d8651463"
-  integrity sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==
-  dependencies:
-    moment ">= 2.9.0"
-
 moment-timezone@^0.5.25:
   version "0.5.27"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.27.tgz#73adec8139b6fe30452e78f210f27b1f346b8877"


### PR DESCRIPTION
## Description

Updating moment-timezone to use the latest version from npm and updating to use the caret version number to support newer versions more automatically / systematically in future.

## Context & Notes

Had to run `yarn cache clean` to get this version to work with semantic versioning, this should be backwards compatible with previous changes.
