### PR TITLE
[PUB-2172]Allow user to cancel out of the max limit pop-up

### DIFF
--- a/packages/composer-user-tags/components/TagInput/index.jsx
+++ b/packages/composer-user-tags/components/TagInput/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, Text } from '@bufferapp/ui';
 import Input from '@bufferapp/ui/Input';
 
-import { ButtonWrapper, MaxCount } from './style';
+import { ButtonWrapper, MaxCount, MaxCountText } from './style';
 
 const TagInput = (
   {
@@ -40,7 +40,15 @@ const TagInput = (
   if (reachedMaxLimit) {
     return (
       <MaxCount>
-        <Text>{translations.maxLimitText}</Text>
+        <MaxCountText>
+          <Text>{translations.maxLimitText}</Text>
+        </MaxCountText>
+        <Button
+          type="secondary"
+          size="small"
+          onClick={cancel}
+          label={translations.inputBtnCancel}
+        />
       </MaxCount>
     );
   }

--- a/packages/composer-user-tags/components/TagInput/style.js
+++ b/packages/composer-user-tags/components/TagInput/style.js
@@ -16,8 +16,13 @@ export const StyledLabel = styled.span`
 
 export const MaxCount = styled.span`
   justify-content: center;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
   display: flex;
   width: 100%;
-  text-align: center;
+  height: 100%;
+`;
+
+export const MaxCountText = styled.span`
+  margin-right: 10px;
 `;

--- a/packages/composer-user-tags/components/TagInput/style.js
+++ b/packages/composer-user-tags/components/TagInput/style.js
@@ -7,13 +7,6 @@ export const ButtonWrapper = styled.div`
   flex-direction: row-reverse;
 `;
 
-export const StyledLabel = styled.span`
-  position: absolute;
-  display: block;
-  top: 167px;
-  margin-left: 5px;
-`;
-
 export const MaxCount = styled.span`
   justify-content: center;
   flex-direction: row;
@@ -25,4 +18,11 @@ export const MaxCount = styled.span`
 
 export const MaxCountText = styled.span`
   margin-right: 10px;
+`;
+
+export const StyledLabel = styled.span`
+  position: absolute;
+  display: block;
+  top: 167px;
+  margin-left: 5px;
 `;

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -407,7 +407,7 @@
     "inputBtnAddTag": "Add Tag",
     "inputBtnCancel": "Cancel",
     "footerText": "Instagram API limitations prevent searching for usernames and tagging private users.",
-    "maxLimitText": "You've reached the 20 tag limit.",
+    "maxLimitText": "Reached the 20 tag limit.",
     "btnSave": "Save",
     "btnCancel": "Cancel",
     "tooltip": "View profile",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Allow user to cancel out of the max limit pop-up by adding a cancel button
https://buffer.atlassian.net/browse/PUB-2172
http://hi.buffer.com/4981e2b02238
<!--- Describe your changes in detail. -->

## Context & Notes
Slightly refactored the max limit message, as it looked a bit funny with the message on two lines.
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
