### PR TITLE
Fixes and improvements to code splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ vendor*.js
 vendor.css
 *.map
 *.vscode
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN yarn install --non-interactive
 
 COPY packages/server /usr/src/app
 COPY staticAssets.json /usr/src/app
+COPY webpackAssets.json /usr/src/app
 COPY version.json /usr/src/app
 
 EXPOSE 80

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,7 +12,6 @@ module.exports = function(api) {
       '@babel/plugin-syntax-dynamic-import',
       '@babel/plugin-transform-modules-commonjs',
       '@babel/plugin-proposal-export-default-from',
-      'babel-plugin-dynamic-import-node',
       [
         '@babel/plugin-transform-runtime',
         {
@@ -27,7 +26,7 @@ module.exports = function(api) {
     ],
     env: {
       test: {
-        plugins: ['require-context-hook'],
+        plugins: ['require-context-hook', 'babel-plugin-dynamic-import-node'],
       },
     },
   };

--- a/package.json
+++ b/package.json
@@ -154,10 +154,12 @@
     "webpack-cli": "3.3.8",
     "webpack-dev-middleware": "3.7.1",
     "webpack-dev-server": "3.8.0",
+    "webpack-manifest-plugin": "^2.2.0",
     "webpack-merge": "4.2.2",
     "xss": "1.0.6"
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "dependencies": {}
 }

--- a/packages/server/index.html
+++ b/packages/server/index.html
@@ -207,6 +207,7 @@
   {{{userScript}}}
   {{{bufferData}}}
   <!-- app scripts -->
+  {{{runtime}}}
   <script crossorigin src="{{{vendor}}}"></script>
   <script crossorigin src="{{{bundle}}}"></script>
 </body>

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -40,6 +40,7 @@ const pusher = require('./lib/pusher');
 const maintenanceHandler = require('./maintenanceHandler');
 const { getFaviconCode, setupFaviconRoutes } = require('./lib/favicon');
 const { getBugsnagClient, getBugsnagScript } = require('./lib/bugsnag');
+const commonWebpackConfig = require('./webpack.config.common');
 
 const app = express();
 const server = http.createServer(app);
@@ -52,6 +53,7 @@ let segmentKey = 'qsP2UfgODyoJB3px9SDkGX5I6wDtdQ6a';
 setupFaviconRoutes(app, isProduction);
 
 let staticAssets = {
+  'runtime.js': 'https://local.buffer.com:8080/static/runtime.js', // webpack runtime
   'bundle.js': 'https://local.buffer.com:8080/static/bundle.js',
   'bundle.css': 'https://local.buffer.com:8080/static/bundle.css',
   'vendor.js': 'https://local.buffer.com:8080/static/vendor.js',
@@ -61,7 +63,9 @@ app.set('isProduction', isProduction);
 
 if (isProduction) {
   staticAssets = JSON.parse(
-    fs.readFileSync(join(__dirname, 'staticAssets.json'), 'utf8')
+    // Load the `webpackAssets.json` file instead of `staticAssets.json` that the buffer-static-uploader
+    // generates because the former keeps simple key names like 'bundle.js' that don't include the hash.
+    fs.readFileSync(join(__dirname, 'webpackAssets.json'), 'utf8')
   );
   segmentKey = '9Plsiyvw9NEgXEN7eSBwiAGlHD3DHp0A';
   // Ensure that static assets is not empty
@@ -230,6 +234,21 @@ const getBugsnag = ({ userId }) => {
 // We are hard coding the planCode check to 1 for free users, but if we need more we should import constants instead
 const canIncludeFullstory = user => (user ? user.planCode !== 1 : true);
 
+/**
+ * Webpack runtime script, inline into the HTML in prod, locally just include the script:
+ * https://survivejs.com/webpack/optimizing/separating-manifest/
+ */
+const getRuntimeScript = () => {
+  if (isProduction) {
+    const {
+      output: { publicPath },
+    } = commonWebpackConfig;
+    const runtimeFilename = staticAssets['runtime.js'].replace(publicPath, '');
+    return fs.readFileSync(join(__dirname, runtimeFilename), 'utf8');
+  }
+  return `<script crossorigin src="${staticAssets['runtime.js']}"></script>`;
+};
+
 const getHtml = ({
   notification,
   userId,
@@ -239,27 +258,12 @@ const getHtml = ({
   profiles,
   includeFullstory = true,
 }) => {
-  /**
-   * Because our static assets have hashes in their names in production
-   * they will also be keyed that way in the staticAssets file. So we
-   * need to do a bit of magic here to extract the correct key for the
-   * bundles full path.
-   */
-  const filenames = Object.keys(staticAssets);
-  const bundleKey = isProduction
-    ? filenames.find(file => file.match(/bundle\.(.*)\.js$/))
-    : 'bundle.js';
-  const vendorKey = isProduction
-    ? filenames.find(file => file.match(/vendor\.(.*)\.js$/))
-    : 'vendor.js';
-  const bundleCssKey = isProduction
-    ? filenames.find(file => file.match(/bundle\.(.*)\.css$/))
-    : 'bundle.css';
   return fs
     .readFileSync(join(__dirname, 'index.html'), 'utf8')
-    .replace('{{{vendor}}}', staticAssets[vendorKey])
-    .replace('{{{bundle}}}', staticAssets[bundleKey])
-    .replace('{{{bundle-css}}}', staticAssets[bundleCssKey])
+    .replace('{{{runtime}}}', getRuntimeScript())
+    .replace('{{{vendor}}}', staticAssets['vendor.js'])
+    .replace('{{{bundle}}}', staticAssets['bundle.js'])
+    .replace('{{{bundle-css}}}', staticAssets['bundle.css'])
     .replace('{{{stripeScript}}}', stripeScript)
     .replace('{{{fullStoryScript}}}', getFullstory({ includeFullstory }))
     .replace('{{{bugsnagScript}}}', getBugsnag({ userId }))

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -40,7 +40,6 @@ const pusher = require('./lib/pusher');
 const maintenanceHandler = require('./maintenanceHandler');
 const { getFaviconCode, setupFaviconRoutes } = require('./lib/favicon');
 const { getBugsnagClient, getBugsnagScript } = require('./lib/bugsnag');
-const commonWebpackConfig = require('./webpack.config.common');
 
 const app = express();
 const server = http.createServer(app);
@@ -240,10 +239,7 @@ const canIncludeFullstory = user => (user ? user.planCode !== 1 : true);
  */
 const getRuntimeScript = () => {
   if (isProduction) {
-    const {
-      output: { publicPath },
-    } = commonWebpackConfig;
-    const runtimeFilename = staticAssets['runtime.js'].replace(publicPath, '');
+    const runtimeFilename = staticAssets['runtime.js'].split('/').pop();
     return fs.readFileSync(join(__dirname, runtimeFilename), 'utf8');
   }
   return `<script crossorigin src="${staticAssets['runtime.js']}"></script>`;

--- a/packages/server/webpack.config.common.js
+++ b/packages/server/webpack.config.common.js
@@ -72,6 +72,9 @@ module.exports = {
     }),
   ],
   optimization: {
+    runtimeChunk: {
+      name: 'manifest',
+    },
     splitChunks: {
       cacheGroups: {
         vendors: false, // Disable the default vendors cache group for finer control

--- a/packages/server/webpack.config.common.js
+++ b/packages/server/webpack.config.common.js
@@ -73,9 +73,10 @@ module.exports = {
   ],
   optimization: {
     runtimeChunk: {
-      name: 'manifest',
+      name: 'runtime',
     },
     splitChunks: {
+      name: false, // don't use dynamic names which could invalidate cache when they change
       cacheGroups: {
         vendors: false, // Disable the default vendors cache group for finer control
         vendor: {

--- a/packages/server/webpack.config.prod.js
+++ b/packages/server/webpack.config.prod.js
@@ -2,7 +2,11 @@
 const merge = require('webpack-merge');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const ManifestPlugin = require('webpack-manifest-plugin');
+
 const common = require('./webpack.config.common.js');
+
+const publicPath = 'https://static.buffer.com/publish/';
 
 const plugins = [
   new MiniCssExtractPlugin({
@@ -13,12 +17,26 @@ const plugins = [
     filename: '[name].[contenthash:8].css',
     chunkFilename: '[name].[contenthash:8].css',
   }),
+  /**
+   * Outputs a JSON file that maps names like 'bundle.js' to the full URL
+   * in production (e.g., https://static.buffer.com/publish/bundle._hash_.js)
+   *
+   * Used in server/index.js to inject bundled files
+   */
+  new ManifestPlugin({
+    fileName: 'webpackAssets.json',
+  }),
 ];
 
 let devtool = 'source-map';
 
+const optimization = {
+  nodeEnv: 'production',
+};
+
 // `yarn run build:analyze` to visually inspect the bundle
-// when building locally
+// when building locally, also disable some optimizations
+// to increase speed of bundling
 if (process.env.ANALYZE_BUNDLE) {
   plugins.push(new BundleAnalyzerPlugin());
   devtool = false;
@@ -27,14 +45,13 @@ if (process.env.ANALYZE_BUNDLE) {
 const merged = merge(common, {
   mode: 'production',
   devtool,
-  optimization: {
-    nodeEnv: 'production',
-  },
+  optimization,
   plugins,
   output: {
-    publicPath: 'https://static.buffer.com/publish/',
+    publicPath,
     filename: '[name].[chunkhash:8].js',
   },
+  performance: { hints: false }, // don't warn that the bundles are big, we know ;)
 });
 
 module.exports = merged;

--- a/packages/server/webpack.config.prod.js
+++ b/packages/server/webpack.config.prod.js
@@ -6,8 +6,12 @@ const common = require('./webpack.config.common.js');
 
 const plugins = [
   new MiniCssExtractPlugin({
-    filename: '[name].[chunkhash:8].css',
-    chunkFilename: '[name].[chunkhash:8].css',
+    /**
+     * Using `contenthash` here instead of `chunkhash` to ensure the CSS hash doesn't change unnecessarily
+     * See: https://survivejs.com/webpack/optimizing/adding-hashes-to-filenames/#setting-up-hashing
+     */
+    filename: '[name].[contenthash:8].css',
+    chunkFilename: '[name].[contenthash:8].css',
   }),
 ];
 

--- a/pre-build.sh
+++ b/pre-build.sh
@@ -20,6 +20,9 @@ yarn run bugsnag:release
 # Build the bundle and it's assets (CSS, chunks, source maps)
 yarn run build
 
+echo "WEBPACK ASSETS:"
+cat ./webpackAssets.json
+
 # Upload the static assets to S3
 UPLOADER="https://github.com/bufferapp/buffer-static-upload/releases/download/0.3.0/buffer-static-upload-`uname -s`"
 curl -L $UPLOADER > ./buffer-static-upload

--- a/yarn.lock
+++ b/yarn.lock
@@ -8608,6 +8608,15 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^8.0.1:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -11426,7 +11435,7 @@ lodash.uniqby@4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.11:
+"lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.11:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -17730,6 +17739,16 @@ webpack-log@^2.0.0:
   dependencies:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
+
+webpack-manifest-plugin@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz#19ca69b435b0baec7e29fbe90fb4015de2de4f16"
+  integrity sha512-9S6YyKKKh/Oz/eryM1RyLVDVmy3NSPV0JXMRhZ18fJsq+AwGxUY34X54VNwkzYcEmEkDwNxuEOboCZEebJXBAQ==
+  dependencies:
+    fs-extra "^7.0.0"
+    lodash ">=3.5 <5"
+    object.entries "^1.1.0"
+    tapable "^1.0.0"
 
 webpack-merge@4.2.2:
   version "4.2.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

* Fixed code splitting that broke in https://github.com/bufferapp/buffer-publish/commit/a90f9216acf7eef0bef8f2c4d6cb8036bca9d679
* Fix hashing of CSS so that it's not linked to changes in JS
* Split out the runtime/manifest chunk and inline that into the HTML (production only) -- this should prevent hashes changing in the main bundles. [[ref]](https://survivejs.com/webpack/optimizing/separating-manifest/)
* Added new `ManifestPlugin` which outputs a JSON file that we're using now instead of `staticAssets.json` since it is keyed by non-hashed filenames. (cc @msanroman in case that might be helpful for Analzye, it simplified some of the server code.) [[ref]](https://github.com/bufferapp/buffer-publish/compare/task/code-splitting-improvements?expand=1#diff-068e7c6acbb89d55e9fa2192f813a6d8R66-R68)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
