### PR TITLE
[PUB-2305] Add maxLength and set width to shopgrid link input

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@bufferapp/dragme": "0.2.2",
     "@bufferapp/react-images-loaded": "1.1.0-fork.0",
     "@bufferapp/react-simple-dropdown": "3.3.0",
-    "@bufferapp/ui": "5.18.1-beta.bd7ed5d",
+    "@bufferapp/ui": "5.21.0",
     "@hot-loader/react-dom": "16.9.0",
     "@storybook/addon-a11y": "5.1.11",
     "@storybook/addon-actions": "5.1.11",

--- a/packages/grid/components/CustomLinks/EditingLinkForm/index.jsx
+++ b/packages/grid/components/CustomLinks/EditingLinkForm/index.jsx
@@ -2,7 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Input, Button } from '@bufferapp/ui';
 
-import { EditingMyLinksItem, ActionsWrapper, LinkInput, StyledButton } from '../styles';
+import {
+  EditingMyLinksItem,
+  ActionsWrapper,
+  LinkUrlInput,
+  LinkTextInput,
+  StyledButton,
+} from '../styles';
 
 const EditingLinkForm = ({
   item,
@@ -15,7 +21,7 @@ const EditingLinkForm = ({
   return (
     <React.Fragment>
       <EditingMyLinksItem>
-        <LinkInput>
+        <LinkTextInput>
           <Input
             label="Link Text"
             type="text"
@@ -23,9 +29,10 @@ const EditingLinkForm = ({
             name="text"
             value={item.text}
             placeholder="Describe link (e.g. “Shop Sale”)"
+            maxLength="35"
           />
-        </LinkInput>
-        <LinkInput>
+        </LinkTextInput>
+        <LinkUrlInput>
           <Input
             label="Link URL"
             type="text"
@@ -34,7 +41,7 @@ const EditingLinkForm = ({
             value={item.url}
             placeholder="Your website or URL"
           />
-        </LinkInput>
+        </LinkUrlInput>
       </EditingMyLinksItem>
       <ActionsWrapper>
         <StyledButton

--- a/packages/grid/components/CustomLinks/styles.js
+++ b/packages/grid/components/CustomLinks/styles.js
@@ -77,7 +77,7 @@ export const LinkUrlInput = styled.div`
 
 export const LinkTextInput = styled.div`
   margin: 8px;
-  width: 205px;
+  width: 230px;
 `;
 
 export const UrlPreview = styled.div`

--- a/packages/grid/components/CustomLinks/styles.js
+++ b/packages/grid/components/CustomLinks/styles.js
@@ -70,9 +70,14 @@ export const EditingMyLinksItem = styled.div`
   background-color: ${grayLighter};
 `;
 
-export const LinkInput = styled.div`
+export const LinkUrlInput = styled.div`
   margin: 8px;
-  width: 50%;
+  flex: 1;
+`;
+
+export const LinkTextInput = styled.div`
+  margin: 8px;
+  width: 205px;
 `;
 
 export const UrlPreview = styled.div`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,10 +1427,10 @@
     "@bufferapp/nav-sidebar" "^1.11.0"
     numeral "2.0.6"
 
-"@bufferapp/ui@5.18.1-beta.bd7ed5d":
-  version "5.18.1-beta.bd7ed5d"
-  resolved "https://registry.yarnpkg.com/@bufferapp/ui/-/ui-5.18.1-beta.bd7ed5d.tgz#6abe202290f7f9e05315280aa52e1877d8a4e1eb"
-  integrity sha512-LObR7NfgD7aGpKvH3HQt9xd5PnG23l581hcLfQFxD2IfOR/xhqcDFi020KagDPEMJV8WPYko2JUd2EGdFNlKuQ==
+"@bufferapp/ui@5.21.0":
+  version "5.21.0"
+  resolved "https://registry.yarnpkg.com/@bufferapp/ui/-/ui-5.21.0.tgz#b9358cf503cd5d4d6f90415abc6cbbd23a9dc3a4"
+  integrity sha512-gpLOuxA9gKLg8sofMKD709hOY/ujMW6DWHCQ5oKUoWsXk2VAPl0E1FkxaEL1GlB4xDruXw+dk0bdheEevgYDoA==
   dependencies:
     "@reach/tooltip" "0.6.2"
     immutability-helper "^2.9.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Add maxLength for shopgrid link text input. 
- Change the width to input so that it's not wider than the max text. 
https://buffer.atlassian.net/browse/PUB-2305

## Context & Notes
Waiting on UI update https://github.com/bufferapp/ui/pull/168

I've noticed we've used maxLength a few times in Publish with the Input component. I don't think this was ever working though 

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
