### PR TITLE
[PUB-2164] Display tag option if at least one ig profle has direct enabled

### DIFF
--- a/packages/composer/composer/components/Composer.jsx
+++ b/packages/composer/composer/components/Composer.jsx
@@ -812,10 +812,14 @@ class Composer extends React.Component {
 
     const composerFooterClassName = usesImageFirstLayout ? styles.imageFirstFooter : styles.composerFooter;
 
+    const selectedProfiles = this.getSelectedProfilesForService();
+    const numSelectedProfiles = selectedProfiles.length;
+
     const canAddUserTag = hasAccessToUserTag // on the user level including feature flip
       && this.isInstagram()
+      && selectedProfiles.some((profile) => profile.instagramDirectEnabled)
       && draft.instagramFeedback.length < 1 // don't allow user to add tag if post is reminder
-      && !appState.isOmniboxEnabled;
+      // && !appState.isOmniboxEnabled;
 
     const composerMediaAttachment = (
       <MediaAttachment
@@ -877,8 +881,6 @@ class Composer extends React.Component {
       && hasSuggestedMedia
     );
 
-    const selectedProfiles = this.getSelectedProfilesForService();
-    const numSelectedProfiles = selectedProfiles.length;
     const networkIconTooltipContent = this.getSelectedProfilesTooltipMarkup();
 
     const sourceUrl = draft.sourceLink !== null ? draft.sourceLink.url : null;

--- a/packages/composer/composer/components/Composer.jsx
+++ b/packages/composer/composer/components/Composer.jsx
@@ -823,7 +823,9 @@ class Composer extends React.Component {
     const canAddUserTag = hasAccessToUserTag // on the user level including feature flip
       && this.isInstagram()
       && selectedProfiles.some((profile) => profile.instagramDirectEnabled)
-      && (draft.instagramFeedback.length < 1 || feedbackNotEnabled); // don't allow user to add tag if post is reminder
+      /* don't allow user to add tag if post is a reminder though its ok if more than one 
+      ig profile is selected and one doesnt have direct scheduling enabled */
+      && (draft.instagramFeedback.length < 1 || feedbackNotEnabled);
 
     const composerMediaAttachment = (
       <MediaAttachment

--- a/packages/composer/composer/components/Composer.jsx
+++ b/packages/composer/composer/components/Composer.jsx
@@ -818,12 +818,12 @@ class Composer extends React.Component {
     // allow if draft feedback states that an account is set up for reminders
     const feedbackNotEnabled =
       draft.instagramFeedback.length === 1 &&
-      draft.instagramFeedback.map(feedback => feedback.code === 'NOT_ENABLED');
+      draft.instagramFeedback.some(feedback => feedback.code === 'NOT_ENABLED');
 
     const canAddUserTag = hasAccessToUserTag // on the user level including feature flip
       && this.isInstagram()
-      && selectedProfiles.some((profile) => profile.instagramDirectEnabled)
-      /* don't allow user to add tag if post is a reminder though its ok if more than one 
+      && selectedProfiles.some(profile => profile.instagramDirectEnabled)
+      /* don't allow user to add tag if post is a reminder though its ok if more than one
       ig profile is selected and one doesnt have direct scheduling enabled */
       && (draft.instagramFeedback.length < 1 || feedbackNotEnabled);
 

--- a/packages/composer/composer/components/Composer.jsx
+++ b/packages/composer/composer/components/Composer.jsx
@@ -815,11 +815,15 @@ class Composer extends React.Component {
     const selectedProfiles = this.getSelectedProfilesForService();
     const numSelectedProfiles = selectedProfiles.length;
 
+    // allow if draft feedback states that an account is set up for reminders
+    const feedbackNotEnabled =
+      draft.instagramFeedback.length === 1 &&
+      draft.instagramFeedback.map(feedback => feedback.code === 'NOT_ENABLED');
+
     const canAddUserTag = hasAccessToUserTag // on the user level including feature flip
       && this.isInstagram()
       && selectedProfiles.some((profile) => profile.instagramDirectEnabled)
-      && draft.instagramFeedback.length < 1 // don't allow user to add tag if post is reminder
-      // && !appState.isOmniboxEnabled;
+      && (draft.instagramFeedback.length < 1 || feedbackNotEnabled); // don't allow user to add tag if post is reminder
 
     const composerMediaAttachment = (
       <MediaAttachment

--- a/packages/composer/composer/components/MediaAttachmentThumbnail.jsx
+++ b/packages/composer/composer/components/MediaAttachmentThumbnail.jsx
@@ -17,6 +17,7 @@ const StyledIconWrapper = styled.span`
   display: flex;
   justify-content: center;
   align-items: center;
+  margin-right: 4px;
 `;
 
 const StyledTagWrapper = styled.div`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Allow tag option if more than one ig profile is selected and atleast one profile has direct scheduling enabled and image meets ig direct conditions. 
- Add spacing between tag thumbnail icon and text

https://buffer.atlassian.net/browse/PUB-2164
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
