### PR TITLE
Simplifying call stack for colour picker and fixing return key validation for link color

### DIFF
--- a/packages/grid/components/CustomLinks/LinksHeader/index.jsx
+++ b/packages/grid/components/CustomLinks/LinksHeader/index.jsx
@@ -43,49 +43,7 @@ const AddLinkSection = styled.div`
   margin: 0 0 0 8px;
 `;
 
-const ColorPickerSection = ({
-  label,
-  defaultColor,
-  setColorButton,
-  setTextColor,
-  onBlur,
-}) => {
-  return (
-    <ColorPicker
-      label={label}
-      defaultColor={defaultColor || DEFAULT_COLOR}
-      onChange={(color, contrastColor) => {
-        setColorButton(color);
-        setTextColor(contrastColor);
-      }}
-      onBlur={(color, contrastColor) => {
-        setColorButton(color);
-        setTextColor(contrastColor);
-        onBlur();
-      }}
-    />
-  );
-};
-
-ColorPickerSection.propTypes = {
-  label: PropTypes.string,
-  defaultColor: PropTypes.string,
-  setColorButton: PropTypes.func,
-  setTextColor: PropTypes.func,
-  onBlur: PropTypes.func,
-};
-
-ColorPickerSection.defaultProps = {
-  label: '',
-  defaultColor: '',
-  setColorButton: () => {},
-  setTextColor: () => {},
-  onBlur: () => {},
-};
-
 const LinksHeader = ({
-  customLinksDetails,
-  maxCustomLinks,
   title = 'Top Links',
   popupText = 'Add up to 3 custom links to the top of your Shop grid page.',
   onAddLinkClick = () => {},
@@ -110,17 +68,23 @@ const LinksHeader = ({
       </MyLinksTitle>
       <AddLinkSection>
         <LinkColorSection>
-          <ColorPickerSection
+          <ColorPicker
             label={pickerText}
-            defaultColor={colorButtons}
+            defaultColor={colorButtons || DEFAULT_COLOR}
             setColorButton={setColorButton}
             setTextColor={setTextColor}
-            onBlur={() =>
+            onChange={(color, contrastColor) => {
+              setColorButton(color);
+              setTextColor(contrastColor);
+            }}
+            onBlur={(color, contrastColor) => {
+              setColorButton(color);
+              setTextColor(contrastColor);
               onUpdateCustomLinksColor({
                 customLinkColor: colorButtons,
                 customLinkContrastColor: textColor,
-              })
-            }
+              });
+            }}
           />
         </LinkColorSection>
         <Button

--- a/packages/grid/components/CustomLinks/index.jsx
+++ b/packages/grid/components/CustomLinks/index.jsx
@@ -68,17 +68,13 @@ EditingLinkItem.defaultProps = {
 
 const CustomLinks = ({
   customLinksDetails,
-  onUpdateCustomLinks,
   onUpdateCustomLinksColor,
   onDeleteCustomLink,
-  onUpdateLinkText,
-  onUpdateLinkUrl,
   maxCustomLinks,
   onToggleEditMode,
   onSwapCustomLinks,
   onSaveNewLinkClick,
   isValidItem,
-  onCancelCustomLinkEdit,
   onUpdateSingleCustomLink,
 }) => {
   const [colorButtons, setColorButton] = useState(
@@ -205,6 +201,7 @@ CustomLinks.propTypes = {
   onSwapCustomLinks: PropTypes.func,
   onCancelCustomLinkEdit: PropTypes.func,
   onUpdateCustomLinksColor: PropTypes.func,
+  onUpdateSingleCustomLink: PropTypes.func,
   onSaveNewLinkClick: PropTypes.func,
   isValidItem: PropTypes.func,
   customLinksDetails: PropTypes.shape({

--- a/packages/shared-components/ColorPicker/components/ColorSelectorPopup/index.jsx
+++ b/packages/shared-components/ColorPicker/components/ColorSelectorPopup/index.jsx
@@ -78,9 +78,10 @@ const ColorSelectorPopup = ({
             type="input"
             prefix={{ text: '#', paddingLeft: '18px' }}
             onChange={e => {
-              const isValidColor = isHexValid(e.target.value);
+              const color = `#${e.target.value}`;
+              const isValidColor = isHexValid(color);
               setIsValidHex(isValidColor);
-              onColorChange(e.target.value, onChange);
+              onColorChange(color, onChange);
             }}
             value={colorSelected.replace('#', '')}
             name="colorInput"
@@ -97,13 +98,11 @@ const ColorSelectorPopup = ({
               // handle return key
               if (e.keyCode === 13) {
                 e.preventDefault();
-                const isValidColor = isHexValid(e.target.value);
-                const selectedHex = !isValidColor
-                  ? getValidHex(e.target.value, lastValidColor)
-                  : e.target.value;
-                onColorSelectionChange(selectedHex);
-                setIsValidHex(true);
-                onBlur();
+                const color = `#${e.target.value}`;
+                const isValidColor = isHexValid(color);
+                if (isValidColor) {
+                  onBlur();
+                }
               }
             }}
             maxLength="6"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Simplifying call stack for colour picker and fixing return key validation for link color

I tried a number of methods to make the colour picker work, and in the end I realised that the validation was "always" failing, and it turned out we were validating for the presence of the # symbol, so I've edited the function to add a # at the start of the string, so the validation now works.
This has allowed me to simplify how we validate, and when we press return, we just check for the presence of a valid field in the UI, and this means I can blur / not based on validity of the field.

I think it would be good to support "transparent" buttons somehow too... then in dark mode, vs light mode, we can support the display more appropriately for each scenario, but that is definitely a different problem. 

But I think this resolves the return on the field problem for the time being :) 
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
