### PR TITLE
[PUB-2277] Increase stories queue count to 100

### DIFF
--- a/packages/server/rpc/getStoryGroups/index.js
+++ b/packages/server/rpc/getStoryGroups/index.js
@@ -16,6 +16,7 @@ module.exports = method(
         since,
         before,
         utc,
+        count: 100,
       },
     })
       .then(result => JSON.parse(result))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Change the stories queue limit to 100. The default is 20, so we need to be explicit and send 100 as count. 
https://buffer.atlassian.net/browse/PUB-2277
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
