### PR TITLE
fix publish-analytics-posts-analyzeTrial-1 CTA

### DIFF
--- a/packages/shared-components/BannerAdvancedAnalytics/index.jsx
+++ b/packages/shared-components/BannerAdvancedAnalytics/index.jsx
@@ -19,7 +19,9 @@ function BannerAdvancedAnalytics({ isAnalyzeCustomer }) {
         size="small"
         onClick={() => {
           window.location.assign(
-            'https://analyze.buffer.com?cta=publish-analytics-posts-analyzeTrial-1'
+            isAnalyzeCustomer ?
+            'https://analyze.buffer.com' :
+            'https://account.buffer.com/analyze?cta=publish-analytics-posts-analyzeTrial-1'
           );
         }}
         label={isAnalyzeCustomer ? 'Visit Analyze' : 'Start Free Analyze Trial'}


### PR DESCRIPTION
To fix publish-analytics-posts-analyzeTrial-1 CTA

<!--- Provide a general summary of your changes in the Title above. -->
We are directly directing non Analyze users to https://account.buffer.com/analyze?cta=publish-analytics-posts-analyzeTrial-1 instead of https://analyze.buffer.com/?cta=publish-analytics-posts-analyzeTrial-1, to avoid a series of nested redirects that end up
removing the original CTA.

## Context & Notes
Here is the Slack convo https://buffer.slack.com/archives/C0DLE125Q/p1573594739255400

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
