### PR TITLE
[PUB-2264] Add Stories Explanation when no reminders

### DIFF
--- a/packages/constants/index.js
+++ b/packages/constants/index.js
@@ -48,10 +48,9 @@ const QUEUE_LIMIT_PRO_UPGRADE =
   'publish-composer-queueLimitNotification-proUpgrade-1';
 const PINTEREST_PRO_UPGRADE =
   'publish-orgAdminConnect-upgradeToConnectPinterest-proUpgrade-1';
-const REMINDERS_MODAL =
-'publish-app-setRemindersModal-setReminders-1';
-const REMINDERS_BANNER =
-'publish-queue-remindersBanner-setReminders-1';
+const REMINDERS_MODAL = 'publish-app-setRemindersModal-setReminders-1';
+const REMINDERS_BANNER = 'publish-queue-remindersBanner-setReminders-1';
+const REMINDERS_STORIES = 'publish-stories-remindersButton-setReminders-1';
 const PLAN_OVERVIEW_PRO_UPGRADE =
   'publish-orgAdminConnect-planOverview-proUpgrade-1';
 const PLANS_SOLO_PREMIUM_UPGRADE =
@@ -159,6 +158,7 @@ module.exports = {
     PINTEREST_PRO_UPGRADE,
     REMINDERS_MODAL,
     REMINDERS_BANNER,
+    REMINDERS_STORIES,
     PLAN_OVERVIEW_PRO_UPGRADE,
     PLANS_SOLO_PREMIUM_UPGRADE,
     PLANS_SOLO_PREMIUM_DOWNGRADE,

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -411,7 +411,18 @@
     "reminderLinkText2": "Reminder ",
     "reminderText3": "to your mobile device.",
     "mobileTagText": "Uh-oh! Looks like you might not have the latest version of the Buffer mobile app. Download it now to start using Stories!",
-    "bannerMobileTagText": "Hmm...looks like you might not have the latest version of the Buffer mobile app. Download it now so that you can share this Story!"
+    "bannerMobileTagText": "Hmm...looks like you might not have the latest version of the Buffer mobile app. Download it now so that you can share this Story!",
+    "start" : {
+      "title": "Get Started with Instagram Stories",
+      "step1Title": "Set Up Reminders",
+      "step1Description": "Due to Instagram limitations, Stories can't be directly scheduled. A Reminder is a notification from the Buffer Publish app.",
+      "step2Title": "Compose Your Story",
+      "step2Description": "Storyboard your content and create draft captions. Then, choose the date and time you'd like to share with your audience.",
+      "step3Title": "Share Your Story",
+      "step3Description": "When your scheduled time arrives, Buffer will send you a Reminder. Preview on mobile, then tap to open in Instagram.",
+      "setReminders": "Set Up Reminders to Get Started",
+      "learnMore": "Learn More"
+    }
   },
   "user-tags": {
     "rightHeader": "Tag Users",

--- a/packages/stories/components/StepCard/index.jsx
+++ b/packages/stories/components/StepCard/index.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { grayDarker } from '@bufferapp/ui/style/colors';
+import { borderRadius } from '@bufferapp/ui/style/borders';
+import { Text } from '@bufferapp/ui';
+
+const StepWrapper = styled.div`
+  font-size: 0;
+`;
+
+const StepImage = styled.img`
+  border-radius: ${borderRadius};
+  background-color: blue;
+  height: 100%;
+  width: 100%;
+`;
+
+const StepTitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const StepTitle = styled(Text)`
+  margin: 18px 0;
+`;
+
+const StepNumber = styled(Text)`
+  margin: 0;
+  text-align: center;
+  margin-right: 8px;
+  width: 24px;
+  height: 24px;
+  line-height: 24px;
+  border-radius: 100%;
+  background-color: ${grayDarker};
+`;
+
+const StepDescription = styled(Text)`
+  margin: 0;
+`;
+
+const StepCard = ({ imageUrl, number, title, description }) => (
+  <StepWrapper>
+    <StepImage src={imageUrl} />
+    <StepTitleWrapper>
+      <StepNumber type="p" color="white">
+        {number}
+      </StepNumber>
+      <StepTitle type="h3">{title}</StepTitle>
+    </StepTitleWrapper>
+    <StepDescription type="p">{description}</StepDescription>
+  </StepWrapper>
+);
+
+StepCard.propTypes = {
+  imageUrl: PropTypes.string.isRequired,
+  number: PropTypes.number,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+};
+
+StepCard.defaultProps = {
+  number: 1,
+  description: '',
+};
+
+export default StepCard;

--- a/packages/stories/components/StepCard/index.jsx
+++ b/packages/stories/components/StepCard/index.jsx
@@ -7,13 +7,17 @@ import { Text } from '@bufferapp/ui';
 
 const StepWrapper = styled.div`
   font-size: 0;
+  width: calc(100% / 3);
+  display: inline-block;
+  vertical-align: top;
+  box-sizing: border-box;
+  padding: 0 2%;
 `;
 
 const StepImage = styled.img`
   border-radius: ${borderRadius};
-  background-color: blue;
-  height: 100%;
   width: 100%;
+  object-fit: contain;
 `;
 
 const StepTitleWrapper = styled.div`
@@ -23,6 +27,7 @@ const StepTitleWrapper = styled.div`
 
 const StepTitle = styled(Text)`
   margin: 18px 0;
+  flex: 1;
 `;
 
 const StepNumber = styled(Text)`

--- a/packages/stories/components/StepCard/story.jsx
+++ b/packages/stories/components/StepCard/story.jsx
@@ -4,12 +4,12 @@ import { withA11y } from '@storybook/addon-a11y';
 
 import StepCard from './index';
 
-storiesOf('StepCard', module)
+storiesOf('Stories|StepCard', module)
   .addDecorator(withA11y)
   .add('default', () => (
     <StepCard
       imageUrl="https://buffer-publish.s3.amazonaws.com/images/reminders-step1.jpg"
-      number="1"
+      number={1}
       title="Set Up Reminders"
       description="Due to Instagram limitations, Stories can't be directly scheduled. A Reminder is a notification from the Buffer Publish app."
     />

--- a/packages/stories/components/StepCard/story.jsx
+++ b/packages/stories/components/StepCard/story.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withA11y } from '@storybook/addon-a11y';
+
+import StepCard from './index';
+
+storiesOf('StepCard', module)
+  .addDecorator(withA11y)
+  .add('default', () => (
+    <StepCard
+      imageUrl="https://buffer-publish.s3.amazonaws.com/images/reminders-step1.jpg"
+      number="1"
+      title="Set Up Reminders"
+      description="Due to Instagram limitations, Stories can't be directly scheduled. A Reminder is a notification from the Buffer Publish app."
+    />
+  ));

--- a/packages/stories/components/StoriesExplanation/index.jsx
+++ b/packages/stories/components/StoriesExplanation/index.jsx
@@ -5,10 +5,6 @@ import { Link } from '@bufferapp/components';
 import { Button, Text } from '@bufferapp/ui';
 import StepCard from '../StepCard';
 
-const Grid = styled.div`
-  margin-bottom: 32px;
-`;
-
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -20,10 +16,14 @@ const Title = styled(Text)`
   text-align: center;
 `;
 
+const RemindersButton = styled(Button)`
+  margin: 32px 0 6px;
+`;
+
 const StoriesExplanation = ({ translations, onSetRemindersClick }) => (
   <Container>
     <Title type="h2">{translations.start.title}</Title>
-    <Grid>
+    <div>
       <StepCard
         imageUrl="https://buffer-publish.s3.amazonaws.com/images/reminders-step1.jpg"
         number={1}
@@ -42,9 +42,10 @@ const StoriesExplanation = ({ translations, onSetRemindersClick }) => (
         title={translations.start.step3Title}
         description={translations.start.step3Description}
       />
-    </Grid>
-    <Button
+    </div>
+    <RemindersButton
       type="primary"
+      size="large"
       label={translations.start.setReminders}
       onClick={onSetRemindersClick}
     />

--- a/packages/stories/components/StoriesExplanation/index.jsx
+++ b/packages/stories/components/StoriesExplanation/index.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Link } from '@bufferapp/components';
+import { Button, Text } from '@bufferapp/ui';
+import StepGrid from '../StepGrid';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0 60px;
+  max-width: 1025px;
+`;
+
+const Title = styled(Text)`
+  margin: 32px 0;
+  text-align: center;
+`;
+
+const StoriesExplanation = ({ translations, onSetRemindersClick }) => (
+  <Container>
+    <Title type="h2">{translations.start.title}</Title>
+    <StepGrid translations={translations.start} />
+    <Button
+      type="primary"
+      label={translations.start.setReminders}
+      onClick={onSetRemindersClick}
+    />
+    <Link
+      href="https://faq.buffer.com/article/950-publish-how-instagram-works"
+      unstyled
+      newTab
+    >
+      <Text type="p">{translations.start.learnMore}</Text>
+    </Link>
+  </Container>
+);
+
+StoriesExplanation.propTypes = {
+  translations: PropTypes.shape({
+    start: PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      learnMore: PropTypes.string.isRequired,
+      setReminders: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  onSetRemindersClick: PropTypes.func.isRequired,
+};
+
+export default StoriesExplanation;

--- a/packages/stories/components/StoriesExplanation/index.jsx
+++ b/packages/stories/components/StoriesExplanation/index.jsx
@@ -3,14 +3,16 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link } from '@bufferapp/components';
 import { Button, Text } from '@bufferapp/ui';
-import StepGrid from '../StepGrid';
+import StepCard from '../StepCard';
+
+const Grid = styled.div`
+  margin-bottom: 32px;
+`;
 
 const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 0 60px;
-  max-width: 1025px;
 `;
 
 const Title = styled(Text)`
@@ -21,7 +23,26 @@ const Title = styled(Text)`
 const StoriesExplanation = ({ translations, onSetRemindersClick }) => (
   <Container>
     <Title type="h2">{translations.start.title}</Title>
-    <StepGrid translations={translations.start} />
+    <Grid>
+      <StepCard
+        imageUrl="https://buffer-publish.s3.amazonaws.com/images/reminders-step1.jpg"
+        number={1}
+        title={translations.start.step1Title}
+        description={translations.start.step1Description}
+      />
+      <StepCard
+        imageUrl="https://buffer-publish.s3.amazonaws.com/images/reminders-step2.jpg"
+        number={2}
+        title={translations.start.step2Title}
+        description={translations.start.step2Description}
+      />
+      <StepCard
+        imageUrl="https://buffer-publish.s3.amazonaws.com/images/reminders-step3.jpg"
+        number={3}
+        title={translations.start.step3Title}
+        description={translations.start.step3Description}
+      />
+    </Grid>
     <Button
       type="primary"
       label={translations.start.setReminders}
@@ -41,6 +62,12 @@ StoriesExplanation.propTypes = {
   translations: PropTypes.shape({
     start: PropTypes.shape({
       title: PropTypes.string.isRequired,
+      step1Title: PropTypes.string.isRequired,
+      step1Description: PropTypes.string.isRequired,
+      step2Title: PropTypes.string.isRequired,
+      step2Description: PropTypes.string.isRequired,
+      step3Title: PropTypes.string.isRequired,
+      step3Description: PropTypes.string.isRequired,
       learnMore: PropTypes.string.isRequired,
       setReminders: PropTypes.string.isRequired,
     }).isRequired,

--- a/packages/stories/components/StoriesExplanation/story.jsx
+++ b/packages/stories/components/StoriesExplanation/story.jsx
@@ -4,12 +4,12 @@ import { action } from '@storybook/addon-actions';
 import { withA11y } from '@storybook/addon-a11y';
 import translations from '@bufferapp/publish-i18n/translations/en-us.json';
 
-import StartStories from './index';
+import StoriesExplanation from './index';
 
-storiesOf('StartStories', module)
+storiesOf('Stories|StoriesExplanation', module)
   .addDecorator(withA11y)
   .add('default', () => (
-    <StartStories
+    <StoriesExplanation
       translations={translations['story-group-queue']}
       onCloseModalClick={action('close-modal')}
       onSetRemindersClick={action('set-reminders')}

--- a/packages/stories/components/StoriesExplanation/story.jsx
+++ b/packages/stories/components/StoriesExplanation/story.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withA11y } from '@storybook/addon-a11y';
+import translations from '@bufferapp/publish-i18n/translations/en-us.json';
+
+import StartStories from './index';
+
+storiesOf('StartStories', module)
+  .addDecorator(withA11y)
+  .add('default', () => (
+    <StartStories
+      translations={translations['story-group-queue']}
+      onCloseModalClick={action('close-modal')}
+      onSetRemindersClick={action('set-reminders')}
+    />
+  ));

--- a/packages/stories/components/StoryGroups/index.jsx
+++ b/packages/stories/components/StoryGroups/index.jsx
@@ -15,6 +15,7 @@ import {
 import { CircleInstReminderIcon } from '@bufferapp/components';
 import WarningIcon from '@bufferapp/ui/Icon/Icons/Warning';
 import { Text } from '@bufferapp/ui';
+import StoriesExplanation from '../StoriesExplanation';
 
 const ErrorBoundary = getErrorBoundary(true);
 
@@ -101,12 +102,17 @@ const StoryGroups = ({
   onClosePreviewClick,
   showStoryPreview,
   userData,
+  hasPushNotifications,
   serviceId,
   translations,
 }) => {
   const hasStoriesMobileVersion = userData.tags
     ? userData.tags.includes('has_instagram_stories_mobile')
     : false;
+
+  if (!hasPushNotifications) {
+    return <StoriesExplanation translations={translations} />;
+  }
 
   if (loading) {
     return (
@@ -182,6 +188,7 @@ StoryGroups.propTypes = {
     })
   ),
   showStoriesComposer: PropTypes.bool,
+  hasPushNotifications: PropTypes.bool,
   hasFirstCommentFlip: PropTypes.bool,
   isBusinessAccount: PropTypes.bool,
   onEmptySlotClick: PropTypes.func.isRequired,
@@ -210,6 +217,7 @@ StoryGroups.propTypes = {
 StoryGroups.defaultProps = {
   loading: true,
   editMode: false,
+  hasPushNotifications: true,
   isLockedProfile: false,
   showStoriesComposer: false,
   hasFirstCommentFlip: false,

--- a/packages/stories/components/StoryGroups/index.jsx
+++ b/packages/stories/components/StoryGroups/index.jsx
@@ -103,6 +103,7 @@ const StoryGroups = ({
   showStoryPreview,
   userData,
   hasPushNotifications,
+  onSetRemindersClick,
   serviceId,
   translations,
 }) => {
@@ -111,7 +112,12 @@ const StoryGroups = ({
     : false;
 
   if (!hasPushNotifications) {
-    return <StoriesExplanation translations={translations} />;
+    return (
+      <StoriesExplanation
+        translations={translations}
+        onSetRemindersClick={onSetRemindersClick}
+      />
+    );
   }
 
   if (loading) {
@@ -189,6 +195,7 @@ StoryGroups.propTypes = {
   ),
   showStoriesComposer: PropTypes.bool,
   hasPushNotifications: PropTypes.bool,
+  onSetRemindersClick: PropTypes.func.isRequired,
   hasFirstCommentFlip: PropTypes.bool,
   isBusinessAccount: PropTypes.bool,
   onEmptySlotClick: PropTypes.func.isRequired,

--- a/packages/stories/components/StoryGroups/story.jsx
+++ b/packages/stories/components/StoryGroups/story.jsx
@@ -44,7 +44,7 @@ const UpgradeModalDecorator = storyFn => (
   <Provider store={store}>{storyFn()}</Provider>
 );
 
-storiesOf('StoryGroups', module)
+storiesOf('Stories|StoryGroups', module)
   .addDecorator(withA11y)
   .addDecorator(UpgradeModalDecorator)
   .add('should show stories storyPosts', () => (

--- a/packages/stories/index.js
+++ b/packages/stories/index.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import { formatPostLists } from '@bufferapp/publish-queue/util';
 import { actions as previewActions } from '@bufferapp/publish-story-preview';
 import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
+import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { SEGMENT_NAMES } from '@bufferapp/publish-constants';
 import getCtaProperties from '@bufferapp/publish-analytics-middleware/utils/CtaStrings';
 
@@ -41,6 +42,7 @@ export default connect(
         isBusinessAccount: profileData.business,
         serviceId: profileData.serviceId,
         userData: state.appSidebar.user,
+        hasPushNotifications: profileData.hasPushNotifications,
         translations: state.i18n.translations['story-group-queue'],
       };
     }
@@ -64,6 +66,13 @@ export default connect(
           storyGroup: storyGroup.post,
           profileId: ownProps.profileId,
         })
+      );
+    },
+    onSetRemindersClick: () => {
+      window.location.assign(
+        `${getURL.getRemindersURL({
+          cta: SEGMENT_NAMES.REMINDERS_STORIES,
+        })}`
       );
     },
     handleCloseStoriesComposer: () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

- Add reminders prompt for Stories tab, with explanation of how it works when users don't have push notifications set

<!--- Describe your changes in detail. -->

## Context & Notes
[PUB-2264](https://buffer.atlassian.net/browse/PUB-2264)
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
<img width="1346" alt="Captura de ecrã 2019-12-11, às 18 09 51" src="https://user-images.githubusercontent.com/16758464/70647700-7a634700-1c41-11ea-9c37-d940a22125f5.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
