### PR TITLE
[PUB-2263] Add set reminders modal

### DIFF
--- a/packages/constants/index.js
+++ b/packages/constants/index.js
@@ -48,6 +48,10 @@ const QUEUE_LIMIT_PRO_UPGRADE =
   'publish-composer-queueLimitNotification-proUpgrade-1';
 const PINTEREST_PRO_UPGRADE =
   'publish-orgAdminConnect-upgradeToConnectPinterest-proUpgrade-1';
+const REMINDERS_MODAL =
+'publish-app-setRemindersModal-setReminders-1';
+const REMINDERS_BANNER =
+'publish-queue-remindersBanner-setReminders-1';
 const PLAN_OVERVIEW_PRO_UPGRADE =
   'publish-orgAdminConnect-planOverview-proUpgrade-1';
 const PLANS_SOLO_PREMIUM_UPGRADE =
@@ -153,6 +157,8 @@ module.exports = {
     LOCKED_PROFILE_PRO_UPGRADE,
     LOCKED_PROFILE_BUSINESS_UPGRADE,
     PINTEREST_PRO_UPGRADE,
+    REMINDERS_MODAL,
+    REMINDERS_BANNER,
     PLAN_OVERVIEW_PRO_UPGRADE,
     PLANS_SOLO_PREMIUM_UPGRADE,
     PLANS_SOLO_PREMIUM_DOWNGRADE,

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -69,6 +69,13 @@
     "planTrial": "You're on the {plan} trial. ",
     "startSubscription": "Start Subscription"
   },
+  "set-reminders-modal": {
+    "tag": "Available on Android and iOS",
+    "title": "Set up Reminders to complete your Instagram post.",
+    "description": "Due to Instagram limitations, we can't auto-publish some of your queued posts. Set up Reminders now to make sure all your content gets published on time.",
+    "dismiss": "Dismiss",
+    "setReminders": "Set Up Reminders"
+  },
   "switch-plan-modal": {
     "proUpgradeHeader": "Upgrade to the Pro Plan!",
     "proTrialistUpgradeHeader": "Complete your trial and upgrade to the Pro Plan!",

--- a/packages/modals/reducer.js
+++ b/packages/modals/reducer.js
@@ -12,6 +12,7 @@ export const initialState = {
   showWelcomeB4BTrialModal: false,
   showInstagramFirstCommentModal: false,
   showTrialCompleteModal: false,
+  showSetRemindersModal: false,
   showInstagramFirstCommentProTrialModal: false,
   showCloseComposerConfirmationModal: false,
   modalToShowLater: null,
@@ -34,6 +35,8 @@ export const actionTypes = keyWrapper('MODALS', {
   HIDE_WELCOME_B4B_TRIAL_MODAL: 0,
   SHOW_TRIAL_COMPLETE_MODAL: 0,
   HIDE_TRIAL_COMPLETE_MODAL: 0,
+  SHOW_SET_REMINDERS_MODAL: 0,
+  HIDE_SET_REMINDERS_MODAL: 0,
   SHOW_INSTAGRAM_FIRST_COMMENT_MODAL: 0,
   HIDE_INSTAGRAM_FIRST_COMMENT_MODAL: 0,
   SHOW_INSTAGRAM_FIRST_COMMENT_PRO_TRIAL_MODAL: 0,
@@ -138,6 +141,16 @@ export default (state = initialState, action) => {
           params: action.params,
         },
       };
+    case actionTypes.SHOW_SET_REMINDERS_MODAL:
+      return {
+        ...state,
+        showSetRemindersModal: true,
+      };
+    case actionTypes.HIDE_SET_REMINDERS_MODAL:
+      return {
+        ...state,
+        showSetRemindersModal: false,
+      };
     case actionTypes.SHOW_WELCOME_B4B_TRIAL_MODAL:
       return {
         ...state,
@@ -240,6 +253,12 @@ export const actions = {
     params: {
       profileId,
     },
+  }),
+  showSetRemindersModal: () => ({
+    type: actionTypes.SHOW_SET_REMINDERS_MODAL,
+  }),
+  hideSetRemindersModal: () => ({
+    type: actionTypes.HIDE_SET_REMINDERS_MODAL,
   }),
   showWelcomeB4BTrialModal: () => ({
     type: actionTypes.SHOW_WELCOME_B4B_TRIAL_MODAL,

--- a/packages/modals/reducer.test.js
+++ b/packages/modals/reducer.test.js
@@ -3,145 +3,248 @@ import reducer, { initialState, actions } from './reducer';
 describe('reducer', () => {
   it('should return initial state', () => {
     const action = { type: 'INIT' };
-    expect(reducer(undefined, action))
-      .toEqual(initialState);
+    expect(reducer(undefined, action)).toEqual(initialState);
   });
 
   describe('actions', () => {
     it('should show upgrade modal', () => {
-      expect(reducer(initialState, actions.showSwitchPlanModal({ source: 'foo' })))
-        .toEqual(Object.assign(initialState, { showSwitchPlanModal: true, switchPlanModalSource: 'foo' }));
+      expect(
+        reducer(initialState, actions.showSwitchPlanModal({ source: 'foo' }))
+      ).toEqual(
+        Object.assign(initialState, {
+          showSwitchPlanModal: true,
+          switchPlanModalSource: 'foo',
+        })
+      );
     });
     it('should hide upgrade modal', () => {
-      const stateWithVisibleModal = Object.assign(
-        initialState,
-        { showSwitchPlanModal: true, switchPlanModalSource: 'foo' },
+      const stateWithVisibleModal = Object.assign(initialState, {
+        showSwitchPlanModal: true,
+        switchPlanModalSource: 'foo',
+      });
+      expect(
+        reducer(stateWithVisibleModal, actions.hideUpgradeModal())
+      ).toEqual(
+        Object.assign(initialState, {
+          showSwitchPlanModal: false,
+          switchPlanModalSource: 'foo',
+        })
       );
-      expect(reducer(stateWithVisibleModal, actions.hideUpgradeModal()))
-        .toEqual(Object.assign(initialState, { showSwitchPlanModal: false, switchPlanModalSource: 'foo' }));
     });
     it('should show welcome modal', () => {
-      expect(reducer(initialState, actions.showWelcomeModal()))
-        .toEqual(Object.assign(initialState, { showWelcomeModal: true }));
+      expect(reducer(initialState, actions.showWelcomeModal())).toEqual(
+        Object.assign(initialState, { showWelcomeModal: true })
+      );
     });
     it('should hide welcome modal', () => {
-      const stateWithVisibleModal = Object.assign(
-        initialState,
-        { showWelcomeModal: true },
-      );
-      expect(reducer(stateWithVisibleModal, actions.hideWelcomeModal()))
-        .toEqual(Object.assign(initialState, { showWelcomeModal: false }));
+      const stateWithVisibleModal = Object.assign(initialState, {
+        showWelcomeModal: true,
+      });
+      expect(
+        reducer(stateWithVisibleModal, actions.hideWelcomeModal())
+      ).toEqual(Object.assign(initialState, { showWelcomeModal: false }));
     });
     it('should show steal profile modal', () => {
-      expect(reducer(initialState, actions.showStealProfileModal({ stealProfileUsername: 'foo' })))
-        .toEqual(Object.assign(initialState, { showStealProfileModal: true, stealProfileUsername: 'foo' }));
+      expect(
+        reducer(
+          initialState,
+          actions.showStealProfileModal({ stealProfileUsername: 'foo' })
+        )
+      ).toEqual(
+        Object.assign(initialState, {
+          showStealProfileModal: true,
+          stealProfileUsername: 'foo',
+        })
+      );
     });
     it('should hide steal profile modal', () => {
-      const stateWithVisibleModal = Object.assign(
-        initialState,
-        { showStealProfileModal: true, stealProfileUsername: 'foo' },
-      );
-      expect(reducer(stateWithVisibleModal, actions.hideStealProfileModal()))
-        .toEqual(Object.assign(initialState, { showStealProfileModal: false }));
+      const stateWithVisibleModal = Object.assign(initialState, {
+        showStealProfileModal: true,
+        stealProfileUsername: 'foo',
+      });
+      expect(
+        reducer(stateWithVisibleModal, actions.hideStealProfileModal())
+      ).toEqual(Object.assign(initialState, { showStealProfileModal: false }));
     });
     it('should show instagram direct posting modal', () => {
-      expect(reducer(initialState, actions.showInstagramDirectPostingModal({ profileId: 'id1' })))
-        .toEqual(Object.assign(initialState, { showInstagramDirectPostingModal: true }));
+      expect(
+        reducer(
+          initialState,
+          actions.showInstagramDirectPostingModal({ profileId: 'id1' })
+        )
+      ).toEqual(
+        Object.assign(initialState, { showInstagramDirectPostingModal: true })
+      );
     });
     it('should hide instagram direct posting modal', () => {
-      const stateWithVisibleModal = Object.assign(
-        initialState,
-        { showInstagramDirectPostingModal: true },
+      const stateWithVisibleModal = Object.assign(initialState, {
+        showInstagramDirectPostingModal: true,
+      });
+      expect(
+        reducer(
+          stateWithVisibleModal,
+          actions.hideInstagramDirectPostingModal()
+        )
+      ).toEqual(
+        Object.assign(initialState, { showInstagramDirectPostingModal: false })
       );
-      expect(reducer(stateWithVisibleModal, actions.hideInstagramDirectPostingModal()))
-        .toEqual(Object.assign(initialState, { showInstagramDirectPostingModal: false }));
     });
     it('should show welcome b4b trial modal', () => {
-      expect(reducer(initialState, actions.showWelcomeB4BTrialModal()))
-        .toEqual(Object.assign(initialState, { showWelcomeB4BTrialModal: true }));
+      expect(reducer(initialState, actions.showWelcomeB4BTrialModal())).toEqual(
+        Object.assign(initialState, { showWelcomeB4BTrialModal: true })
+      );
     });
     it('should hide welcome b4b trial modal', () => {
-      const stateWithVisibleModal = Object.assign(
-        initialState,
-        { showWelcomeB4BTrialModal: true },
+      const stateWithVisibleModal = Object.assign(initialState, {
+        showWelcomeB4BTrialModal: true,
+      });
+      expect(
+        reducer(stateWithVisibleModal, actions.hideWelcomeB4BTrialModal())
+      ).toEqual(
+        Object.assign(initialState, { showWelcomeB4BTrialModal: false })
       );
-      expect(reducer(stateWithVisibleModal, actions.hideWelcomeB4BTrialModal()))
-        .toEqual(Object.assign(initialState, { showWelcomeB4BTrialModal: false }));
     });
     it('should show profiles disconnected modal', () => {
-      expect(reducer(initialState, actions.showProfilesDisconnectedModal()))
-        .toEqual(Object.assign(initialState, { showProfilesDisconnectedModal: true }));
+      expect(
+        reducer(initialState, actions.showProfilesDisconnectedModal())
+      ).toEqual(
+        Object.assign(initialState, { showProfilesDisconnectedModal: true })
+      );
     });
     it('should hide profiles disconnected modal', () => {
-      const stateWithVisibleModal = Object.assign(
-        initialState,
-        { showProfilesDisconnectedModal: true },
+      const stateWithVisibleModal = Object.assign(initialState, {
+        showProfilesDisconnectedModal: true,
+      });
+      expect(
+        reducer(stateWithVisibleModal, actions.hideProfilesDisconnectedModal())
+      ).toEqual(
+        Object.assign(initialState, { showProfilesDisconnectedModal: false })
       );
-      expect(reducer(stateWithVisibleModal, actions.hideProfilesDisconnectedModal()))
-        .toEqual(Object.assign(initialState, { showProfilesDisconnectedModal: false }));
     });
     it('should show welcome paid modal', () => {
-      expect(reducer(initialState, actions.showWelcomePaidModal()))
-        .toEqual(Object.assign(initialState, { showWelcomePaidModal: true }));
+      expect(reducer(initialState, actions.showWelcomePaidModal())).toEqual(
+        Object.assign(initialState, { showWelcomePaidModal: true })
+      );
     });
     it('should hide welcome paid modal', () => {
-      const stateWithVisibleModal = Object.assign(
-        initialState,
-        { showWelcomePaidModal: true },
-      );
-      expect(reducer(stateWithVisibleModal, actions.hideWelcomePaidModal()))
-        .toEqual(Object.assign(initialState, { showWelcomePaidModal: false }));
+      const stateWithVisibleModal = Object.assign(initialState, {
+        showWelcomePaidModal: true,
+      });
+      expect(
+        reducer(stateWithVisibleModal, actions.hideWelcomePaidModal())
+      ).toEqual(Object.assign(initialState, { showWelcomePaidModal: false }));
     });
     it('should show instagram first comment start trial modal', () => {
-      expect(reducer(initialState, actions.showInstagramFirstCommentProTrialModal({ source: 'foo' })))
-        .toEqual(Object.assign(initialState, { showInstagramFirstCommentProTrialModal: true }));
+      expect(
+        reducer(
+          initialState,
+          actions.showInstagramFirstCommentProTrialModal({ source: 'foo' })
+        )
+      ).toEqual(
+        Object.assign(initialState, {
+          showInstagramFirstCommentProTrialModal: true,
+        })
+      );
     });
     it('should hide instagram first comment start trial modal', () => {
-      const stateWithVisibleModal = Object.assign(
-        initialState,
-        { showInstagramFirstCommentProTrialModal: true },
+      const stateWithVisibleModal = Object.assign(initialState, {
+        showInstagramFirstCommentProTrialModal: true,
+      });
+      expect(
+        reducer(
+          stateWithVisibleModal,
+          actions.hideInstagramFirstCommentProTrialModal()
+        )
+      ).toEqual(
+        Object.assign(initialState, {
+          showInstagramFirstCommentProTrialModal: false,
+        })
       );
-      expect(reducer(stateWithVisibleModal, actions.hideInstagramFirstCommentProTrialModal()))
-        .toEqual(Object.assign(initialState, { showInstagramFirstCommentProTrialModal: false }));
     });
     it('should show close composer confirmation modal', () => {
-      expect(reducer(initialState, actions.showCloseComposerConfirmationModal()))
-        .toEqual(Object.assign(initialState, { showCloseComposerConfirmationModal: true }));
+      expect(
+        reducer(initialState, actions.showCloseComposerConfirmationModal())
+      ).toEqual(
+        Object.assign(initialState, {
+          showCloseComposerConfirmationModal: true,
+        })
+      );
     });
     it('should hide close composer confirmation modal', () => {
-      expect(reducer(initialState, actions.hideCloseComposerConfirmationModal()))
-        .toEqual(Object.assign(initialState, { showCloseComposerConfirmationModal: false }));
+      expect(
+        reducer(initialState, actions.hideCloseComposerConfirmationModal())
+      ).toEqual(
+        Object.assign(initialState, {
+          showCloseComposerConfirmationModal: false,
+        })
+      );
+    });
+    it('should show set reminders modal', () => {
+      expect(reducer(initialState, actions.showSetRemindersModal())).toEqual(
+        Object.assign(initialState, {
+          showSetRemindersModal: true,
+        })
+      );
+    });
+    it('should hide set reminders modal', () => {
+      expect(reducer(initialState, actions.hideSetRemindersModal())).toEqual(
+        Object.assign(initialState, {
+          showSetRemindersModal: false,
+        })
+      );
     });
     it('should show instagram first comment modal', () => {
-      expect(reducer(initialState, actions.showInstagramFirstCommentModal({ ids: 'ids' })))
-        .toEqual(Object.assign(initialState,
-          { showInstagramFirstCommentModal: true, firstCommentIds: 'ids' }));
+      expect(
+        reducer(
+          initialState,
+          actions.showInstagramFirstCommentModal({ ids: 'ids' })
+        )
+      ).toEqual(
+        Object.assign(initialState, {
+          showInstagramFirstCommentModal: true,
+          firstCommentIds: 'ids',
+        })
+      );
     });
     it('should hide instagram first comment modal', () => {
-      expect(reducer(initialState, actions.hideInstagramFirstCommentModal()))
-        .toEqual(Object.assign(initialState,
-          { showInstagramFirstCommentModal: false, firstCommentIds: null }));
+      expect(
+        reducer(initialState, actions.hideInstagramFirstCommentModal())
+      ).toEqual(
+        Object.assign(initialState, {
+          showInstagramFirstCommentModal: false,
+          firstCommentIds: null,
+        })
+      );
     });
     it('should show trial complete modal', () => {
-      expect(reducer(initialState, actions.showTrialCompleteModal()))
-        .toEqual(Object.assign(initialState,
-          { showTrialCompleteModal: true }));
+      expect(reducer(initialState, actions.showTrialCompleteModal())).toEqual(
+        Object.assign(initialState, { showTrialCompleteModal: true })
+      );
     });
     it('should hide trial complete modal', () => {
-      expect(reducer(initialState, actions.hideTrialCompleteModal()))
-        .toEqual(Object.assign(initialState,
-          { showTrialCompleteModal: false }));
+      expect(reducer(initialState, actions.hideTrialCompleteModal())).toEqual(
+        Object.assign(initialState, { showTrialCompleteModal: false })
+      );
     });
     it('should save modal to show later', () => {
-      expect(reducer(initialState, actions.saveModalToShowLater({ modalId: 'modalId', profileId: 'profileId' })))
-        .toEqual(Object.assign(initialState, {
+      expect(
+        reducer(
+          initialState,
+          actions.saveModalToShowLater({
+            modalId: 'modalId',
+            profileId: 'profileId',
+          })
+        )
+      ).toEqual(
+        Object.assign(initialState, {
           modalToShowLater: {
             id: 'modalId',
             params: {
               profileId: 'profileId',
             },
           },
-        }));
+        })
+      );
     });
   });
 });

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -70,6 +70,7 @@ const QueuedPosts = ({
   hasPushNotifications,
   hasAtLeastOneReminderPost,
   onComposerOverlayClick,
+  onSetRemindersClick,
 }) => {
   if (loading) {
     return (
@@ -96,7 +97,9 @@ const QueuedPosts = ({
       <div>
         {!hasPushNotifications &&
           isInstagramProfile &&
-          hasAtLeastOneReminderPost && <RemindersBanner />}
+          hasAtLeastOneReminderPost && (
+            <RemindersBanner onSetRemindersClick={onSetRemindersClick} />
+          )}
         <div style={topBarContainerStyle}>
           <div style={composerStyle}>
             {showComposer && !editMode && (
@@ -195,6 +198,7 @@ QueuedPosts.propTypes = {
   onImageClose: PropTypes.func.isRequired,
   onDropPost: PropTypes.func.isRequired,
   onSwapPosts: PropTypes.func.isRequired,
+  onSetRemindersClick: PropTypes.func.isRequired,
   showComposer: PropTypes.bool,
   editMode: PropTypes.bool,
   paused: PropTypes.bool,

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -2,6 +2,8 @@ import { connect } from 'react-redux';
 import { actions as profileSidebarActions } from '@bufferapp/publish-profile-sidebar/reducer';
 import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
+import { SEGMENT_NAMES } from '@bufferapp/publish-constants';
+import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { trackAction } from '@bufferapp/publish-data-tracking';
 
 import { actions } from './reducer';
@@ -202,6 +204,13 @@ export default connect(
     },
     onHideInstagramModal: () => {
       dispatch(actions.handleHideInstagramModal());
+    },
+    onSetRemindersClick: () => {
+      window.location.assign(
+        `${getURL.getRemindersURL({
+          cta: SEGMENT_NAMES.REMINDERS_BANNER,
+        })}`
+      );
     },
     onCalendarClick: (weekOrMonth, trackingAction) => {
       const openAfterTrack = () => {

--- a/packages/server/formatters/src/getURL.js
+++ b/packages/server/formatters/src/getURL.js
@@ -81,6 +81,14 @@ module.exports = {
     }
     return `https://buffer.com/app/account/receipts?content_only=true${ctaParam}`;
   },
+  getRemindersURL: ({ cta }) => {
+    const ctaParam = cta ? `&cta=${cta}` : '';
+    // Temporary link, to be updated soon
+    if (window.location.hostname === 'publish.local.buffer.com') {
+      return `https://local.buffer.com/${ctaParam}`;
+    }
+    return `https://buffer.com/${ctaParam}`;
+  },
   getPublishUrl: () => {
     if (window.location.hostname === 'publish.local.buffer.com') {
       return 'https://publish.local.buffer.com';

--- a/packages/set-reminders-modal/components/SetRemindersModal/index.jsx
+++ b/packages/set-reminders-modal/components/SetRemindersModal/index.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Popover } from '@bufferapp/components';
+import { white } from '@bufferapp/ui/style/colors';
+import { borderRadius } from '@bufferapp/ui/style/borders';
+import { Button, Text } from '@bufferapp/ui';
+
+const Modal = styled.div`
+  background-color: ${white};
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  border-radius: ${borderRadius};
+  text-align: left;
+  width: 450px;
+`;
+
+const Title = styled(Text)`
+  margin: 0;
+`;
+
+const Description = styled(Text)`
+  margin-bottom: 24px;
+`;
+
+const ModalContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 16px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  align-self: flex-end;
+`;
+
+const Tag = styled(Text)`
+  position: absolute;
+  left: 16px;
+  top: 150px;
+  font-size: 12px;
+  width: 90px;
+`;
+
+const SetRemindersModal = ({
+  translations,
+  onCloseModalClick,
+  onSetRemindersClick,
+}) => (
+  <Popover width="100%" top="5rem">
+    <Modal>
+      <img
+        width="100%"
+        alt="push_notifications_snippet"
+        src="https://buffer-publish.s3.amazonaws.com/images/stories-promo-modal.png"
+      />
+      <Tag type="p" color="white">
+        {translations.tag}
+      </Tag>
+      <ModalContent>
+        <Title type="h2">{translations.title}</Title>
+        <Description type="p">{translations.description}</Description>
+        <ButtonWrapper>
+          <Button
+            type="text"
+            label={translations.dismiss}
+            onClick={onCloseModalClick}
+          />
+          <Button
+            type="primary"
+            label={translations.setReminders}
+            onClick={onSetRemindersClick}
+          />
+        </ButtonWrapper>
+      </ModalContent>
+    </Modal>
+  </Popover>
+);
+
+SetRemindersModal.propTypes = {
+  translations: PropTypes.shape({
+    tag: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    dismiss: PropTypes.string.isRequired,
+    setReminders: PropTypes.string.isRequired,
+  }).isRequired,
+  onCloseModalClick: PropTypes.func.isRequired,
+  onSetRemindersClick: PropTypes.func.isRequired,
+};
+
+export default SetRemindersModal;

--- a/packages/set-reminders-modal/components/SetRemindersModal/index.jsx
+++ b/packages/set-reminders-modal/components/SetRemindersModal/index.jsx
@@ -39,7 +39,7 @@ const ButtonWrapper = styled.div`
 const Tag = styled(Text)`
   position: absolute;
   left: 16px;
-  top: 150px;
+  top: 135px;
   font-size: 12px;
   width: 90px;
 `;

--- a/packages/set-reminders-modal/components/SetRemindersModal/index.jsx
+++ b/packages/set-reminders-modal/components/SetRemindersModal/index.jsx
@@ -54,7 +54,7 @@ const SetRemindersModal = ({
       <img
         width="100%"
         alt="push_notifications_snippet"
-        src="https://buffer-publish.s3.amazonaws.com/images/stories-promo-modal.png"
+        src="https://buffer-publish.s3.amazonaws.com/images/ig-reminders-modal.png"
       />
       <Tag type="p" color="white">
         {translations.tag}

--- a/packages/set-reminders-modal/components/SetRemindersModal/story.jsx
+++ b/packages/set-reminders-modal/components/SetRemindersModal/story.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withA11y } from '@storybook/addon-a11y';
+import translations from '@bufferapp/publish-i18n/translations/en-us.json';
+
+import SetRemindersModal from './index';
+
+storiesOf('Modals|SetRemindersModal', module)
+  .addDecorator(withA11y)
+  .add('default', () => (
+    <SetRemindersModal
+      translations={translations['set-reminders-modal']}
+      onCloseModalClick={action('close-modal')}
+      onSetRemindersClick={action('set-reminders')}
+    />
+  ));

--- a/packages/set-reminders-modal/index.js
+++ b/packages/set-reminders-modal/index.js
@@ -1,0 +1,23 @@
+import { connect } from 'react-redux';
+import { actions as modalsActions } from '@bufferapp/publish-modals/reducer';
+import { SEGMENT_NAMES } from '@bufferapp/publish-constants';
+import { getURL } from '@bufferapp/publish-server/formatters/src';
+import SetRemindersModal from './components/SetRemindersModal';
+
+export default connect(
+  state => ({
+    translations: state.i18n.translations['set-reminders-modal'],
+  }),
+  dispatch => ({
+    onCloseModalClick: () => {
+      dispatch(modalsActions.hideSetRemindersModal());
+    },
+    onSetRemindersClick: () => {
+      window.location.assign(
+        `${getURL.getRemindersURL({
+          cta: SEGMENT_NAMES.REMINDERS_MODAL,
+        })}`
+      );
+    },
+  })
+)(SetRemindersModal);

--- a/packages/set-reminders-modal/index.test.js
+++ b/packages/set-reminders-modal/index.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { Button } from '@bufferapp/ui';
+import translations from '@bufferapp/publish-i18n/translations/en-us.json';
+import { actions as modalsActions } from '@bufferapp/publish-modals/reducer';
+import SetRemindersModalWrapper from './index';
+import SetRemindersModal from './components/SetRemindersModal';
+
+describe('SetRemindersModal', () => {
+  describe('Component', () => {
+    let store;
+
+    beforeEach(() => {
+      const storeFake = state => ({
+        default: () => {},
+        subscribe: () => {},
+        dispatch: jest.fn(),
+        getState: () => ({ ...state }),
+      });
+
+      store = storeFake({
+        i18n: {
+          translations: {
+            'set-reminders-modal': translations['set-reminders-modal'],
+          },
+        },
+      });
+    });
+
+    it('renders', () => {
+      const wrapper = mount(
+        <Provider store={store}>
+          <SetRemindersModalWrapper />
+        </Provider>
+      );
+      expect(wrapper.find(SetRemindersModal).length).toBe(1);
+      wrapper.unmount();
+    });
+
+    it('dispatches a hideSetRemindersModal action when clicks on dismiss button', () => {
+      const wrapper = mount(
+        <Provider store={store}>
+          <SetRemindersModalWrapper />
+        </Provider>
+      );
+
+      // User is in the modal and clicks on dismiss
+      wrapper
+        .find(Button)
+        .at(0)
+        .simulate('click');
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        modalsActions.hideSetRemindersModal()
+      );
+      wrapper.unmount();
+    });
+  });
+});

--- a/packages/set-reminders-modal/package.json
+++ b/packages/set-reminders-modal/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@bufferapp/publish-set-reminders-modal",
+  "version": "2.0.0",
+  "description": "A modal asking users to set reminders.",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint . --ignore-pattern coverage node_modules"
+  },
+  "author": "ana@buffer.com",
+  "dependencies": {
+    "@bufferapp/publish-modals": "2.0.0"
+  },
+  "devDependencies": {
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

- Add Set Reminders Modal;
- Add modal actions to show and hide;
- Add CTA actions:
`publish-app-setRemindersModal-setReminders-1` and `publish-queue-remindersBanner-setReminders-1`.
- Create `getRemindersURL` in formatters, with a temporary link (no problem, it's not being used by users)
- Set `onSetRemindersClick` action, in both the RemindersModal and the Queue Banner.

<!--- Describe your changes in detail. -->

## Context & Notes
[PUB-2263](https://buffer.atlassian.net/browse/PUB-2263)
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
![Captura de ecrã 2019-12-09, às 16 57 57](https://user-images.githubusercontent.com/16758464/70455957-17d54400-1aa5-11ea-868a-f9d377fd252e.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
