### PR TITLE
[PUB-2275] Remove app switcher modal

### DIFF
--- a/packages/app-switcher/reducer.js
+++ b/packages/app-switcher/reducer.js
@@ -25,7 +25,7 @@ export default (state = initialState, action) => {
       return {
         ...state,
         // User is not in phased rollout - so they can switch
-        showGoBackToClassic: !action.result.hasNewPublish,
+        showGoBackToClassic: false,
         user: {
           ...action.result,
           loading: false,

--- a/packages/app-switcher/reducer.test.js
+++ b/packages/app-switcher/reducer.test.js
@@ -12,28 +12,6 @@ describe('reducer', () => {
       expect(reducer(undefined, action)).toEqual(initialState);
     });
 
-    it('sets showGoBackToClassic to true when the user is on new publish beta', () => {
-      const features = ['new_publish_beta', 'new_publish_beta_redirect'];
-      const stateAfter = {
-        ...initialState,
-        showGoBackToClassic: true,
-        user: {
-          loading: false,
-          features,
-        },
-      };
-
-      const action = {
-        type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
-        result: {
-          features,
-        },
-      };
-
-      deepFreeze(action);
-      expect(reducer(undefined, action)).toEqual(stateAfter);
-    });
-
     it('sets submittingFeedback to true on FETCH_START', () => {
       const stateAfter = {
         ...initialState,


### PR DESCRIPTION
## Description
Remove outdated app switcher modal.
## Context & Notes
Change is required so that Awesome customers who visit the Payday page are unencumbered by any other CTAs.

https://buffer.atlassian.net/browse/PUB-2275

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
