### PR TITLE
[PUB-2086] Enabling button for current trial plan on payday page.

### DIFF
--- a/packages/plans/components/PlanColumn/index.jsx
+++ b/packages/plans/components/PlanColumn/index.jsx
@@ -21,32 +21,26 @@ const PlanColumn = ({
   subtitle,
   imageSrc,
   plan,
-  currentPlan,
   source,
   onChoosePlanClick,
   monthly,
   features,
   buttonText,
-  buttonCurrentPlanText,
   billingText,
 }) => (
   <ColumnStyle>
     <TopContentStyle>
-      <Text type="h3">{ title }</Text>
+      <Text type="h3">{title}</Text>
       <ImageWrapperStyle>
-        <Image
-          src={imageSrc}
-          width="auto"
-          height="130px"
-        />
+        <Image src={imageSrc} width="auto" height="130px" />
       </ImageWrapperStyle>
       <Text type="h1">
         { isNonprofit ? nonProfitCost : cost }
-        { monthly }
+        {monthly}
       </Text>
-      <Text>{ billingText }</Text>
+      <Text>{billingText}</Text>
       <SubtitleStyle>
-        <Text>{ subtitle }</Text>
+        <Text>{subtitle}</Text>
       </SubtitleStyle>
     </TopContentStyle>
     {features.map(feature => (
@@ -56,9 +50,9 @@ const PlanColumn = ({
       <ButtonWrapperStyle>
         <Button
           type="primary"
-          label={currentPlan === plan ? buttonCurrentPlanText : buttonText}
+          label={buttonText}
           fullWidth
-          disabled={currentPlan === plan}
+          disabled={false}
           onClick={() => onChoosePlanClick({ source, plan })}
         />
       </ButtonWrapperStyle>
@@ -77,11 +71,9 @@ PlanColumn.propTypes = {
   subtitle: PropTypes.string.isRequired,
   imageSrc: PropTypes.string.isRequired,
   plan: PropTypes.string.isRequired,
-  currentPlan: PropTypes.string.isRequired,
   source: PropTypes.string.isRequired,
   onChoosePlanClick: PropTypes.func.isRequired,
   buttonText: PropTypes.string.isRequired,
-  buttonCurrentPlanText: PropTypes.string.isRequired,
   billingText: PropTypes.string.isRequired,
   features: PropTypes.array.isRequired,
   isNonprofit: PropTypes.bool.isRequired,

--- a/packages/plans/components/PlanColumnWithPremiumSolo/index.jsx
+++ b/packages/plans/components/PlanColumnWithPremiumSolo/index.jsx
@@ -98,14 +98,12 @@ const PlanColumnWithPremiumSolo = ({
   isNonprofit,
   imageSrc,
   plan,
-  currentPlan,
   source,
   onChoosePlanClick,
   features,
   featureTooltips,
   monthly,
   buttonText,
-  buttonCurrentPlanText,
   billingText,
   onPremiumPlanClick,
   selectedPremiumPlan,
@@ -184,9 +182,9 @@ const PlanColumnWithPremiumSolo = ({
         <ButtonWrapperStyle>
           <Button
             type="primary"
-            label={currentPlan === plan ? buttonCurrentPlanText : buttonText}
+            label={buttonText}
             fullWidth
-            disabled={currentPlan === plan}
+            disabled={false}
             onClick={() =>
               onChoosePlanClick({
                 source,
@@ -207,14 +205,11 @@ PlanColumnWithPremiumSolo.propTypes = {
   nonProfitCost: PropTypes.string.isRequired,
   soloCost: PropTypes.string.isRequired,
   soloNonProfitCost: PropTypes.string.isRequired,
-  subtitle: PropTypes.string.isRequired,
   imageSrc: PropTypes.string.isRequired,
   plan: PropTypes.string.isRequired,
-  currentPlan: PropTypes.string.isRequired,
   source: PropTypes.string.isRequired,
   onChoosePlanClick: PropTypes.func.isRequired,
   buttonText: PropTypes.string.isRequired,
-  buttonCurrentPlanText: PropTypes.string.isRequired,
   billingText: PropTypes.string.isRequired,
   features: PropTypes.array.isRequired,
   featureTooltips: PropTypes.array.isRequired,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Users currently on a trial should be able to finish trial and pay on Payday page

<!--- Describe your changes in detail. -->
## Context & Notes
JIRA card -> [PUB-2086](https://buffer.atlassian.net/browse/PUB-2086)

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots
<img width="1019" alt="Image 2019-11-06 at 3 28 56 PM" src="https://user-images.githubusercontent.com/988972/68376999-ea197a00-0149-11ea-9f65-052902750a39.png">

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
