### PR TITLE
[PUB-2193] Change sentPosts fetch

### DIFF
--- a/packages/past-reminders/components/PastRemindersWrapper/index.jsx
+++ b/packages/past-reminders/components/PastRemindersWrapper/index.jsx
@@ -1,9 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import {
-  Divider,
-  Text,
-} from '@bufferapp/components';
+import { Divider, Text } from '@bufferapp/components';
 import styled from 'styled-components';
 import { QueueButtonGroup } from '@bufferapp/publish-shared-components';
 import LockedProfileNotification from '@bufferapp/publish-locked-profile-notification';
@@ -18,7 +15,7 @@ const HeaderWrapper = styled.div`
 `;
 
 const TitleWrapper = styled.div`
-  margin-bottom: 8px,
+  margin-bottom: 8px;
 `;
 
 const ButtonRelativeContainer = styled.div`
@@ -31,15 +28,14 @@ const ButtonWrapper = styled.div`
   top: 15px;
 `;
 
-const Header = ({
-  header,
-  subHeader,
-}) => (
+const Header = ({ header, subHeader }) => (
   <HeaderWrapper>
     <TitleWrapper>
       <Text color="black">{header}</Text>
     </TitleWrapper>
-    <Text color="shuttleGray" size="mini">{subHeader}</Text>
+    <Text color="shuttleGray" size="mini">
+      {subHeader}
+    </Text>
     <Divider />
   </HeaderWrapper>
 );
@@ -54,12 +50,12 @@ Header.defaultProps = {
   subHeader: null,
 };
 
-const PastRemindersWrapper = (props) => {
-  const {
-    isLockedProfile,
-    viewType,
-    onToggleViewType,
-  } = props;
+const PastRemindersWrapper = props => {
+  const { isLockedProfile, viewType, onToggleViewType, profileId } = props;
+
+  useEffect(() => {
+    onToggleViewType('posts');
+  }, [profileId]);
 
   if (isLockedProfile) {
     return <LockedProfileNotification />;
@@ -88,6 +84,7 @@ PastRemindersWrapper.propTypes = {
   total: PropTypes.number,
   isLockedProfile: PropTypes.bool,
   onToggleViewType: PropTypes.func,
+  profileId: PropTypes.string.isRequired,
 };
 
 PastRemindersWrapper.defaultProps = {

--- a/packages/past-reminders/middleware.js
+++ b/packages/past-reminders/middleware.js
@@ -1,46 +1,44 @@
-import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
-import { actions as dataFetchActions, actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
+import {
+  actions as dataFetchActions,
+  actionTypes as dataFetchActionTypes,
+} from '@bufferapp/async-data-fetch';
 import { actions as notificationActions } from '@bufferapp/notifications';
 import { getMappedStories } from '@bufferapp/publish-story-group-composer/middleware';
 import { actionTypes } from './reducer';
 
 const fetchPastReminders = (dispatch, action) => {
   const { viewType } = action;
-  const pastRemindersRPC = viewType === 'stories' ? 'getPastRemindersStories' : 'pastRemindersPosts';
+  const pastRemindersRPC =
+    viewType === 'stories' ? 'getPastRemindersStories' : 'pastRemindersPosts';
 
-  dispatch(dataFetchActions.fetch({
-    name: pastRemindersRPC,
-    args: {
-      profileId: action.profileId || action.profile.id,
-      isFetchingMore: false,
-    },
-  }));
+  dispatch(
+    dataFetchActions.fetch({
+      name: pastRemindersRPC,
+      args: {
+        profileId: action.profileId || action.profile.id,
+        isFetchingMore: false,
+      },
+    })
+  );
 };
 
-export default ({ getState, dispatch }) => next => (action) => {
+export default ({ getState, dispatch }) => next => action => {
   next(action);
   const state = getState();
   const { selectedProfileId } = state.profileSidebar;
   switch (action.type) {
-    case profileActionTypes.SELECT_PROFILE:
-      dispatch(dataFetchActions.fetch({
-        name: 'pastRemindersPosts',
-        args: {
-          profileId: action.profile.id,
-          isFetchingMore: false,
-        },
-      }));
-      break;
     case actionTypes.TOGGLE_VIEW_TYPE:
       fetchPastReminders(dispatch, action);
       break;
     case actionTypes.POST_MOBILE_REMINDER:
-      dispatch(dataFetchActions.fetch({
-        name: 'mobileReminder',
-        args: {
-          updateId: action.updateId,
-        },
-      }));
+      dispatch(
+        dataFetchActions.fetch({
+          name: 'mobileReminder',
+          args: {
+            updateId: action.updateId,
+          },
+        })
+      );
       break;
     case actionTypes.STORY_GROUP_MOBILE_REMINDER: {
       if (action.storyGroup && action.storyGroup.storyDetails) {
@@ -48,29 +46,36 @@ export default ({ getState, dispatch }) => next => (action) => {
         const { stories } = storyGroup.storyDetails;
         const sendStories = stories.map(getMappedStories);
 
-        dispatch(dataFetchActions.fetch({
-          name: 'createStoryGroup',
-          args: {
-            profileId: selectedProfileId,
-            scheduledAt: null,
-            stories: sendStories,
-            shareNow: true,
-          },
-        }));
+        dispatch(
+          dataFetchActions.fetch({
+            name: 'createStoryGroup',
+            args: {
+              profileId: selectedProfileId,
+              scheduledAt: null,
+              stories: sendStories,
+              shareNow: true,
+            },
+          })
+        );
       }
       break;
     }
     case `mobileReminder_${dataFetchActionTypes.FETCH_SUCCESS}`:
-      dispatch(notificationActions.createNotification({
-        notificationType: 'success',
-        message: 'A push notification to your connected mobile devices has been sent so you can post to Instagram!',
-      }));
+      dispatch(
+        notificationActions.createNotification({
+          notificationType: 'success',
+          message:
+            'A push notification to your connected mobile devices has been sent so you can post to Instagram!',
+        })
+      );
       break;
     case `mobileReminder_${dataFetchActionTypes.FETCH_FAIL}`:
-      dispatch(notificationActions.createNotification({
-        notificationType: 'error',
-        message: action.error,
-      }));
+      dispatch(
+        notificationActions.createNotification({
+          notificationType: 'error',
+          message: action.error,
+        })
+      );
       break;
     default:
       break;

--- a/packages/sent/components/SentPosts/index.jsx
+++ b/packages/sent/components/SentPosts/index.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
   PostLists,
@@ -64,7 +64,12 @@ const SentPosts = ({
   loadMore,
   showAnalyzeBannerAfterFirstPost,
   isAnalyzeCustomer,
+  fetchSentPosts,
 }) => {
+  useEffect(() => {
+    fetchSentPosts();
+  }, [profileId]);
+
   if (loading) {
     return (
       <div style={loadingContainerStyle}>
@@ -147,6 +152,7 @@ const SentPosts = ({
 };
 
 SentPosts.propTypes = {
+  fetchSentPosts: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   moreToLoad: PropTypes.bool, // eslint-disable-line
   page: PropTypes.number, // eslint-disable-line

--- a/packages/sent/components/SentPosts/story.jsx
+++ b/packages/sent/components/SentPosts/story.jsx
@@ -48,6 +48,7 @@ storiesOf('SentPosts', module)
       onComposerCreateSuccess={action('onComposerCreateSuccess')}
       onClickUpgrade={action('onClickUpgrade')}
       onShareAgainClick={action('onShareAgainClick')}
+      fetchSentPosts={action('fetchSentPosts')}
     />
   ))
   .add('if in Business Account', () => (
@@ -60,5 +61,6 @@ storiesOf('SentPosts', module)
       onComposerCreateSuccess={action('onComposerCreateSuccess')}
       onClickUpgrade={action('onClickUpgrade')}
       onShareAgainClick={action('onShareAgainClick')}
+      fetchSentPosts={action('fetchSentPosts')}
     />
   ));

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -103,6 +103,13 @@ export default connect(
         })
       );
     },
+    fetchSentPosts: () => {
+      dispatch(
+        actions.fetchSentPosts({
+          profileId: ownProps.profileId,
+        })
+      );
+    },
   })
 )(SentPosts);
 

--- a/packages/sent/middleware.js
+++ b/packages/sent/middleware.js
@@ -1,17 +1,20 @@
-import { actionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
 import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
+import { actionTypes } from './reducer';
 
-export default ({ dispatch }) => next => (action) => { // eslint-disable-line no-unused-vars
+export default ({ dispatch }) => next => action => {
+  // eslint-disable-line no-unused-vars
   next(action);
   switch (action.type) {
-    case actionTypes.SELECT_PROFILE:
-      dispatch(dataFetchActions.fetch({
-        name: 'sentPosts',
-        args: {
-          profileId: action.profile.id,
-          isFetchingMore: false,
-        },
-      }));
+    case actionTypes.FETCH_SENT_POSTS:
+      dispatch(
+        dataFetchActions.fetch({
+          name: 'sentPosts',
+          args: {
+            profileId: action.profileId,
+            isFetchingMore: false,
+          },
+        })
+      );
       break;
     default:
       break;

--- a/packages/sent/middleware.test.js
+++ b/packages/sent/middleware.test.js
@@ -1,34 +1,29 @@
-import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
-import {
-  actions as dataFetchActions,
-} from '@bufferapp/async-data-fetch';
+import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 import middleware from './middleware';
+import { actionTypes } from './reducer';
 
 describe('middleware', () => {
   const next = jest.fn();
   const dispatch = jest.fn();
   it('should export middleware', () => {
-    expect(middleware)
-      .toBeDefined();
+    expect(middleware).toBeDefined();
   });
 
   it('should fetch sentPosts', () => {
     const action = {
-      type: profileActionTypes.SELECT_PROFILE,
-      profile: {
-        id: 'id1',
-      },
+      type: actionTypes.FETCH_SENT_POSTS,
+      profileId: 'id1',
     };
     middleware({ dispatch })(next)(action);
-    expect(next)
-    .toBeCalledWith(action);
-    expect(dispatch)
-    .toBeCalledWith(dataFetchActions.fetch({
-      name: 'sentPosts',
-      args: {
-        profileId: action.profile.id,
-        isFetchingMore: false,
-      },
-    }));
+    expect(next).toBeCalledWith(action);
+    expect(dispatch).toBeCalledWith(
+      dataFetchActions.fetch({
+        name: 'sentPosts',
+        args: {
+          profileId: action.profileId,
+          isFetchingMore: false,
+        },
+      })
+    );
   });
 });

--- a/packages/sent/reducer.js
+++ b/packages/sent/reducer.js
@@ -10,6 +10,7 @@ export const actionTypes = keyWrapper('SENT', {
   POST_IMAGE_CLICKED_NEXT: 0,
   POST_IMAGE_CLICKED_PREV: 0,
   POST_IMAGE_CLOSED: 0,
+  FETCH_SENT_POSTS: 0,
 });
 
 export const initialState = {
@@ -228,6 +229,10 @@ export const actions = {
     type: actionTypes.POST_IMAGE_CLOSED,
     updateId: post.id,
     post,
+    profileId,
+  }),
+  fetchSentPosts: ({ profileId }) => ({
+    type: actionTypes.FETCH_SENT_POSTS,
     profileId,
   }),
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

- Fetch sentPosts inside the `SentPosts` component, instead of users' SELECT_PROFILE.
- Fetch pastReminders inside the `PastRemindersWrapper` component, instead of users' SELECT_PROFILE.

<!--- Describe your changes in detail. -->

## Context & Notes
Used the effect hook instead of componentDidMount.
This change allows us to only fetch data when we need it.
[PUB-2193](https://buffer.atlassian.net/browse/PUB-2193)

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
