### PR TITLE
[PUB-2249] Auto select monthly option for Awesome promo users

### DIFF
--- a/packages/switch-plan-modal/reducer.js
+++ b/packages/switch-plan-modal/reducer.js
@@ -45,6 +45,7 @@ export default (state = initialState, action) => {
         ...state,
         source: action.source || 'unknown',
         plan: action.plan || 'pro',
+        cycle: action.isPromo && action.plan === 'pro' ? 'month' : 'year',
         isPromo: action.isPromo || false,
       };
     case modalsActionTypes.HIDE_SWITCH_PLAN_MODAL:


### PR DESCRIPTION
## Description

In the switch plan modal, the only Pro option for Awesome users who are receiving the promotional discount will be the monthly plan. To reflect this, we're changing the default behavior for the switch plan modal for these users so that the monthly option is auto selected, instead of the yearly payment option.

## Context & Notes

https://buffer.atlassian.net/browse/PUB-2249

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`