### PR TITLE
Add handler if processedErrors is undefined

### DIFF
--- a/packages/story-group-composer/reducer.js
+++ b/packages/story-group-composer/reducer.js
@@ -347,7 +347,11 @@ export default (state, action) => {
         processedErrors: [],
       };
     case actionTypes.SHOW_ERRORS:
-      if (action.uploadId !== null && state.processedErrors.includes(action.uploadId)) {
+      if (
+        action.uploadId !== null &&
+        state.processedErrors &&
+        state.processedErrors.includes(action.uploadId)
+      ) {
         return state;
       }
       return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Bugsnag error is happening where cases of `processedErrors` is undefined
https://buffer.slack.com/archives/CEJMCLB37/p1572894531000700/

Not able to replicate, but adding an error handler to prevent crash
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
