### PR TITLE
Hide advance analytics tab if user has signed up after today

### DIFF
--- a/packages/profile-page/components/ProfilePage/index.jsx
+++ b/packages/profile-page/components/ProfilePage/index.jsx
@@ -75,6 +75,8 @@ const verifyTab = (
   isFreeUser,
   onChangeTab,
   hasStoriesFlip,
+  childTabId,
+  shouldHideAdvancedAnalytics
 ) => {
   let isInstagramProfile = false;
   let isBusinessAccount = false;
@@ -85,8 +87,16 @@ const verifyTab = (
     isBusinessAccount = selectedProfile.business;
     isManager = selectedProfile.isManager;
 
-    const validTabId =
-      getValidTab(tabId, isBusinessAccount, isInstagramProfile, isManager, isFreeUser, hasStoriesFlip);
+    const validTabId = getValidTab(
+      tabId,
+      isBusinessAccount,
+      isInstagramProfile,
+      isManager,
+      isFreeUser,
+      hasStoriesFlip,
+      childTabId,
+      shouldHideAdvancedAnalytics
+    );
 
     // if current tabId is not valid, redirect to the queue
     if (tabId !== validTabId) {
@@ -95,9 +105,28 @@ const verifyTab = (
   }
 };
 
-const TabContent = ({ tabId, profileId, childTabId, loadMore, selectedProfile, features, onChangeTab, hasStoriesFlip }) => {
+const TabContent = ({
+  tabId,
+  profileId,
+  childTabId,
+  loadMore,
+  selectedProfile,
+  features,
+  onChangeTab,
+  hasStoriesFlip,
+  shouldHideAdvancedAnalytics,
+}) => {
   // if current tabId is not valid, redirect to the queue
-  verifyTab(tabId, profileId, selectedProfile, features.isFreeUser(), onChangeTab, hasStoriesFlip);
+  verifyTab(
+    tabId,
+    profileId,
+    selectedProfile,
+    features.isFreeUser(),
+    onChangeTab,
+    hasStoriesFlip,
+    childTabId,
+    shouldHideAdvancedAnalytics
+  );
 
   switch (tabId) {
     case 'queue':
@@ -118,7 +147,13 @@ const TabContent = ({ tabId, profileId, childTabId, loadMore, selectedProfile, f
           return <Analytics />;
         case 'posts':
         default:
-          return <SentPosts profileId={profileId} tabId={tabId} loadMore={loadMore} />;
+          return (
+            <SentPosts
+              profileId={profileId}
+              tabId={tabId}
+              loadMore={loadMore}
+            />
+          );
       }
     case 'settings':
       switch (childTabId) {
@@ -150,6 +185,8 @@ TabContent.propTypes = {
     isManager: PropTypes.bool,
   }),
   features: PropTypes.object.isRequired, // eslint-disable-line
+  hasStoriesFlip: PropTypes.bool,
+  shouldHideAdvancedAnalytics: PropTypes.bool,
 };
 
 TabContent.defaultProps = {
@@ -157,6 +194,8 @@ TabContent.defaultProps = {
   childTabId: '',
   onChangeTab: () => {},
   selectedProfile: {},
+  hasStoriesFlip: false,
+  shouldHideAdvancedAnalytics: false,
 };
 
 function ProfilePage({
@@ -171,6 +210,7 @@ function ProfilePage({
   features,
   onChangeTab,
   hasStoriesFlip,
+  shouldHideAdvancedAnalytics,
 }) {
   const isQueueTab = tabId === 'queue' || tabId === 'stories';
   const isOtherPostsTab =
@@ -223,6 +263,7 @@ function ProfilePage({
               features={features}
               onChangeTab={onChangeTab}
               hasStoriesFlip={hasStoriesFlip}
+              shouldHideAdvancedAnalytics={shouldHideAdvancedAnalytics}
             />
             {loadingMore && (
               <div style={loadingAnimationStyle}>
@@ -256,6 +297,7 @@ ProfilePage.propTypes = {
   }),
   features: PropTypes.object.isRequired, // eslint-disable-line
   hasStoriesFlip: PropTypes.bool,
+  shouldHideAdvancedAnalytics: PropTypes.bool,
 };
 
 ProfilePage.defaultProps = {
@@ -266,6 +308,7 @@ ProfilePage.defaultProps = {
   onChangeTab: () => {},
   selectedProfile: null,
   hasStoriesFlip: false,
+  shouldHideAdvancedAnalytics: false,
 };
 
 export default WithFeatureLoader(ProfilePage);

--- a/packages/profile-page/index.js
+++ b/packages/profile-page/index.js
@@ -6,19 +6,21 @@ import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 import { actions } from '@bufferapp/publish-tabs';
 import ProfilePage from './components/ProfilePage';
 
-const requestName = tabId => ({
-  queue: 'queuedPosts',
-  drafts: 'draftPosts',
-  awaitingApproval: 'draftPosts',
-  pendingApproval: 'draftPosts',
-  grid: 'gridPosts',
-  analytics: 'sentPosts',
-  pastReminders: 'pastRemindersPosts',
-  stories: 'getStoryGroups',
-  default: 'queuedPosts',
-})[tabId];
+const requestName = tabId =>
+  ({
+    queue: 'queuedPosts',
+    drafts: 'draftPosts',
+    awaitingApproval: 'draftPosts',
+    pendingApproval: 'draftPosts',
+    grid: 'gridPosts',
+    analytics: 'sentPosts',
+    pastReminders: 'pastRemindersPosts',
+    stories: 'getStoryGroups',
+    default: 'queuedPosts',
+  }[tabId]);
 
-export const getRequestName = tabId => requestName(tabId) || requestName('default');
+export const getRequestName = tabId =>
+  requestName(tabId) || requestName('default');
 
 // default export = container
 export default hot(
@@ -28,10 +30,12 @@ export default hot(
         getProfilePageParams({ path: ownProps.history.location.pathname }) ||
         {};
       // With analytics, the reducer state name doesnt match the tabId
-      let reducerName = tabId === 'analytics' && (!childTabId || childTabId === 'posts')
-        ? 'sent'
-        : tabId;
-      if (tabId === 'awaitingApproval' || tabId === 'pendingApproval') reducerName = 'drafts';
+      let reducerName =
+        tabId === 'analytics' && (!childTabId || childTabId === 'posts')
+          ? 'sent'
+          : tabId;
+      if (tabId === 'awaitingApproval' || tabId === 'pendingApproval')
+        reducerName = 'drafts';
       if (
         state[reducerName] &&
         state[reducerName].byProfileId &&
@@ -48,17 +52,23 @@ export default hot(
           view: state[reducerName].byProfileId[profileId].tabId || null,
           isBusinessAccount: state.profileSidebar.selectedProfile.business,
           selectedProfile: state.profileSidebar.selectedProfile,
-          hasStoriesFlip: state.appSidebar.user.features ? state.appSidebar.user.features.includes('stories_groups') : false,
+          hasStoriesFlip: state.appSidebar.user.features
+            ? state.appSidebar.user.features.includes('stories_groups')
+            : false,
+          shouldHideAdvancedAnalytics:
+            state.appSidebar.user.shouldHideAdvancedAnalytics,
         };
       }
       return {};
     },
     dispatch => ({
       onChangeTab: (tabId, profileId) => {
-        dispatch(actions.selectTab({
-          tabId,
-          profileId,
-        }));
+        dispatch(
+          actions.selectTab({
+            tabId,
+            profileId,
+          })
+        );
       },
       onLoadMore: ({ profileId, page, tabId }) => {
         dispatch(
@@ -68,11 +78,13 @@ export default hot(
               profileId,
               page,
               isFetchingMore: true,
-              needsApproval: ['awaitingApproval', 'pendingApproval'].includes(tabId),
+              needsApproval: ['awaitingApproval', 'pendingApproval'].includes(
+                tabId
+              ),
             },
-          }),
+          })
         );
       },
-    }),
-  )(ProfilePage),
+    })
+  )(ProfilePage)
 );

--- a/packages/profile-page/index.js
+++ b/packages/profile-page/index.js
@@ -55,8 +55,9 @@ export default hot(
           hasStoriesFlip: state.appSidebar.user.features
             ? state.appSidebar.user.features.includes('stories_groups')
             : false,
-          shouldHideAdvancedAnalytics:
-            state.appSidebar.user.shouldHideAdvancedAnalytics,
+          shouldHideAdvancedAnalytics: state.profileSidebar.selectedProfile
+            ? state.profileSidebar.selectedProfile.shouldHideAdvancedAnalytics
+            : false,
         };
       }
       return {};

--- a/packages/sent/components/SentPosts/index.jsx
+++ b/packages/sent/components/SentPosts/index.jsx
@@ -62,6 +62,8 @@ const SentPosts = ({
   profileId,
   page,
   loadMore,
+  showAnalyzeBannerAfterFirstPost,
+  isAnalyzeCustomer,
 }) => {
   if (loading) {
     return (
@@ -76,9 +78,10 @@ const SentPosts = ({
   }
 
   if (total < 1) {
-    const title = isBusinessAccount || !features.isFreeUser() ?
-      'You haven’t published any posts with this account!' :
-      'You haven’t published any posts with this account in the past 30 days!';
+    const title =
+      isBusinessAccount || !features.isFreeUser()
+        ? 'You haven’t published any posts with this account!'
+        : 'You haven’t published any posts with this account in the past 30 days!';
     return (
       <Fragment>
         <EmptyState
@@ -95,9 +98,10 @@ const SentPosts = ({
     loadMore({ profileId, page, tabId });
   };
 
-  const header = isBusinessAccount || !features.isFreeUser() ?
-    'Your sent posts' :
-    'Your sent posts for the last 30 days';
+  const header =
+    isBusinessAccount || !features.isFreeUser()
+      ? 'Your sent posts'
+      : 'Your sent posts for the last 30 days';
   return (
     <ErrorBoundary>
       <div>
@@ -129,15 +133,13 @@ const SentPosts = ({
           isBusinessAccount={isBusinessAccount}
           isSent
           hasFirstCommentFlip={hasFirstCommentFlip}
+          showAnalyzeBannerAfterFirstPost={showAnalyzeBannerAfterFirstPost}
+          isAnalyzeCustomer={isAnalyzeCustomer}
         />
       </div>
       {moreToLoad && (
         <div style={loadMoreButtonStyle}>
-          <Button
-            type="primary"
-            label="Load More"
-            onClick={loadMorePosts}
-          />
+          <Button type="primary" label="Load More" onClick={loadMorePosts} />
         </div>
       )}
     </ErrorBoundary>
@@ -155,12 +157,14 @@ SentPosts.propTypes = {
       posts: PropTypes.arrayOf(
         PropTypes.shape({
           text: PropTypes.string,
-        }),
+        })
       ),
-    }),
+    })
   ),
   total: PropTypes.number,
   showComposer: PropTypes.bool,
+  showAnalyzeBannerAfterFirstPost: PropTypes.bool,
+  isAnalyzeCustomer: PropTypes.bool,
   editMode: PropTypes.bool,
   onComposerCreateSuccess: PropTypes.func.isRequired,
   onEditClick: PropTypes.func.isRequired,
@@ -182,6 +186,8 @@ SentPosts.defaultProps = {
   postLists: [],
   total: 0,
   showComposer: false,
+  showAnalyzeBannerAfterFirstPost: false,
+  isAnalyzeCustomer: false,
   editMode: false,
   isManager: true,
   isBusinessAccount: false,

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -6,20 +6,24 @@ import SentPosts from './components/SentPosts';
 
 const servicesWithCommentFeature = ['instagram'];
 
-const formatPostLists = (posts) => {
+const formatPostLists = posts => {
   const postLists = [];
   let day;
   let newList;
-  const orderedPosts = (posts && typeof posts === 'object') ?
-    Object.values(posts).sort((a, b) => b.due_at - a.due_at) : [];
+  const orderedPosts =
+    posts && typeof posts === 'object'
+      ? Object.values(posts).sort((a, b) => b.due_at - a.due_at)
+      : [];
 
-  orderedPosts.forEach((post) => {
-    post.hasCommentEnabled = servicesWithCommentFeature.indexOf(post.profile_service) !== -1;
+  orderedPosts.forEach(post => {
+    post.hasCommentEnabled =
+      servicesWithCommentFeature.indexOf(post.profile_service) !== -1;
     if (post.day !== day) {
       day = post.day;
       newList = { listHeader: day, posts: [post] };
       postLists.push(newList);
-    } else { // if same day add to posts array of current list
+    } else {
+      // if same day add to posts array of current list
       newList.posts.push(post);
     }
   });
@@ -44,47 +48,62 @@ export default connect(
         editMode: state.sent.editMode,
         isManager: state.profileSidebar.selectedProfile.isManager,
         isBusinessAccount: state.profileSidebar.selectedProfile.business,
+        showAnalyzeBannerAfterFirstPost:
+          state.profileSidebar.selectedProfile.shouldHideAdvancedAnalytics,
         isLockedProfile: state.profileSidebar.isLockedProfile,
-        hasFirstCommentFlip: state.appSidebar.user.features ? state.appSidebar.user.features.includes('first_comment') : false,
+        isAnalyzeCustomer: state.appSidebar.user.isAnalyzeCustomer,
+        hasFirstCommentFlip: state.appSidebar.user.features
+          ? state.appSidebar.user.features.includes('first_comment')
+          : false,
       };
     }
     return {};
   },
   (dispatch, ownProps) => ({
     onShareAgainClick: ({ post }) => {
-      dispatch(actions.handleShareAgainClick({
-        post,
-        profileId: ownProps.profileId,
-      }));
+      dispatch(
+        actions.handleShareAgainClick({
+          post,
+          profileId: ownProps.profileId,
+        })
+      );
     },
     onComposerCreateSuccess: () => {
       dispatch(actions.handleComposerCreateSuccess());
     },
-    onImageClick: (post) => {
-      dispatch(actions.handleImageClick({
-        post: post.post,
-        profileId: ownProps.profileId,
-      }));
+    onImageClick: post => {
+      dispatch(
+        actions.handleImageClick({
+          post: post.post,
+          profileId: ownProps.profileId,
+        })
+      );
     },
-    onImageClose: (post) => {
-      dispatch(actions.handleImageClose({
-        post: post.post,
-        profileId: ownProps.profileId,
-      }));
+    onImageClose: post => {
+      dispatch(
+        actions.handleImageClose({
+          post: post.post,
+          profileId: ownProps.profileId,
+        })
+      );
     },
-    onImageClickNext: (post) => {
-      dispatch(actions.handleImageClickNext({
-        post: post.post,
-        profileId: ownProps.profileId,
-      }));
+    onImageClickNext: post => {
+      dispatch(
+        actions.handleImageClickNext({
+          post: post.post,
+          profileId: ownProps.profileId,
+        })
+      );
     },
-    onImageClickPrev: (post) => {
-      dispatch(actions.handleImageClickPrev({
-        post: post.post,
-        profileId: ownProps.profileId,
-      }));
+    onImageClickPrev: post => {
+      dispatch(
+        actions.handleImageClickPrev({
+          post: post.post,
+          profileId: ownProps.profileId,
+        })
+      );
     },
-  }),
+  })
 )(SentPosts);
 
 // export reducer, actions and action types

--- a/packages/server/parsers/src/profileParser.js
+++ b/packages/server/parsers/src/profileParser.js
@@ -37,6 +37,7 @@ module.exports = profile => ({
   isContributor: profile.is_contributor,
   isDisconnected: profile.oauth_broken,
   location: profile.location,
+  shouldHideAdvancedAnalytics: profile.should_hide_advanced_analytics,
   // Remove when publish stops importing Analyze components
   organizationId: profile.organization_id,
   username: profile.service_username,

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -102,5 +102,5 @@ module.exports = userData => ({
     userData.features.includes('instagram_user_tags') &&
     (userData.is_pro_premium_or_business_org_user || // this includes team members
       isOnEnterprisePlan(userData.plan)), // TO-DO: Add to api
-  shouldHideAdvancedAnalytics: userData.should_hide_advanced_analytics,
+  isAnalyzeCustomer: userData.is_analyze_customer,
 });

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -1,10 +1,13 @@
-const hasProTrialExpired = trials => trials.some(trial => trial.is_awesome && trial.status === 'expired');
+const hasProTrialExpired = trials =>
+  trials.some(trial => trial.is_awesome && trial.status === 'expired');
 
-const isOnBusinessPlan = trialPlan => ['business', 'agency', 'small', 'premium_business'].some(
-  plan => plan === trialPlan,
-);
+const isOnBusinessPlan = trialPlan =>
+  ['business', 'agency', 'small', 'premium_business'].some(
+    plan => plan === trialPlan
+  );
 
-const isOnEnterprisePlan = plan => ['enterprise'].some(enterprisePlan => plan === enterprisePlan);
+const isOnEnterprisePlan = plan =>
+  ['enterprise'].some(enterprisePlan => plan === enterprisePlan);
 
 module.exports = userData => ({
   id: userData.id,
@@ -23,7 +26,7 @@ module.exports = userData => ({
   new_contributions_emails_subscribe_link:
     userData.new_contributions_emails_subscribe_link,
   skip_empty_text_alert: userData.messages.includes(
-    'remember_confirm_saving_modal',
+    'remember_confirm_saving_modal'
   ),
   profile_groups: userData.profile_groups || [],
   s3_upload_signature: userData.s3_upload_signature,
@@ -32,14 +35,16 @@ module.exports = userData => ({
   has_ig_direct_flip: userData.features.includes('instagram_direct_posting'),
   twofactor: userData.twofactor,
   has_simplified_free_plan_ux: userData.features.includes(
-    'has_simplified_free_plan_ux',
+    'has_simplified_free_plan_ux'
   ),
   hasIGLocationTaggingFeature: userData.features.includes(
-    'instagram-location-tagging',
+    'instagram-location-tagging'
   ),
   hasIGDirectVideoFlip: userData.features.includes('ig_direct_video_posting'),
-  hasPaydayExperimentControlFlip: userData.experiments['payday_page_experiment'] === 'control',
-  hasPaydayExperimentEnabledFlip: userData.experiments['payday_page_experiment'] === 'enabled',
+  hasPaydayExperimentControlFlip:
+    userData.experiments['payday_page_experiment'] === 'control',
+  hasPaydayExperimentEnabledFlip:
+    userData.experiments['payday_page_experiment'] === 'enabled',
   profile_limit: userData.profile_limit,
   profiles_schedules_slots: userData.profiles_schedules_slots,
   hasNewPublish: userData.in_new_publish_rollout,
@@ -50,48 +55,52 @@ module.exports = userData => ({
     updateSuccesses: userData.email_notifications.includes('update_successes'),
     weeklyDigests: userData.email_notifications.includes('weekly_digests'),
     newContributions: userData.email_notifications.includes(
-      'new_contributions',
+      'new_contributions'
     ),
     postMovedBackToDrafts: userData.email_notifications.includes(
-      'post_moved_back_to_drafts',
+      'post_moved_back_to_drafts'
     ),
     celebrations: userData.email_notifications.includes('celebrations'),
   },
   canStartBusinessTrial: userData.can_start_business_trial,
   canStartProTrial: userData.can_start_pro_trial,
   isOnProTrial: userData.on_awesome_trial,
-  shouldShowProTrialExpiredModal: hasProTrialExpired(userData.feature_trials)
-    && userData.plan === 'free'
-    && !userData.has_cancelled,
+  shouldShowProTrialExpiredModal:
+    hasProTrialExpired(userData.feature_trials) &&
+    userData.plan === 'free' &&
+    !userData.has_cancelled,
   isOnBusinessTrial: isOnBusinessPlan(userData.trial_plan),
-  shouldShowBusinessTrialExpiredModal: isOnBusinessPlan(userData.trial_plan)
-    && userData.trial_expired
-    && !userData.trial_done,
+  shouldShowBusinessTrialExpiredModal:
+    isOnBusinessPlan(userData.trial_plan) &&
+    userData.trial_expired &&
+    !userData.trial_done,
   trial: userData.on_awesome_trial
     ? {
-      hasCardDetails: userData.has_card_details,
-      hasTrialExtended: userData.has_trial_extended,
-      onTrial: userData.on_awesome_trial,
-      postTrialCost: '',
-      trialLength: userData.awesome_trial_length,
-      trialTimeRemaining: userData.awesome_trial_time_remaining,
-    }
+        hasCardDetails: userData.has_card_details,
+        hasTrialExtended: userData.has_trial_extended,
+        onTrial: userData.on_awesome_trial,
+        postTrialCost: '',
+        trialLength: userData.awesome_trial_length,
+        trialTimeRemaining: userData.awesome_trial_time_remaining,
+      }
     : {
-      hasCardDetails: userData.has_card_details,
-      hasTrialExtended: userData.has_trial_extended,
-      onTrial: userData.on_trial,
-      postTrialCost: userData.post_trial_cost,
-      trialLength: userData.trial_length,
-      trialTimeRemaining: userData.trial_time_remaining,
-      trialPlan: userData.trial_plan,
-    },
+        hasCardDetails: userData.has_card_details,
+        hasTrialExtended: userData.has_trial_extended,
+        onTrial: userData.on_trial,
+        postTrialCost: userData.post_trial_cost,
+        trialLength: userData.trial_length,
+        trialTimeRemaining: userData.trial_time_remaining,
+        trialPlan: userData.trial_plan,
+      },
   isNonprofit: userData.billing_status_nonprofit,
   orgUserCount: userData.org_user_count,
   profileCount: userData.profile_usage,
   showReturnToClassic: userData.has_np_app_switcher,
   helpScoutConfig: userData.helpscout_beacon_params,
   isBusinessTeamMember: userData.is_business_team_member,
-  hasAccessToUserTag: userData.features.includes('instagram_user_tags')
-    && (userData.is_pro_premium_or_business_org_user // this includes team members
-    || isOnEnterprisePlan(userData.plan)), // TO-DO: Add to api
+  hasAccessToUserTag:
+    userData.features.includes('instagram_user_tags') &&
+    (userData.is_pro_premium_or_business_org_user || // this includes team members
+      isOnEnterprisePlan(userData.plan)), // TO-DO: Add to api
+  shouldHideAdvancedAnalytics: userData.should_hide_advanced_analytics,
 });

--- a/packages/shared-components/BannerAdvancedAnalytics/analyzeLogo.jsx
+++ b/packages/shared-components/BannerAdvancedAnalytics/analyzeLogo.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const AnalyzeLogo = ({ className }) => (
+  <svg
+    width="16"
+    height="17"
+    viewBox="0 0 16 17"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M7.1336 2.8703C3.28309 2.8703 0.167206 6.03021 0.167206 9.93515C0.167206 13.8401 3.28309 17 7.1336 17C10.9841 17 14.1 13.8401 14.1 9.93515H7.1336V2.8703Z"
+      fill="#F3AFB9"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M16 8.00839C16 4.10346 12.8841 0.943542 9.0336 0.943542V8.00839H16Z"
+      fill="#132062"
+    />
+  </svg>
+);
+
+AnalyzeLogo.propTypes = {
+  className: PropTypes.string,
+};
+
+AnalyzeLogo.defaultProps = {
+  className: '',
+};
+
+export default AnalyzeLogo;

--- a/packages/shared-components/BannerAdvancedAnalytics/index.jsx
+++ b/packages/shared-components/BannerAdvancedAnalytics/index.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Text } from '@bufferapp/ui';
+import PropTypes from 'prop-types';
+
+import { ModalWrapper, AnalyzeIcon, CTAButton } from './style';
+
+function BannerAdvancedAnalytics({ isAnalyzeCustomer }) {
+  return (
+    <ModalWrapper>
+      <div>
+        <AnalyzeIcon />
+        <Text>
+          <b>Looking for advanced analytics? </b>
+          Track, measure, and report with Analyze
+        </Text>
+      </div>
+      <CTAButton
+        type="primary"
+        size="small"
+        onClick={() => {
+          window.location.assign('https://analyze.buffer.com');
+        }}
+        label={isAnalyzeCustomer ? 'Visit Analyze' : 'Start Free Analyze Trial'}
+      />
+    </ModalWrapper>
+  );
+}
+
+BannerAdvancedAnalytics.propTypes = {
+  isAnalyzeCustomer: PropTypes.bool,
+};
+
+BannerAdvancedAnalytics.defaultProps = {
+  isAnalyzeCustomer: false,
+};
+
+export default BannerAdvancedAnalytics;

--- a/packages/shared-components/BannerAdvancedAnalytics/story.jsx
+++ b/packages/shared-components/BannerAdvancedAnalytics/story.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withA11y } from '@storybook/addon-a11y';
+import BannerAdvancedAnalytics from './index';
+
+storiesOf('BannerAdvancedAnalytics', module)
+  .addDecorator(withA11y)
+  .add('default', () => <BannerAdvancedAnalytics />)
+  .add('existing analyze customer', () => (
+    <BannerAdvancedAnalytics isAnalyzeCustomer />
+  ));

--- a/packages/shared-components/BannerAdvancedAnalytics/style.js
+++ b/packages/shared-components/BannerAdvancedAnalytics/style.js
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+import { blueDark } from '@bufferapp/ui/style/colors';
+import Button from '@bufferapp/ui/Button';
+
+import AnalyzeLogo from './analyzeLogo';
+
+export const ModalWrapper = styled.div`
+  clear: both;
+  margin-bottom: 20px;
+  margin-top: -10px;
+  max-width: 652px;
+  background-color: rgba(171, 183, 255, 0.2);
+  color: ${blueDark};
+  padding: 16px 25px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  border-radius: 4px;
+`;
+
+export const AnalyzeIcon = styled(AnalyzeLogo)`
+  margin-right: 9px;
+  vertical-align: bottom;
+`;
+
+export const CTAButton = styled(Button)`
+  margin-left: 12px;
+  font-weight: normal;
+`;

--- a/packages/shared-components/PostList/index.jsx
+++ b/packages/shared-components/PostList/index.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  List,
-  Text,
-} from '@bufferapp/components';
+import { List, Text } from '@bufferapp/components';
 import { Button } from '@bufferapp/ui';
 import styled from 'styled-components';
 import { WithFeatureLoader } from '@bufferapp/product-features';
@@ -13,9 +10,9 @@ import MultipleImagesPost from '../MultipleImagesPost';
 import LinkPost from '../LinkPost';
 import VideoPost from '../VideoPost';
 import Story from '../Story';
+import BannerAdvancedAnalytics from '../BannerAdvancedAnalytics';
 
-const RemindersButtons = styled.div`
-`;
+const RemindersButtons = styled.div``;
 
 const ShareAgainWrapper = styled.div`
   padding-left: 1rem;
@@ -93,9 +90,7 @@ const renderPost = ({
 
 const Header = ({ listHeader, isFirstItem }) => (
   <HeaderStyle isFirstItem={isFirstItem}>
-    <Text color="black">
-      {listHeader}
-    </Text>
+    <Text color="black">{listHeader}</Text>
   </HeaderStyle>
 );
 
@@ -124,23 +119,25 @@ const PostList = ({
   index,
   userData,
   onPreviewClick,
+  showAnalyzeBannerAfterFirstPost,
+  isAnalyzeCustomer,
 }) => (
   <React.Fragment>
     <Header listHeader={listHeader} isFirstItem={index === 0} />
     <List
-      items={posts.map(post => (
-        <PostStyle
-          id={`update-${post.id}`}
-          className={[
-            'update',
-            `post_${post.profile_service}`,
-            post.postDetails && post.postDetails.isRetweet
-              ? 'is_retweet'
-              : 'not_retweet',
-          ].join(' ')}
-        >
-          {
-            renderPost({
+      items={posts.map((post, position) => (
+        <React.Fragment>
+          <PostStyle
+            id={`update-${post.id}`}
+            className={[
+              'update',
+              `post_${post.profile_service}`,
+              post.postDetails && post.postDetails.isRetweet
+                ? 'is_retweet'
+                : 'not_retweet',
+            ].join(' ')}
+          >
+            {renderPost({
               post,
               onDeleteConfirmClick,
               onEditClick,
@@ -158,46 +155,51 @@ const PostList = ({
               hasFirstCommentFlip,
               userData,
               onPreviewClick,
-            })
-          }
-          {(!features.isFreeUser() || isBusinessAccount) && !isPastReminder
-            && (
+            })}
+            {(!features.isFreeUser() || isBusinessAccount) && !isPastReminder && (
               <ShareAgainWrapper>
                 <Button
                   type="secondary"
                   label="Share Again"
-                  onClick={() => { onShareAgainClick({ post }); }}
+                  onClick={() => {
+                    onShareAgainClick({ post });
+                  }}
                 />
               </ShareAgainWrapper>
             )}
-          {isPastReminder
-            && (
+            {isPastReminder && (
               <RemindersButtons>
-                {(!features.isFreeUser() || isBusinessAccount)
-                  && (
-                    <ShareAgainWrapper>
-                      <Button
-                        fullWidth
-                        type="secondary"
-                        label="Share Again"
-                        onClick={() => { onShareAgainClick({ post }); }}
-                      />
-                    </ShareAgainWrapper>
-                  )}
-                {isManager
-                && (
+                {(!features.isFreeUser() || isBusinessAccount) && (
+                  <ShareAgainWrapper>
+                    <Button
+                      fullWidth
+                      type="secondary"
+                      label="Share Again"
+                      onClick={() => {
+                        onShareAgainClick({ post });
+                      }}
+                    />
+                  </ShareAgainWrapper>
+                )}
+                {isManager && (
                   <ShareAgainWrapper>
                     <Button
                       fullWidth
                       type="secondary"
                       label="Send to Mobile"
-                      onClick={() => { onMobileClick({ post }); }}
+                      onClick={() => {
+                        onMobileClick({ post });
+                      }}
                     />
                   </ShareAgainWrapper>
                 )}
               </RemindersButtons>
             )}
-        </PostStyle>
+          </PostStyle>
+          {showAnalyzeBannerAfterFirstPost && position === 0 ? (
+            <BannerAdvancedAnalytics isAnalyzeCustomer={isAnalyzeCustomer} />
+          ) : null}
+        </React.Fragment>
       ))}
     />
   </React.Fragment>
@@ -209,7 +211,7 @@ PostList.propTypes = {
   posts: PropTypes.arrayOf(
     PropTypes.shape({
       text: PropTypes.string,
-    }),
+    })
   ),
   onDeleteConfirmClick: PropTypes.func,
   onEditClick: PropTypes.func,
@@ -228,12 +230,15 @@ PostList.propTypes = {
   isPastReminder: PropTypes.bool,
   isBusinessAccount: PropTypes.bool,
   hasFirstCommentFlip: PropTypes.bool,
+  showAnalyzeBannerAfterFirstPost: PropTypes.bool.isRequired,
+  isAnalyzeCustomer: PropTypes.bool,
   features: PropTypes.object.isRequired, // eslint-disable-line
 };
 
 PostList.defaultProps = {
   index: 0,
   posts: [],
+  isAnalyzeCustomer: false,
   onPreviewClick: () => {},
 };
 

--- a/packages/shared-components/PostList/index.jsx
+++ b/packages/shared-components/PostList/index.jsx
@@ -230,7 +230,7 @@ PostList.propTypes = {
   isPastReminder: PropTypes.bool,
   isBusinessAccount: PropTypes.bool,
   hasFirstCommentFlip: PropTypes.bool,
-  showAnalyzeBannerAfterFirstPost: PropTypes.bool.isRequired,
+  showAnalyzeBannerAfterFirstPost: PropTypes.bool,
   isAnalyzeCustomer: PropTypes.bool,
   features: PropTypes.object.isRequired, // eslint-disable-line
 };
@@ -239,6 +239,7 @@ PostList.defaultProps = {
   index: 0,
   posts: [],
   isAnalyzeCustomer: false,
+  showAnalyzeBannerAfterFirstPost: false,
   onPreviewClick: () => {},
 };
 

--- a/packages/shared-components/PostLists/index.jsx
+++ b/packages/shared-components/PostLists/index.jsx
@@ -1,6 +1,4 @@
-import {
-  List,
-} from '@bufferapp/components';
+import { List } from '@bufferapp/components';
 
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -35,6 +33,8 @@ const renderPostList = ({
   hasFirstCommentFlip,
   userData,
   onPreviewClick,
+  showAnalyzeBannerAfterFirstPost,
+  isAnalyzeCustomer,
 }) => (
   <div style={postListStyle}>
     <PostList
@@ -61,6 +61,8 @@ const renderPostList = ({
       hasFirstCommentFlip={hasFirstCommentFlip}
       userData={userData}
       onPreviewClick={onPreviewClick}
+      showAnalyzeBannerAfterFirstPost={showAnalyzeBannerAfterFirstPost}
+      isAnalyzeCustomer={isAnalyzeCustomer}
     />
   </div>
 );
@@ -88,6 +90,8 @@ const PostLists = ({
   hasFirstCommentFlip,
   userData,
   onPreviewClick,
+  showAnalyzeBannerAfterFirstPost,
+  isAnalyzeCustomer,
 }) => (
   <List
     items={postLists.map((postList, index) =>
@@ -113,7 +117,9 @@ const PostLists = ({
         hasFirstCommentFlip,
         userData,
         onPreviewClick,
-      }),
+        showAnalyzeBannerAfterFirstPost,
+        isAnalyzeCustomer,
+      })
     )}
     fillContainer
   />
@@ -126,9 +132,9 @@ PostLists.propTypes = {
       posts: PropTypes.arrayOf(
         PropTypes.shape({
           text: PropTypes.string,
-        }),
+        })
       ),
-    }),
+    })
   ).isRequired,
   onDeleteConfirmClick: PropTypes.func,
   onEditClick: PropTypes.func,
@@ -147,9 +153,13 @@ PostLists.propTypes = {
   isPastReminder: PropTypes.bool,
   isBusinessAccount: PropTypes.bool,
   hasFirstCommentFlip: PropTypes.bool,
+  showAnalyzeBannerAfterFirstPost: PropTypes.bool,
+  isAnalyzeCustomer: PropTypes.bool,
 };
 
 PostLists.defaultProps = {
+  showAnalyzeBannerAfterFirstPost: false,
+  isAnalyzeCustomer: false,
 };
 
 export default PostLists;

--- a/packages/shared-components/index.js
+++ b/packages/shared-components/index.js
@@ -30,3 +30,4 @@ export Slider from './Slider';
 export DiscontinuousProgressBar from './DiscontinuousProgressBar';
 export Arrow from './Arrow';
 export ComposerSidepanel from './ComposerSidepanel';
+export BannerAdvancedAnalytics from './BannerAdvancedAnalytics';

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Tabs,
-  Tab,
-} from '@bufferapp/publish-shared-components';
+import { Tabs, Tab } from '@bufferapp/publish-shared-components';
 import { Button } from '@bufferapp/ui';
 import { WithFeatureLoader } from '@bufferapp/product-features';
 import { getURL } from '@bufferapp/publish-server/formatters/src';
@@ -30,8 +27,8 @@ const Tag = styled.span`
   font-size: 12px;
   margin-left: 8px;
   border-radius: 100px;
-  color: #FFFFFF;
-  background-color: #87C221;
+  color: #ffffff;
+  background-color: #87c221;
 `;
 
 const tabsStyle = {
@@ -50,7 +47,7 @@ class TabNavigation extends React.Component {
     this.isValidTab = this.isValidTab.bind(this);
   }
 
-  isValidTab (tabId) {
+  isValidTab(tabId) {
     const {
       features,
       isBusinessAccount,
@@ -59,17 +56,20 @@ class TabNavigation extends React.Component {
       hasStoriesFlip,
     } = this.props;
 
-    return tabId === getValidTab(
-      tabId,
-      isBusinessAccount,
-      isInstagramProfile,
-      isManager,
-      features.isFreeUser(),
-      hasStoriesFlip,
+    return (
+      tabId ===
+      getValidTab(
+        tabId,
+        isBusinessAccount,
+        isInstagramProfile,
+        isManager,
+        features.isFreeUser(),
+        hasStoriesFlip
+      )
     );
   }
 
-  render () {
+  render() {
     const { loading } = this.state;
     const {
       selectedTabId,
@@ -79,7 +79,7 @@ class TabNavigation extends React.Component {
       shouldShowUpgradeButton,
       shouldShowNestedSettingsTab,
       shouldShowNestedAnalyticsTab,
-      shouldHideAnalyticsOverviewTab,
+      shouldHideAdvancedAnalytics,
       onUpgradeButtonClick,
       isLockedProfile,
     } = this.props;
@@ -88,49 +88,41 @@ class TabNavigation extends React.Component {
       /* wrapper div with "tabs" id necessary as a selector
       for a11y focus after selecting profile in sidebar */
       <div id="tabs" style={tabsStyle}>
-        <Tabs
-          selectedTabId={selectedTabId}
-          onTabClick={onTabClick}
-        >
+        <Tabs selectedTabId={selectedTabId} onTabClick={onTabClick}>
           <Tab tabId="queue">Queue</Tab>
           {/* IG, Business users or Team Members */}
-          {this.isValidTab('stories')
-            && (
-              <Tab tabId="stories">
-                Stories
-                <Tag>New</Tag>
-              </Tab>
-            )}
-          {this.isValidTab('pastReminders')
-            && <Tab tabId="pastReminders">Past Reminders</Tab>
-          }
+          {this.isValidTab('stories') && (
+            <Tab tabId="stories">
+              Stories
+              <Tag>New</Tag>
+            </Tab>
+          )}
+          {this.isValidTab('pastReminders') && (
+            <Tab tabId="pastReminders">Past Reminders</Tab>
+          )}
           <Tab tabId="analytics">Analytics</Tab>
           {/* Team Members who are Managers */}
-          {this.isValidTab('awaitingApproval')
-            && <Tab tabId="awaitingApproval">Awaiting Approval</Tab>
-          }
+          {this.isValidTab('awaitingApproval') && (
+            <Tab tabId="awaitingApproval">Awaiting Approval</Tab>
+          )}
           {/* Team Members who are Contributors */}
-          {this.isValidTab('pendingApproval')
-            && <Tab tabId="pendingApproval">Pending Approval</Tab>
-          }
+          {this.isValidTab('pendingApproval') && (
+            <Tab tabId="pendingApproval">Pending Approval</Tab>
+          )}
           {/* Pro and up users or Team Members */}
-          {this.isValidTab('drafts')
-            && <Tab tabId="drafts">Drafts</Tab>
-          }
+          {this.isValidTab('drafts') && <Tab tabId="drafts">Drafts</Tab>}
           {/* IG, Business users or Team Members */}
-          {this.isValidTab('grid')
-            && <Tab tabId="grid">Shop Grid</Tab>
-          }
+          {this.isValidTab('grid') && <Tab tabId="grid">Shop Grid</Tab>}
           <Tab tabId="settings">Settings</Tab>
         </Tabs>
-        { shouldShowUpgradeButton && (
+        {shouldShowUpgradeButton && (
           <UpgradeCtaStyle>
             <ButtonWrapper>
               <Button
                 label="Upgrade"
                 type="secondary"
                 size="small"
-                onClick={(e) => {
+                onClick={e => {
                   e.preventDefault();
                   onUpgradeButtonClick();
                 }}
@@ -145,9 +137,9 @@ class TabNavigation extends React.Component {
             secondary
           >
             <Tab tabId="posts">Posts</Tab>
-            {!shouldHideAnalyticsOverviewTab
-              && <Tab tabId="overview">Overview</Tab>
-            }
+            {!shouldHideAdvancedAnalytics && (
+              <Tab tabId="overview">Overview</Tab>
+            )}
           </Tabs>
         )}
         {shouldShowNestedSettingsTab && !isLockedProfile && (
@@ -163,7 +155,7 @@ class TabNavigation extends React.Component {
                 type="secondary"
                 size="small"
                 label={loading ? 'Reconnecting…' : 'Reconnect'}
-                onClick={(e) => {
+                onClick={e => {
                   e.preventDefault();
                   this.setState({ loading: true });
                   window.location.assign(`${getURL.getManageURL()}`);
@@ -180,7 +172,7 @@ class TabNavigation extends React.Component {
 TabNavigation.defaultProps = {
   shouldShowNestedSettingsTab: false,
   shouldShowNestedAnalyticsTab: false,
-  shouldHideAnalyticsOverviewTab: false,
+  shouldHideAdvancedAnalytics: false,
   shouldShowUpgradeButton: false,
   selectedChildTabId: null,
   isLockedProfile: false,
@@ -201,7 +193,7 @@ TabNavigation.propTypes = {
   selectedChildTabId: PropTypes.string,
   shouldShowNestedSettingsTab: PropTypes.bool,
   shouldShowNestedAnalyticsTab: PropTypes.bool,
-  shouldHideAnalyticsOverviewTab: PropTypes.bool,
+  shouldHideAdvancedAnalytics: PropTypes.bool,
   isLockedProfile: PropTypes.bool,
   isInstagramProfile: PropTypes.bool,
   shouldShowUpgradeButton: PropTypes.bool,

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -172,7 +172,7 @@ class TabNavigation extends React.Component {
 TabNavigation.defaultProps = {
   shouldShowNestedSettingsTab: false,
   shouldShowNestedAnalyticsTab: false,
-  shouldHideAdvancedAnalytics: false,
+  shouldHideAdvancedAnalytics: true,
   shouldShowUpgradeButton: false,
   selectedChildTabId: null,
   isLockedProfile: false,

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -30,10 +30,10 @@ export default connect(
       state.appSidebar.user.plan === 'premium_business',
     shouldShowNestedSettingsTab: ownProps.tabId === 'settings',
     shouldShowNestedAnalyticsTab: ownProps.tabId === 'analytics',
-    shouldHideAnalyticsOverviewTab:
+    shouldHideAdvancedAnalytics:
       state.profileSidebar.selectedProfile.type === 'linkedin' ||
       state.profileSidebar.selectedProfile.type === 'pinterest' ||
-      state.appSidebar.user.shouldHideAnalyticsOverviewTab,
+      state.profileSidebar.selectedProfile.shouldHideAdvancedAnalytics,
     profileId: ownProps.profileId,
     isLockedProfile: state.profileSidebar.isLockedProfile,
     isInstagramProfile: state.generalSettings.isInstagramProfile,

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -1,5 +1,8 @@
 import { push } from 'connected-react-router';
-import { generateChildTabRoute, plansPageRoute } from '@bufferapp/publish-routes';
+import {
+  generateChildTabRoute,
+  plansPageRoute,
+} from '@bufferapp/publish-routes';
 import { connect } from 'react-redux';
 import { trackAction } from '@bufferapp/publish-data-tracking';
 
@@ -13,52 +16,70 @@ export default connect(
     isManager: state.profileSidebar.selectedProfile.isManager,
     selectedTabId: ownProps.tabId,
     selectedChildTabId: ownProps.childTabId,
-    onProTrial: state.appSidebar.user.trial &&
-                state.appSidebar.user.trial.onTrial &&
-                !state.profileSidebar.selectedProfile.business,
-    shouldShowUpgradeCta: state.appSidebar.user.is_free_user && !state.appSidebar.user.isBusinessTeamMember,
-    shouldShowUpgradeButton: state.appSidebar.user.plan === 'free'
-                             || state.appSidebar.user.plan === 'pro'
-                             || state.appSidebar.user.plan === 'solo_premium_business'
-                             || state.appSidebar.user.plan === 'premium_business',
+    onProTrial:
+      state.appSidebar.user.trial &&
+      state.appSidebar.user.trial.onTrial &&
+      !state.profileSidebar.selectedProfile.business,
+    shouldShowUpgradeCta:
+      state.appSidebar.user.is_free_user &&
+      !state.appSidebar.user.isBusinessTeamMember,
+    shouldShowUpgradeButton:
+      state.appSidebar.user.plan === 'free' ||
+      state.appSidebar.user.plan === 'pro' ||
+      state.appSidebar.user.plan === 'solo_premium_business' ||
+      state.appSidebar.user.plan === 'premium_business',
     shouldShowNestedSettingsTab: ownProps.tabId === 'settings',
     shouldShowNestedAnalyticsTab: ownProps.tabId === 'analytics',
-    shouldHideAnalyticsOverviewTab: state.profileSidebar.selectedProfile.type === 'linkedin'
-                                    || state.profileSidebar.selectedProfile.type === 'pinterest',
+    shouldHideAnalyticsOverviewTab:
+      state.profileSidebar.selectedProfile.type === 'linkedin' ||
+      state.profileSidebar.selectedProfile.type === 'pinterest' ||
+      state.appSidebar.user.shouldHideAnalyticsOverviewTab,
     profileId: ownProps.profileId,
     isLockedProfile: state.profileSidebar.isLockedProfile,
     isInstagramProfile: state.generalSettings.isInstagramProfile,
     selectedProfile: state.profileSidebar.selectedProfile,
     canStartProTrial: state.appSidebar.user.canStartProTrial,
-    hasStoriesFlip: state.appSidebar.user.features ? state.appSidebar.user.features.includes('stories_groups') : false,
+    hasStoriesFlip: state.appSidebar.user.features
+      ? state.appSidebar.user.features.includes('stories_groups')
+      : false,
   }),
   (dispatch, ownProps) => ({
-    onTabClick: (tabId) => {
+    onTabClick: tabId => {
       const profileId = ownProps.profileId;
-      trackAction({ location: 'tabs', action: `click_tab_${tabId}`, metadata: { profileId } });
-      dispatch(actions.selectTab({
-        tabId,
-        profileId,
-      }));
-    },
-    onUpgradeButtonClick: () => {
+      trackAction({
+        location: 'tabs',
+        action: `click_tab_${tabId}`,
+        metadata: { profileId },
+      });
       dispatch(
-        push(
-          plansPageRoute,
-        ),
+        actions.selectTab({
+          tabId,
+          profileId,
+        })
       );
     },
-    onChildTabClick: (childTabId) => {
+    onUpgradeButtonClick: () => {
+      dispatch(push(plansPageRoute));
+    },
+    onChildTabClick: childTabId => {
       const tabId = ownProps.tabId;
       const profileId = ownProps.profileId;
-      trackAction({ location: 'tabs', action: `click_tab_${tabId}_${childTabId}`, metadata: { profileId } });
-      dispatch(push(generateChildTabRoute({
-        tabId,
-        childTabId,
-        profileId,
-      })));
+      trackAction({
+        location: 'tabs',
+        action: `click_tab_${tabId}_${childTabId}`,
+        metadata: { profileId },
+      });
+      dispatch(
+        push(
+          generateChildTabRoute({
+            tabId,
+            childTabId,
+            profileId,
+          })
+        )
+      );
     },
-  }),
+  })
 )(TabNavigation);
 
 // export reducer, actions and action types

--- a/packages/tabs/utils/index.js
+++ b/packages/tabs/utils/index.js
@@ -1,8 +1,10 @@
 const getBaseURL = () => {
-  return window.location.hostname === 'publish.local.buffer.com' ? 'https://local.buffer.com' : 'https://buffer.com';
+  return window.location.hostname === 'publish.local.buffer.com'
+    ? 'https://local.buffer.com'
+    : 'https://buffer.com';
 };
 
-const openCalendarWindow = (profileId) => {
+const openCalendarWindow = profileId => {
   window.location.href = `${getBaseURL()}/app/profile/${profileId}/buffer/queue/calendar/week/?content_only=true`;
 };
 
@@ -22,7 +24,16 @@ const openBillingWindow = () => {
  *
  * @returns string validTabId with the valid tab, default value is 'queue'
  */
-const getValidTab = (selectedTab, isBusinessAccount, isInstagramProfile, isManager, isFreeUser, hasStoriesFlip) => {
+const getValidTab = (
+  selectedTab,
+  isBusinessAccount,
+  isInstagramProfile,
+  isManager,
+  isFreeUser,
+  hasStoriesFlip,
+  childTabId,
+  shouldHideAdvancedAnalytics
+) => {
   let validTabId = selectedTab;
 
   switch (selectedTab) {
@@ -33,27 +44,36 @@ const getValidTab = (selectedTab, isBusinessAccount, isInstagramProfile, isManag
       validTabId = isInstagramProfile ? 'pastReminders' : 'queue';
       break;
     case 'analytics':
-      validTabId = 'analytics';
+      if (childTabId === 'overview') {
+        validTabId = shouldHideAdvancedAnalytics ? 'queue' : 'analytics';
+      } else {
+        validTabId = 'analytics';
+      }
       break;
     case 'awaitingApproval':
       /* Team Members who are Managers */
-      validTabId = (isBusinessAccount && isManager) ? 'awaitingApproval' : 'queue';
+      validTabId =
+        isBusinessAccount && isManager ? 'awaitingApproval' : 'queue';
       break;
     case 'pendingApproval':
       /* Team Members who are Contributors */
-      validTabId = (isBusinessAccount && !isManager) ? 'pendingApproval' : 'queue';
+      validTabId =
+        isBusinessAccount && !isManager ? 'pendingApproval' : 'queue';
       break;
     case 'drafts':
       /* Pro and up users or Team Members */
-      validTabId = (!isFreeUser || isBusinessAccount) ? 'drafts' : 'queue';
+      validTabId = !isFreeUser || isBusinessAccount ? 'drafts' : 'queue';
       break;
     case 'grid':
       /* IG, Business users or Team Members */
-      validTabId = (isBusinessAccount && isInstagramProfile) ? 'grid' : 'queue';
+      validTabId = isBusinessAccount && isInstagramProfile ? 'grid' : 'queue';
       break;
     case 'stories':
       /* IG, Business users or Team Members */
-      validTabId = (isBusinessAccount && isInstagramProfile && hasStoriesFlip) ? 'stories' : 'queue';
+      validTabId =
+        isBusinessAccount && isInstagramProfile && hasStoriesFlip
+          ? 'stories'
+          : 'queue';
       break;
     case 'settings':
       validTabId = 'settings';


### PR DESCRIPTION
## Description
- Hide overview analytics tab if user has signed up after certain date (coming from API).
- This also shows a banner in the sent posts to promote Analyze.


## Context & Notes
https://buffer.atlassian.net/browse/PUB-2147

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
