### PR TITLE
Change color picker divs to buttons to make more accessible

### DIFF
--- a/packages/shared-components/ColorPicker/components/ColorSwatches/index.jsx
+++ b/packages/shared-components/ColorPicker/components/ColorSwatches/index.jsx
@@ -21,6 +21,7 @@ const ColorSwatches = ({ colorSelected, onColorChange, onChange }) => (
           colorContrast={getColorContrast(colorSwatches[key])}
           onClick={() => onColorChange(colorSwatches[key], onChange)}
           selectable
+          aria-label={`link color ${key}`}
         >
           {colorSelected === colorSwatches[key] && (
             <CheckmarkWrapper>

--- a/packages/shared-components/ColorPicker/styles.js
+++ b/packages/shared-components/ColorPicker/styles.js
@@ -60,13 +60,14 @@ export const StyledButton = styled(Button)`
   justify-content: space-between;
 `;
 
-export const CircleColor = styled.div`
+export const CircleColor = styled.button`
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 22px;
   height: 22px;
+  padding: 0px;
   border-radius: 50%;
   background-color: ${props => props.color || DEFAULT_COLOR};
   color: ${props => props.colorContrast || colorSwatches.white};
@@ -81,7 +82,7 @@ export const CircleColor = styled.div`
       display: ${props => (props.selectable ? 'block' : 'none')};
       content: '';
       width: 30px;
-      height: 30px;
+      height: 28px;
       border: 1px solid #4307ff;
       border-radius: 50%;
       margin: -5px -5px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Change color picker elements to buttons to allow user to tab through and select color with keyboard.
<!--- Describe your changes in detail. -->

## Context & Notes
I decided to change the elements to buttons as submit works a bit easier on keyboard. (If we kept div, we'd have to add a keyboard listener to submit on enter). 
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
