### PR TITLE
Stop free user tracking fullstory

### DIFF
--- a/packages/bootstrap/middleware.js
+++ b/packages/bootstrap/middleware.js
@@ -12,9 +12,11 @@ export default ({ dispatch }) => next => action => {
         dispatch(
           dataFetchActions.fetchSuccess({
             name: 'user',
-            result: window.bufferUser,
+            result: { ...window.bufferUser },
           })
         );
+        // make sure we only bootstrap this data once
+        window.bufferUser = undefined;
       } else {
         dispatch(
           dataFetchActions.fetch({

--- a/packages/bootstrap/middleware.js
+++ b/packages/bootstrap/middleware.js
@@ -1,0 +1,29 @@
+import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
+
+export default ({ dispatch }) => next => action => {
+  next(action);
+  switch (action.type) {
+    case 'APP_INIT':
+      if (
+        typeof window !== 'undefined' &&
+        typeof window.bufferUser !== 'undefined' &&
+        window.bufferUser
+      ) {
+        dispatch(
+          dataFetchActions.fetchSuccess({
+            name: 'user',
+            result: window.bufferUser,
+          })
+        );
+      } else {
+        dispatch(
+          dataFetchActions.fetch({
+            name: 'user',
+          })
+        );
+      }
+      break;
+    default:
+      break;
+  }
+};

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@bufferapp/publish-bootstrap",
+  "version": "2.0.0",
+  "description": "Bootstrap Package",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint . --ignore-pattern coverage node_modules"
+  },
+  "author": "karel@buffer.com",
+  "dependencies": {
+  },
+  "devDependencies": {
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/server/index.html
+++ b/packages/server/index.html
@@ -189,6 +189,7 @@
       message.style.display = 'block';
     }
   </script>
+  {{{bufferUser}}}
   <script crossorigin src="{{{vendor}}}"></script>
   <script crossorigin src="{{{bundle}}}"></script>
 </body>

--- a/packages/server/index.html
+++ b/packages/server/index.html
@@ -158,7 +158,20 @@
 </head>
 
 <body>
-  <div id="root"></div>
+  <div id="root">
+    <!-- initial loading icon -->
+    <div style="display: inline-block; width: 100px; height: 100px; position: absolute; top: 50%; left: 50%; margin: -50px 0px 0px -50px;">
+      <div style="opacity: 1;position: absolute;top: 0px;left: 0px;animation: 2s ease 0ms infinite normal none running fade;display: block;">
+        <svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="width: 100px; height: 100px; fill: rgb(89, 98, 106);"><g class="shuttleGray"><path d="M1.10241622,4.34038738 L7.75166358,7.40469806 C7.88821853,7.46764349 8.11178147,7.46764349 8.24833642,7.40469806 L14.8975838,4.34038738 C15.0341387,4.27744195 15.0341387,4.17446518 14.8975838,4.11151975 L8.24833642,1.04720908 C8.11178147,0.984263641 7.88821853,0.984263641 7.75166358,1.04720908 L1.10241622,4.11151975 C0.965861261,4.17446518 0.965861261,4.27744195 1.10241622,4.34038738"></path></g></svg>
+      </div>
+      <div style="opacity: 1;position: absolute;top: 0px;left: 0px;animation: 2s ease 150ms infinite normal none running fade;display: block;">
+        <svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="width: 100px; height: 100px; fill: rgb(89, 98, 106);"><g class="shuttleGray"><path d="M14.8975838,7.88556618 L13.3049713,7.1516585 C13.1684163,7.08871306 12.9449081,7.08871306 12.8082985,7.1516585 L8.24833642,9.25308448 C8.11178147,9.31602991 7.88821853,9.31602991 7.75166358,9.25308448 L3.19170155,7.1516585 C3.0550919,7.08871306 2.83158366,7.08871306 2.6950287,7.1516585 L1.10241622,7.88556618 C0.965861261,7.94851162 0.965861261,8.05154307 1.10241622,8.1144885 L7.75166358,11.1787445 C7.88821853,11.2416899 8.11178147,11.2416899 8.24833642,11.1787445 L14.8975838,8.1144885 C15.0341387,8.05154307 15.0341387,7.94851162 14.8975838,7.88556618"></path></g></svg>
+      </div>
+      <div style="opacity: 1;position: absolute;top: 0px;left: 0px;animation: 2s ease 300ms infinite normal none running fade;display: block;">
+        <svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="width: 100px; height: 100px; fill: rgb(89, 98, 106);"><g class="shuttleGray"><path d="M14.8975838,11.6596673 L13.3049713,10.9257049 C13.1684163,10.8627595 12.9449081,10.8627595 12.8082985,10.9257049 L8.24833642,13.0271856 C8.11178147,13.090131 7.88821853,13.090131 7.75166358,13.0271856 L3.19170155,10.9257049 C3.0550919,10.8627595 2.83158366,10.8627595 2.6950287,10.9257049 L1.10241622,11.6596673 C0.965861261,11.7226127 0.965861261,11.8255895 1.10241622,11.8885349 L7.75166358,14.9528456 C7.88821853,15.015791 8.11178147,15.015791 8.24833642,14.9528456 L14.8975838,11.8885349 C15.0341387,11.8255895 15.0341387,11.7226127 14.8975838,11.6596673"></path></g></svg>
+      </div>
+    </div>
+  </div>
   <span id="browser-extension-marker" style="display: none"></span>
   <div id="browser-message" style="display: none">
     <div class="browser-message-popover">

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -206,7 +206,7 @@ const getHtml = ({
   const bufferUser =
     typeof userData === 'undefined'
       ? ''
-      : `<script>window.bufferUser = ${JSON.stringify(userData)}</script>`;
+      : `<script>try { window.bufferUser = ${JSON.stringify(userData)}; } catch(e) {}</script>`;
   return fs
     .readFileSync(join(__dirname, 'index.html'), 'utf8')
     .replace('{{{vendor}}}', staticAssets['vendor.js'])

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -194,6 +194,26 @@ const iterateScript = `<script>
     if(i.attachEvent) {i.attachEvent('onload', l);} else{i.addEventListener('load', l, false);}}(window, document,'script','iterate-js','Iterate'));
   </script>`;
 
+const getUserData = ({ userData }) => {
+  const bufferUser =
+    typeof userData === 'undefined'
+      ? ''
+      : `<script>try { window.bufferUser = ${JSON.stringify(
+          userData
+        )}; } catch(e) {}</script>`;
+
+  return bufferUser;
+};
+
+const getFullstory = ({ includeFullstory }) => {
+  const includedFullstoryScript = includeFullstory ? fullStoryScript : '';
+  return isProduction ? includedFullstoryScript : '';
+};
+
+const getBugsnag = ({ userId }) => {
+  return isProduction ? getBugsnagScript(userId) : '';
+};
+
 const getHtml = ({
   notification,
   userId,
@@ -202,25 +222,14 @@ const getHtml = ({
   userData,
   includeFullstory = true,
 }) => {
-  const includedFullstoryScript = includeFullstory ? fullStoryScript : '';
-  const bufferUser =
-    typeof userData === 'undefined'
-      ? ''
-      : `<script>try { window.bufferUser = ${JSON.stringify(userData)}; } catch(e) {}</script>`;
   return fs
     .readFileSync(join(__dirname, 'index.html'), 'utf8')
     .replace('{{{vendor}}}', staticAssets['vendor.js'])
     .replace('{{{bundle}}}', staticAssets['bundle.js'])
     .replace('{{{bundle-css}}}', staticAssets['bundle.css'])
     .replace('{{{stripeScript}}}', stripeScript)
-    .replace(
-      '{{{fullStoryScript}}}',
-      isProduction ? includedFullstoryScript : ''
-    )
-    .replace(
-      '{{{bugsnagScript}}}',
-      isProduction ? getBugsnagScript(userId) : ''
-    )
+    .replace('{{{fullStoryScript}}}', getFullstory({ includeFullstory }))
+    .replace('{{{bugsnagScript}}}', getBugsnag({ userId }))
     .replace('{{{notificationScript}}}', notificationScript(notification))
     .replace('{{{showModalScript}}}', showModalScript(modalKey, modalValue))
     .replace('{{{appcues}}}', isProduction ? appcuesScript : '')
@@ -230,7 +239,7 @@ const getHtml = ({
     .replace('{{{userScript}}}', getUserScript({ id: userId }))
     .replace('{{{favicon}}}', getFaviconCode({ cacheBust: 'v1' }))
     .replace('{{{segmentScript}}}', segmentScript)
-    .replace('{{{bufferUser}}}', bufferUser);
+    .replace('{{{bufferUser}}}', getUserData({ userData }));
 };
 
 app.use(logMiddleware({ name: 'BufferPublish' }));

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -215,7 +215,7 @@ const getHtml = ({
     .replace('{{{stripeScript}}}', stripeScript)
     .replace(
       '{{{fullStoryScript}}}',
-      !isProduction ? includedFullstoryScript : ''
+      isProduction ? includedFullstoryScript : ''
     )
     .replace(
       '{{{bugsnagScript}}}',

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -16,7 +16,8 @@ import postingScheduleSettingsMiddleware from '@bufferapp/publish-posting-schedu
 import generalSettingsMiddleware from '@bufferapp/publish-general-settings/middleware';
 import profileSidebarMiddleware from '@bufferapp/publish-profile-sidebar/middleware';
 import clientAccessMiddleware from '@bufferapp/client-access/middleware';
-import appSidebarMiddleware from '@bufferapp/app-sidebar/lib/middleware';
+import bootstrapMiddleware from '@bufferapp/publish-bootstrap/middleware';
+//import appSidebarMiddleware from '@bufferapp/app-sidebar/lib/middleware';
 import productFeatureMiddleware from '@bufferapp/product-features/middleware';
 import i18nMiddleware from '@bufferapp/publish-i18n/middleware';
 import asyncDataFetchMiddleware from '@bufferapp/async-data-fetch/lib/middleware';
@@ -94,7 +95,8 @@ const configureStore = initialstate => {
         i18nMiddleware,
         profileSidebarMiddleware,
         clientAccessMiddleware,
-        appSidebarMiddleware,
+        bootstrapMiddleware,
+        //appSidebarMiddleware,
         productFeatureMiddleware,
         queueMiddleware,
         sentMiddleware,

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -17,7 +17,6 @@ import generalSettingsMiddleware from '@bufferapp/publish-general-settings/middl
 import profileSidebarMiddleware from '@bufferapp/publish-profile-sidebar/middleware';
 import clientAccessMiddleware from '@bufferapp/client-access/middleware';
 import bootstrapMiddleware from '@bufferapp/publish-bootstrap/middleware';
-//import appSidebarMiddleware from '@bufferapp/app-sidebar/lib/middleware';
 import productFeatureMiddleware from '@bufferapp/product-features/middleware';
 import i18nMiddleware from '@bufferapp/publish-i18n/middleware';
 import asyncDataFetchMiddleware from '@bufferapp/async-data-fetch/lib/middleware';
@@ -96,7 +95,6 @@ const configureStore = initialstate => {
         profileSidebarMiddleware,
         clientAccessMiddleware,
         bootstrapMiddleware,
-        //appSidebarMiddleware,
         productFeatureMiddleware,
         queueMiddleware,
         sentMiddleware,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

Boostrapping the user on the initial request (in the backend)

This should allow us to speed up perceived loading time, as the menu will be ready immediately for users as the user "should" always be present.

This version prevents FullStory from being loaded for free users as per https://buffer.atlassian.net/browse/PUB-2207

More streamlining to come around external script loading optimizations, but fullstory is the start of this

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
