### PR TITLE
[PUB-2323] Fix Analytics Overview CSV export + clean up

### DIFF
--- a/packages/analytics/index.js
+++ b/packages/analytics/index.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 
 import Analytics from './components/Analytics';
 

--- a/packages/analytics/middleware.js
+++ b/packages/analytics/middleware.js
@@ -12,7 +12,12 @@ const actionsOnlyForAnalyzeMiddleware = middlewareType => () => next => action =
   const placeholderType = '@@ANALYZE_ACTION';
 
   // intercept and 'hide' the action
-  if (middlewareType === 'hide' && action.args && action.args.forAnalyze) {
+  if (
+    middlewareType === 'hide' &&
+    action.type === 'profiles_FETCH_SUCCESS' &&
+    action.args &&
+    action.args.forAnalyze === true
+  ) {
     return next({
       ...action,
       type: placeholderType,

--- a/packages/server/rpc/analytics/analyticsStartDate/index.js
+++ b/packages/server/rpc/analytics/analyticsStartDate/index.js
@@ -1,0 +1,22 @@
+const { method } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+module.exports = method(
+  'analytics_start_date',
+  'fetch analytics start date for profiles and pages',
+  ({ profileId }, req) =>
+    rp({
+      uri: `${req.app.get(
+        'analyzeApiAddr'
+      )}/1/profiles/${profileId}/analytics/gnip_start_date.json`,
+      method: 'GET',
+      strictSSL: !(
+        process.env.NODE_ENV === 'development' ||
+        process.env.NODE_ENV === 'test'
+      ),
+      qs: {
+        access_token: req.session.publish.accessToken,
+      },
+      json: true,
+    }).then(({ response }) => response[0])
+);

--- a/packages/server/rpc/analytics/posts/index.js
+++ b/packages/server/rpc/analytics/posts/index.js
@@ -17,7 +17,7 @@ function mapSortBy(sortBy) {
 }
 
 function normalizeDate(posts) {
-  return posts.map(post => ({ ...post, date: post.date * 1000 }));
+  return posts ? posts.map(post => ({ ...post, date: post.date * 1000 })) : [];
 }
 
 module.exports = method(

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -79,6 +79,7 @@ const compare = require('./analytics/compare');
 const getReport = require('./analytics/getReport');
 const posts = require('./analytics/posts');
 const summaryMethod = require('./analytics/summary');
+const analyticsStartDate = require('./analytics/analyticsStartDate');
 
 module.exports = rpc(
   profilesMethod,
@@ -120,11 +121,6 @@ module.exports = rpc(
   toggleGoogleAnalytics,
   saveGATrackingSettings,
   getGATrackingSettings,
-  average,
-  compare,
-  getReport,
-  posts,
-  summaryMethod,
   checkInstagramBusinessMethod,
   toggleInstagramReminders,
   mobileReminder,
@@ -157,5 +153,13 @@ module.exports = rpc(
   updateShopGridPostLink,
   updateCustomLinksMethod,
   updateSingleCustomLinkMethod,
-  deleteCustomLinkMethod
+  deleteCustomLinkMethod,
+
+  // Analyze RPC
+  average,
+  compare,
+  getReport,
+  posts,
+  summaryMethod,
+  analyticsStartDate,
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

In some browsers / systems the analyze export is failing (See https://buffer.atlassian.net/browse/PUB-2323). I was able to reproduce the issue in Safari and then debug and go deeper to learn that the profiles weren't being populated properly in the Analyze store. This had something do with how I was trying to 'hide' the `profiles_FETCH_SUCCESS` event from the rest of Publish when it's triggered by the lazy-loading of the analyze page (otherwise going to Overview would always re-trigger all the modals, etc.)

After fixing the logic it appears that the exports are now working again.

<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
