### PR TITLE
make-cpu-request-limit-more-balanced

### DIFF
--- a/helm/buffer-publish.yaml
+++ b/helm/buffer-publish.yaml
@@ -19,7 +19,7 @@ resources:
     cpu: 1000m
     memory: 512Mi
   requests:
-    cpu: 100m
+    cpu: 500m
     memory: 50Mi
 extraMainContainerValues:
   livenessProbe:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
This PR should prevent all publish pods from being scheduled on the same node due to the low request. Then getting terminated because of the high usage and high limit.

## Context & Notes
It's intended to solve the kubelet issue when a node CPU is overloaded 

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
