### PR TITLE
[PUB-1869] Replace manual count by dedicated endpoint

### DIFF
--- a/packages/server/parsers/src/profileParser.js
+++ b/packages/server/parsers/src/profileParser.js
@@ -13,8 +13,6 @@ module.exports = profile => ({
   hasOrganizationMembers: profile.has_organization_members,
   pendingCount: profile.counts.pending,
   sentCount: profile.counts.sent,
-  draftsNeedApprovalCount: profile.counts.drafts_needs_approval_true,
-  draftsCount: profile.counts.drafts_needs_approval_false,
   timezone: profile.timezone,
   timezone_city: profile.timezone_city,
   schedules: profile.schedules,

--- a/packages/server/rpc/getCounts/index.js
+++ b/packages/server/rpc/getCounts/index.js
@@ -1,0 +1,21 @@
+const { method } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+module.exports = method(
+  'getCounts',
+  'get counts',
+  ({ profileId }, { session }) => {
+    return rp({
+      uri: `${process.env.API_ADDR}/1/profiles/${profileId}/counts.json`,
+      method: 'GET',
+      strictSSL: !(process.env.NODE_ENV === 'development'),
+      qs: {
+        access_token: session.publish.accessToken,
+      },
+    })
+      .then(result => JSON.parse(result))
+      .then(result => ({
+        counts: result,
+      }));
+  }
+);

--- a/packages/server/rpc/getCounts/index.test.js
+++ b/packages/server/rpc/getCounts/index.test.js
@@ -1,0 +1,11 @@
+import getCounts from '.';
+
+describe('rpc/getCounts', () => {
+  it('should have the expected name', () => {
+    expect(getCounts.name).toBe('getCounts');
+  });
+
+  it('should have the expected docs', () => {
+    expect(getCounts.docs).toBe('get counts');
+  });
+});

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -56,6 +56,7 @@ const startTrial = require('./startTrial');
 const intercom = require('./intercom');
 const v1ToV2UpgradeDetails = require('./v1ToV2UpgradeDetails');
 const globalAccount = require('./globalAccount');
+const getCounts = require('./getCounts');
 const createHashtagGroup = require('./createHashtagGroup');
 const deleteHashtagGroup = require('./deleteHashtagGroup');
 const getHashtagGroups = require('./getHashtagGroups');
@@ -136,6 +137,7 @@ module.exports = rpc(
   intercom,
   v1ToV2UpgradeDetails,
   globalAccount,
+  getCounts,
   createHashtagGroup,
   deleteHashtagGroup,
   getHashtagGroups,

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -99,21 +99,27 @@ class TabNavigation extends React.Component {
           {this.isValidTab('awaitingApproval') && (
             <Tab tabId="awaitingApproval">
               Awaiting Approval
-              <TabTag type="counter" labelName={draftsNeedApprovalCount} />
+              {draftsNeedApprovalCount != null && (
+                <TabTag type="counter" labelName={draftsNeedApprovalCount} />
+              )}
             </Tab>
           )}
           {/* Team Members who are Contributors */}
           {this.isValidTab('pendingApproval') && (
             <Tab tabId="pendingApproval">
               Pending Approval
-              <TabTag type="counter" labelName={draftsNeedApprovalCount} />
+              {draftsNeedApprovalCount != null && (
+                <TabTag type="counter" labelName={draftsNeedApprovalCount} />
+              )}
             </Tab>
           )}
           {/* Pro and up users or Team Members */}
           {this.isValidTab('drafts') && (
             <Tab tabId="drafts">
               Drafts
-              <TabTag type="counter" labelName={draftsCount} />
+              {draftsCount != null && (
+                <TabTag type="counter" labelName={draftsCount} />
+              )}
             </Tab>
           )}
           {/* IG, Business users or Team Members */}

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -31,6 +31,9 @@ const tabsStyle = {
   zIndex: 1,
 };
 
+const TabCounterTag = ({ labelName }) =>
+  labelName != null && <TabTag type="counter" labelName={labelName} />;
+
 class TabNavigation extends React.Component {
   constructor(props) {
     super(props);
@@ -99,27 +102,21 @@ class TabNavigation extends React.Component {
           {this.isValidTab('awaitingApproval') && (
             <Tab tabId="awaitingApproval">
               Awaiting Approval
-              {draftsNeedApprovalCount != null && (
-                <TabTag type="counter" labelName={draftsNeedApprovalCount} />
-              )}
+              <TabCounterTag labelName={draftsNeedApprovalCount} />
             </Tab>
           )}
           {/* Team Members who are Contributors */}
           {this.isValidTab('pendingApproval') && (
             <Tab tabId="pendingApproval">
               Pending Approval
-              {draftsNeedApprovalCount != null && (
-                <TabTag type="counter" labelName={draftsNeedApprovalCount} />
-              )}
+              <TabCounterTag labelName={draftsNeedApprovalCount} />
             </Tab>
           )}
           {/* Pro and up users or Team Members */}
           {this.isValidTab('drafts') && (
             <Tab tabId="drafts">
               Drafts
-              {draftsCount != null && (
-                <TabTag type="counter" labelName={draftsCount} />
-              )}
+              <TabCounterTag labelName={draftsCount} />
             </Tab>
           )}
           {/* IG, Business users or Team Members */}

--- a/packages/tabs/middleware.js
+++ b/packages/tabs/middleware.js
@@ -1,8 +1,10 @@
 import { push } from 'connected-react-router';
 import { generateProfilePageRoute } from '@bufferapp/publish-routes';
 import { actionTypes as draftActionTypes } from '@bufferapp/publish-drafts';
+import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar';
+import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 
-import { actionTypes, actions } from './reducer';
+import { actionTypes } from './reducer';
 
 export default ({ getState, dispatch }) => next => action => {
   next(action);
@@ -23,6 +25,18 @@ export default ({ getState, dispatch }) => next => action => {
       }
       break;
 
+    case profileActionTypes.SELECT_PROFILE: {
+      dispatch(
+        dataFetchActions.fetch({
+          name: 'getCounts',
+          args: {
+            profileId: action.profile.id,
+          },
+        })
+      );
+      break;
+    }
+
     // Drafts pusher events trigger a draft counter update action
     case draftActionTypes.DRAFT_CREATED:
     case draftActionTypes.DRAFT_DELETED:
@@ -30,9 +44,11 @@ export default ({ getState, dispatch }) => next => action => {
     case draftActionTypes.DRAFT_MOVED: {
       if (getState().profileSidebar.selectedProfileId === action.profileId) {
         dispatch(
-          actions.updateDraftCounter({
-            needsApproval: action.draft.needsApproval,
-            draftAction: action.type,
+          dataFetchActions.fetch({
+            name: 'getCounts',
+            args: {
+              profileId: action.profileId,
+            },
           })
         );
       }

--- a/packages/tabs/middleware.test.js
+++ b/packages/tabs/middleware.test.js
@@ -1,8 +1,10 @@
 import { push } from 'connected-react-router';
 import { generateProfilePageRoute } from '@bufferapp/publish-routes';
 import { actionTypes as draftActionTypes } from '@bufferapp/publish-drafts';
+import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar';
+import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 import middleware from './middleware';
-import { actionTypes, actions } from './reducer';
+import { actionTypes } from './reducer';
 
 describe('middleware', () => {
   it('exports middleware', () => {
@@ -35,6 +37,29 @@ describe('middleware', () => {
     );
   });
 
+  it('updates drafts counter when SELECT_PROFILE', () => {
+    const dispatch = jest.fn();
+    const next = jest.fn();
+
+    const action = {
+      type: profileActionTypes.SELECT_PROFILE,
+      profile: {
+        id: 'id',
+      },
+    };
+
+    middleware({ dispatch })(next)(action);
+    expect(next).toBeCalledWith(action);
+    expect(dispatch).toBeCalledWith(
+      dataFetchActions.fetch({
+        name: 'getCounts',
+        args: {
+          profileId: 'id',
+        },
+      })
+    );
+  });
+
   it('updates drafts counter when DRAFT_CREATED', () => {
     const fakeState = () => ({
       profileSidebar: {
@@ -55,9 +80,11 @@ describe('middleware', () => {
     middleware({ dispatch, getState: fakeState })(next)(action);
     expect(next).toBeCalledWith(action);
     expect(dispatch).toBeCalledWith(
-      actions.updateDraftCounter({
-        needsApproval: false,
-        draftAction: 'DRAFTS__DRAFT_CREATED',
+      dataFetchActions.fetch({
+        name: 'getCounts',
+        args: {
+          profileId: 'id',
+        },
       })
     );
   });
@@ -82,9 +109,11 @@ describe('middleware', () => {
     middleware({ dispatch, getState: fakeState })(next)(action);
     expect(next).toBeCalledWith(action);
     expect(dispatch).toBeCalledWith(
-      actions.updateDraftCounter({
-        needsApproval: false,
-        draftAction: 'DRAFTS__DRAFT_DELETED',
+      dataFetchActions.fetch({
+        name: 'getCounts',
+        args: {
+          profileId: 'id',
+        },
       })
     );
   });
@@ -109,9 +138,11 @@ describe('middleware', () => {
     middleware({ dispatch, getState: fakeState })(next)(action);
     expect(next).toBeCalledWith(action);
     expect(dispatch).toBeCalledWith(
-      actions.updateDraftCounter({
-        needsApproval: true,
-        draftAction: 'DRAFTS__DRAFT_APPROVED',
+      dataFetchActions.fetch({
+        name: 'getCounts',
+        args: {
+          profileId: 'id',
+        },
       })
     );
   });
@@ -136,9 +167,11 @@ describe('middleware', () => {
     middleware({ dispatch, getState: fakeState })(next)(action);
     expect(next).toBeCalledWith(action);
     expect(dispatch).toBeCalledWith(
-      actions.updateDraftCounter({
-        needsApproval: false,
-        draftAction: 'DRAFTS__DRAFT_MOVED',
+      dataFetchActions.fetch({
+        name: 'getCounts',
+        args: {
+          profileId: 'id',
+        },
       })
     );
   });
@@ -163,9 +196,11 @@ describe('middleware', () => {
     middleware({ dispatch, getState: fakeState })(next)(action);
     expect(next).toBeCalledWith(action);
     expect(dispatch).not.toBeCalledWith(
-      actions.updateDraftCounter({
-        needsApproval: false,
-        draftAction: 'DRAFTS__DRAFT_CREATED',
+      dataFetchActions.fetch({
+        name: 'getCounts',
+        args: {
+          profileId: 'id',
+        },
       })
     );
   });

--- a/packages/tabs/reducer.js
+++ b/packages/tabs/reducer.js
@@ -25,6 +25,14 @@ export default (state = initialState, action) => {
       };
     }
 
+    case `getCounts_${dataFetchActionTypes.FETCH_START}`: {
+      return {
+        ...state,
+        draftsNeedApprovalCount: null,
+        draftsCount: null,
+      };
+    }
+
     case `getCounts_${dataFetchActionTypes.FETCH_SUCCESS}`: {
       return {
         ...state,

--- a/packages/tabs/reducer.js
+++ b/packages/tabs/reducer.js
@@ -1,5 +1,5 @@
 import keyWrapper from '@bufferapp/keywrapper';
-import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar';
+import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 
 export const actionTypes = keyWrapper('TABS', {
   SELECT_TAB: 0,
@@ -12,8 +12,8 @@ export const initialState = {
   selectedProfileId: '',
   selectedProfile: {},
   isBusinessAccount: false,
-  draftsNeedApprovalCount: '',
-  draftsCount: '',
+  draftsNeedApprovalCount: null,
+  draftsCount: null,
 };
 
 export default (state = initialState, action) => {
@@ -25,63 +25,17 @@ export default (state = initialState, action) => {
       };
     }
 
-    case profileActionTypes.SELECT_PROFILE: {
+    case `getCounts_${dataFetchActionTypes.FETCH_SUCCESS}`: {
       return {
         ...state,
-        draftsNeedApprovalCount: action.profile.draftsNeedApprovalCount,
-        draftsCount: action.profile.draftsCount,
+        draftsNeedApprovalCount:
+          action.result.counts.drafts_needs_approval_true,
+        draftsCount:
+          action.result.counts.drafts_needs_approval_false ||
+          action.result.counts.drafts,
       };
     }
 
-    case actionTypes.UPDATE_DRAFT_COUNTER: {
-      // Updates counter when draft is created
-      if (action.draftAction === 'DRAFTS__DRAFT_CREATED') {
-        if (action.needsApproval) {
-          return {
-            ...state,
-            draftsNeedApprovalCount: state.draftsNeedApprovalCount + 1,
-          };
-        }
-        return {
-          ...state,
-          draftsCount: state.draftsCount + 1,
-        };
-      }
-      // Updates counter when draft is deleted or approved
-      if (
-        action.draftAction === 'DRAFTS__DRAFT_DELETED' ||
-        action.draftAction === 'DRAFTS__DRAFT_APPROVED'
-      ) {
-        if (action.needsApproval) {
-          return {
-            ...state,
-            draftsNeedApprovalCount: state.draftsNeedApprovalCount - 1,
-          };
-        }
-        return {
-          ...state,
-          draftsCount: state.draftsCount - 1,
-        };
-      }
-      // Updates counter when draft is moved
-      if (action.draftAction === 'DRAFTS__DRAFT_MOVED') {
-        if (action.needsApproval) {
-          return {
-            ...state,
-            draftsNeedApprovalCount: state.draftsNeedApprovalCount + 1,
-            draftsCount: state.draftsCount - 1,
-          };
-        }
-        return {
-          ...state,
-          draftsNeedApprovalCount: state.draftsNeedApprovalCount - 1,
-          draftsCount: state.draftsCount + 1,
-        };
-      }
-      return {
-        ...state,
-      };
-    }
     default:
       return state;
   }
@@ -92,10 +46,5 @@ export const actions = {
     type: actionTypes.SELECT_TAB,
     tabId,
     profileId,
-  }),
-  updateDraftCounter: ({ needsApproval, draftAction }) => ({
-    type: actionTypes.UPDATE_DRAFT_COUNTER,
-    needsApproval,
-    draftAction,
   }),
 };

--- a/packages/tabs/reducer.test.js
+++ b/packages/tabs/reducer.test.js
@@ -1,5 +1,4 @@
 import deepFreeze from 'deep-freeze';
-import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar';
 import reducer, { initialState, actionTypes, actions } from './reducer';
 
 describe('reducer', () => {
@@ -36,7 +35,7 @@ describe('reducer', () => {
     expect(reducer(stateBefore, action)).toEqual(stateAfter);
   });
 
-  it('handles SELECT_PROFILE action type', () => {
+  it('handles getCounts_FETCH_SUCCESS action type', () => {
     const stateBefore = {
       ...initialState,
       draftsNeedApprovalCount: null,
@@ -48,10 +47,12 @@ describe('reducer', () => {
       draftsCount: 2,
     };
     const action = {
-      type: profileActionTypes.SELECT_PROFILE,
-      profile: {
-        draftsNeedApprovalCount: 1,
-        draftsCount: 2,
+      type: 'getCounts_FETCH_SUCCESS',
+      result: {
+        counts: {
+          drafts_needs_approval_true: 1,
+          drafts_needs_approval_false: 2,
+        },
       },
     };
 
@@ -59,200 +60,6 @@ describe('reducer', () => {
     deepFreeze(action);
 
     expect(reducer(stateBefore, action)).toEqual(stateAfter);
-  });
-
-  describe('UPDATE_DRAFT_COUNTER action type', () => {
-    describe('When DRAFT_CREATED', () => {
-      it('updates counter if draft needs approval', () => {
-        const stateBefore = {
-          ...initialState,
-          draftsNeedApprovalCount: 0,
-          draftsCount: 0,
-        };
-        const stateAfter = {
-          ...initialState,
-          draftsNeedApprovalCount: 1,
-          draftsCount: 0,
-        };
-        const action = {
-          type: actionTypes.UPDATE_DRAFT_COUNTER,
-          needsApproval: true,
-          draftAction: 'DRAFTS__DRAFT_CREATED',
-        };
-
-        deepFreeze(stateBefore);
-        deepFreeze(action);
-
-        expect(reducer(stateBefore, action)).toEqual(stateAfter);
-      });
-
-      it('updates counter if draft does not need approval', () => {
-        const stateBefore = {
-          ...initialState,
-          draftsNeedApprovalCount: 0,
-          draftsCount: 0,
-        };
-        const stateAfter = {
-          ...initialState,
-          draftsNeedApprovalCount: 0,
-          draftsCount: 1,
-        };
-        const action = {
-          type: actionTypes.UPDATE_DRAFT_COUNTER,
-          needsApproval: false,
-          draftAction: 'DRAFTS__DRAFT_CREATED',
-        };
-
-        deepFreeze(stateBefore);
-        deepFreeze(action);
-
-        expect(reducer(stateBefore, action)).toEqual(stateAfter);
-      });
-    });
-
-    describe('When DRAFT_DELETED', () => {
-      it('updates counter if draft needs approval', () => {
-        const stateBefore = {
-          ...initialState,
-          draftsNeedApprovalCount: 2,
-          draftsCount: 0,
-        };
-        const stateAfter = {
-          ...initialState,
-          draftsNeedApprovalCount: 1,
-          draftsCount: 0,
-        };
-        const action = {
-          type: actionTypes.UPDATE_DRAFT_COUNTER,
-          needsApproval: true,
-          draftAction: 'DRAFTS__DRAFT_DELETED',
-        };
-
-        deepFreeze(stateBefore);
-        deepFreeze(action);
-
-        expect(reducer(stateBefore, action)).toEqual(stateAfter);
-      });
-
-      it('updates counter if draft does not need approval', () => {
-        const stateBefore = {
-          ...initialState,
-          draftsNeedApprovalCount: 0,
-          draftsCount: 2,
-        };
-        const stateAfter = {
-          ...initialState,
-          draftsNeedApprovalCount: 0,
-          draftsCount: 1,
-        };
-        const action = {
-          type: actionTypes.UPDATE_DRAFT_COUNTER,
-          needsApproval: false,
-          draftAction: 'DRAFTS__DRAFT_DELETED',
-        };
-
-        deepFreeze(stateBefore);
-        deepFreeze(action);
-
-        expect(reducer(stateBefore, action)).toEqual(stateAfter);
-      });
-    });
-
-    describe('When DRAFT_APPROVED', () => {
-      it('updates counter if draft needs approval', () => {
-        const stateBefore = {
-          ...initialState,
-          draftsNeedApprovalCount: 2,
-          draftsCount: 0,
-        };
-        const stateAfter = {
-          ...initialState,
-          draftsNeedApprovalCount: 1,
-          draftsCount: 0,
-        };
-        const action = {
-          type: actionTypes.UPDATE_DRAFT_COUNTER,
-          needsApproval: true,
-          draftAction: 'DRAFTS__DRAFT_APPROVED',
-        };
-
-        deepFreeze(stateBefore);
-        deepFreeze(action);
-
-        expect(reducer(stateBefore, action)).toEqual(stateAfter);
-      });
-
-      it('updates counter if draft does not need approval', () => {
-        const stateBefore = {
-          ...initialState,
-          draftsNeedApprovalCount: 0,
-          draftsCount: 2,
-        };
-        const stateAfter = {
-          ...initialState,
-          draftsNeedApprovalCount: 0,
-          draftsCount: 1,
-        };
-        const action = {
-          type: actionTypes.UPDATE_DRAFT_COUNTER,
-          needsApproval: false,
-          draftAction: 'DRAFTS__DRAFT_APPROVED',
-        };
-
-        deepFreeze(stateBefore);
-        deepFreeze(action);
-
-        expect(reducer(stateBefore, action)).toEqual(stateAfter);
-      });
-    });
-
-    describe('When DRAFT_MOVED', () => {
-      it('updates counter if draft needs approval', () => {
-        const stateBefore = {
-          ...initialState,
-          draftsNeedApprovalCount: 0,
-          draftsCount: 1,
-        };
-        const stateAfter = {
-          ...initialState,
-          draftsNeedApprovalCount: 1,
-          draftsCount: 0,
-        };
-        const action = {
-          type: actionTypes.UPDATE_DRAFT_COUNTER,
-          needsApproval: true,
-          draftAction: 'DRAFTS__DRAFT_MOVED',
-        };
-
-        deepFreeze(stateBefore);
-        deepFreeze(action);
-
-        expect(reducer(stateBefore, action)).toEqual(stateAfter);
-      });
-
-      it('updates counter if draft does not need approval', () => {
-        const stateBefore = {
-          ...initialState,
-          draftsNeedApprovalCount: 1,
-          draftsCount: 0,
-        };
-        const stateAfter = {
-          ...initialState,
-          draftsNeedApprovalCount: 0,
-          draftsCount: 1,
-        };
-        const action = {
-          type: actionTypes.UPDATE_DRAFT_COUNTER,
-          needsApproval: false,
-          draftAction: 'DRAFTS__DRAFT_MOVED',
-        };
-
-        deepFreeze(stateBefore);
-        deepFreeze(action);
-
-        expect(reducer(stateBefore, action)).toEqual(stateAfter);
-      });
-    });
   });
 
   // Test action creators:
@@ -266,20 +73,6 @@ describe('reducer', () => {
       expect(actions.selectTab({ tabId: 'tab', profileId: 'id' })).toEqual(
         expectedAction
       );
-    });
-
-    it('creates a UPDATE_DRAFT_COUNTER action', () => {
-      const expectedAction = {
-        type: actionTypes.UPDATE_DRAFT_COUNTER,
-        needsApproval: true,
-        draftAction: 'action',
-      };
-      expect(
-        actions.updateDraftCounter({
-          needsApproval: true,
-          draftAction: 'action',
-        })
-      ).toEqual(expectedAction);
     });
   });
 });

--- a/packages/tabs/reducer.test.js
+++ b/packages/tabs/reducer.test.js
@@ -35,6 +35,33 @@ describe('reducer', () => {
     expect(reducer(stateBefore, action)).toEqual(stateAfter);
   });
 
+  it('handles getCounts_FETCH_START action type', () => {
+    const stateBefore = {
+      ...initialState,
+      draftsNeedApprovalCount: 0,
+      draftsCount: 1,
+    };
+    const stateAfter = {
+      ...initialState,
+      draftsNeedApprovalCount: null,
+      draftsCount: null,
+    };
+    const action = {
+      type: 'getCounts_FETCH_START',
+      result: {
+        counts: {
+          drafts_needs_approval_true: 1,
+          drafts_needs_approval_false: 2,
+        },
+      },
+    };
+
+    deepFreeze(stateBefore);
+    deepFreeze(action);
+
+    expect(reducer(stateBefore, action)).toEqual(stateAfter);
+  });
+
   it('handles getCounts_FETCH_SUCCESS action type', () => {
     const stateBefore = {
       ...initialState,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Get drafts count through a dedicated getCounts rpc method
- Make the counts request both when a profile is selected and a drafts pusher event occurs
- Hide counter from tabs while the request is happening (fetch start)
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-1869
Counts endpoint created here: https://github.com/bufferapp/buffer-web/pull/16679
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
