### PR TITLE
PUB-1709 | Adding fix for sent posts re-posting

### DIFF
--- a/packages/composer-popover/components/ComposerWrapper/index.jsx
+++ b/packages/composer-popover/components/ComposerWrapper/index.jsx
@@ -39,7 +39,10 @@ export default connect(
           options = {
             editMode: state.sent.editMode,
             sentPost: true,
-            post: state.sent.byProfileId[selectedProfileId].posts[postId],
+            post: {
+              ...state.sent.byProfileId[selectedProfileId].posts[postId],
+              scheduled_at: null,
+            },
           };
           break;
         case 'pastReminders':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

Removing scheduled_at times for sent posts, so that they can be rescheduled later.
https://buffer.atlassian.net/browse/PUB-1709

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
