### PR TITLE
Add ability to isolate link editing, and call the single update endpoint

### DIFF
--- a/packages/grid/components/CustomLinks/index.jsx
+++ b/packages/grid/components/CustomLinks/index.jsx
@@ -12,6 +12,60 @@ import {
   Separator,
 } from './styles';
 
+const EditingLinkItem = ({
+  customLinkItem,
+  onUpdateCustomLinks,
+  onCancelCustomLinkEdit,
+  isValidItem,
+}) => {
+  const [linkItem, updateLinkItem] = useState(customLinkItem);
+
+  return (
+    <EditingLinkForm
+      item={linkItem}
+      onUpdateLinkText={({ item, value }) => {
+        updateLinkItem({ ...item, text: value });
+      }}
+      onUpdateLinkUrl={({ item, value }) => {
+        updateLinkItem({ ...item, url: value });
+      }}
+      onCancelClick={onCancelCustomLinkEdit}
+      onSaveClick={() => {
+        return onUpdateCustomLinks({
+          item: linkItem,
+        });
+      }}
+      isValidItem={isValidItem}
+    />
+  );
+};
+
+EditingLinkItem.propTypes = {
+  customLinkItem: PropTypes.any,
+  customLinksDetails: PropTypes.shape({
+    customLinks: PropTypes.array,
+    maxCustomLinks: PropTypes.number,
+    buttonColor: PropTypes.string,
+    buttonContrastColor: PropTypes.string,
+  }),
+  onUpdateCustomLinks: PropTypes.func,
+  onCancelCustomLinkEdit: PropTypes.func,
+  isValidItem: PropTypes.func,
+};
+
+EditingLinkItem.defaultProps = {
+  customLinkItem: {},
+  onUpdateCustomLinks: () => {},
+  onCancelCustomLinkEdit: () => {},
+  isValidItem: () => {},
+  customLinksDetails: {
+    customLinks: [],
+    maxCustomLinks: 0,
+    buttonColor: null,
+    buttonContrastColor: null,
+  },
+};
+
 const CustomLinks = ({
   customLinksDetails,
   onUpdateCustomLinks,
@@ -25,6 +79,7 @@ const CustomLinks = ({
   onSaveNewLinkClick,
   isValidItem,
   onCancelCustomLinkEdit,
+  onUpdateSingleCustomLink,
 }) => {
   const [colorButtons, setColorButton] = useState(
     customLinksDetails.buttonColor || DEFAULT_COLOR
@@ -101,20 +156,12 @@ const CustomLinks = ({
                   />
                 )}
                 {customLinkItem.editing && (
-                  <EditingLinkForm
+                  <EditingLinkItem
                     key={customLinkItem.order}
-                    item={customLinkItem}
+                    customLinkItem={customLinkItem}
                     customLinksDetails={customLinksDetails}
-                    onUpdateLinkText={onUpdateLinkText}
-                    onUpdateLinkUrl={onUpdateLinkUrl}
-                    onCancelClick={({ item }) => {
-                      onCancelCustomLinkEdit({ item });
-                    }}
-                    onSaveClick={() =>
-                      onUpdateCustomLinks({
-                        customLinks: customLinksDetails.customLinks,
-                      })
-                    }
+                    onUpdateCustomLinks={onUpdateSingleCustomLink}
+                    onCancelCustomLinkEdit={onToggleEditMode}
                     isValidItem={isValidItem}
                   />
                 )}

--- a/packages/grid/components/GridPosts/index.jsx
+++ b/packages/grid/components/GridPosts/index.jsx
@@ -158,6 +158,7 @@ const GridPosts = ({
   onSwapCustomLinks,
   onCancelCustomLinkEdit,
   onSaveNewLinkClick,
+  onUpdateSingleCustomLink,
   isValidItem,
 }) => {
   if (loading) {
@@ -258,6 +259,7 @@ const GridPosts = ({
             onSwapCustomLinks={onSwapCustomLinks}
             onCancelCustomLinkEdit={onCancelCustomLinkEdit}
             onSaveNewLinkClick={onSaveNewLinkClick}
+            onUpdateSingleCustomLink={onUpdateSingleCustomLink}
             isValidItem={isValidItem}
           />
         )}

--- a/packages/grid/index.js
+++ b/packages/grid/index.js
@@ -51,7 +51,10 @@ export default connect(
       dispatch(
         actions.handleAddNewGridLink({
           profileId: ownProps.profileId,
-          item,
+          item: {
+            ...item,
+            url: urlHasProtocol(item.url) ? item.url : `https://${item.url}`,
+          },
         })
       );
     },
@@ -209,9 +212,7 @@ export default connect(
       const itemText = (item && item.text) || '';
       const itemUrl = (item && item.url) || '';
       const cleanItemText = itemText.replace(/ /g, '');
-      return (
-        cleanItemText !== '' && isValidURL(itemUrl) && urlHasProtocol(itemUrl)
-      );
+      return cleanItemText !== '' && isValidURL(itemUrl);
     },
   })
 )(GridPosts);

--- a/packages/grid/index.js
+++ b/packages/grid/index.js
@@ -107,6 +107,15 @@ export default connect(
         analyticsActions.trackEvent('Shop Grid Page Previewed', metadata)
       );
     },
+    onUpdateSingleCustomLink: ({ item }) => {
+      dispatch(
+        actions.handleUpdateSingleCustomLink({
+          profileId: ownProps.profileId,
+          linkId: item._id,
+          item,
+        })
+      );
+    },
     onUpdateCustomLinks: ({ customLinks, linkText, linkUrl, item }) => {
       dispatch(
         actions.handleUpdateCustomLinks({

--- a/packages/grid/middleware.js
+++ b/packages/grid/middleware.js
@@ -162,6 +162,19 @@ export default ({ getState, dispatch }) => next => action => {
       break;
     }
 
+    case gridActionTypes.UPDATE_SINGLE_CUSTOM_LINK: {
+      dispatch(
+        dataFetchActions.fetch({
+          name: 'updateSingleCustomLink',
+          args: {
+            profileId: action.profileId,
+            linkId: action.linkId,
+            customLink: action.item,
+          },
+        })
+      );
+      break;
+    }
     case gridActionTypes.UPDATE_CUSTOM_LINKS: {
       const profile = getState().grid.byProfileId[action.profileId];
       const linkDetails = profile.customLinksDetails;
@@ -199,6 +212,7 @@ export default ({ getState, dispatch }) => next => action => {
       break;
     }
 
+    case `updateSingleCustomLink_${dataFetchActionTypes.FETCH_SUCCESS}`:
     case `updateCustomLinks_${dataFetchActionTypes.FETCH_SUCCESS}`:
       dispatch({
         type: 'SINGLE_PROFILE_INIT',

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -68,6 +68,7 @@ const shareStoryGroupNowMethod = require('./shareStoryGroupNow');
 const getShopGridPostsMethod = require('./shopGrid/getPosts');
 const updateShopGridPostLink = require('./shopGrid/updatePostLink');
 const updateCustomLinksMethod = require('./shopGrid/customLinks/update');
+const updateSingleCustomLinkMethod = require('./shopGrid/customLinks/update/single');
 const deleteCustomLinkMethod = require('./shopGrid/customLinks/delete');
 const addUserTag = require('./addUserTag');
 const removeUserTag = require('./removeUserTag');
@@ -155,5 +156,6 @@ module.exports = rpc(
   getShopGridPostsMethod,
   updateShopGridPostLink,
   updateCustomLinksMethod,
+  updateSingleCustomLinkMethod,
   deleteCustomLinkMethod
 );

--- a/packages/server/rpc/shopGrid/customLinks/update/single.js
+++ b/packages/server/rpc/shopGrid/customLinks/update/single.js
@@ -1,0 +1,30 @@
+const { method, createError } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+module.exports = method(
+  'updateSingleCustomLink',
+  'update single custom link for a profile',
+  async ({ profileId, linkId, customLink }, { session }) => {
+    let result;
+    try {
+      result = await rp({
+        uri: `${process.env.API_ADDR}/1/profiles/${profileId}/custom_links/${linkId}/update.json`,
+        method: 'POST',
+        strictSSL: !(process.env.NODE_ENV === 'development'),
+        form: {
+          access_token: session.publish.accessToken,
+          text: customLink.text,
+          url: customLink.url,
+        },
+      });
+    } catch (err) {
+      if (err.error) {
+        const { message } = JSON.parse(err.error);
+        throw createError({ message });
+      }
+      throw err;
+    }
+    result = JSON.parse(result);
+    return Promise.resolve(result);
+  }
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

Add ability to isolate link editing, and call the single update endpoint

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
