### PR TITLE
[PUB-2385] Add Profiles Disconnected Banner

### DIFF
--- a/packages/drafts/components/DraftList/index.jsx
+++ b/packages/drafts/components/DraftList/index.jsx
@@ -9,6 +9,7 @@ import {
 import ComposerPopover from '@bufferapp/publish-composer-popover';
 import { WithFeatureLoader } from '@bufferapp/product-features';
 import LockedProfileNotification from '@bufferapp/publish-locked-profile-notification';
+import ProfilesDisconnectedBanner from '@bufferapp/publish-profiles-disconnected-banner';
 import getErrorBoundary from '@bufferapp/publish-web/components/ErrorBoundary';
 import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { SEGMENT_NAMES } from '@bufferapp/publish-constants';
@@ -54,6 +55,7 @@ const DraftList = ({
   editMode,
   tabId,
   isLockedProfile,
+  isDisconnectedProfile,
   canStartBusinessTrial,
   hasFirstCommentFlip,
   onImageClick,
@@ -114,6 +116,7 @@ const DraftList = ({
   return (
     <ErrorBoundary>
       <div className={containerStyle}>
+        {isDisconnectedProfile && <ProfilesDisconnectedBanner />}
         <div style={topBarContainerStyle}>
           {tabId === 'drafts' && (
             <div style={composerStyle}>
@@ -188,6 +191,7 @@ DraftList.propTypes = {
   editMode: PropTypes.bool,
   tabId: PropTypes.oneOf(['awaitingApproval', 'pendingApproval', 'drafts']),
   isLockedProfile: PropTypes.bool,
+  isDisconnectedProfile: PropTypes.bool,
   hasFirstCommentFlip: PropTypes.bool,
   onImageClick: PropTypes.func.isRequired,
   onImageClose: PropTypes.func.isRequired,
@@ -203,6 +207,7 @@ DraftList.defaultProps = {
   editMode: false,
   tabId: null,
   isLockedProfile: false,
+  isDisconnectedProfile: false,
   hasFirstCommentFlip: false,
 };
 

--- a/packages/drafts/components/DraftList/index.jsx
+++ b/packages/drafts/components/DraftList/index.jsx
@@ -9,7 +9,6 @@ import {
 import ComposerPopover from '@bufferapp/publish-composer-popover';
 import { WithFeatureLoader } from '@bufferapp/product-features';
 import LockedProfileNotification from '@bufferapp/publish-locked-profile-notification';
-import ProfilesDisconnectedBanner from '@bufferapp/publish-profiles-disconnected-banner';
 import getErrorBoundary from '@bufferapp/publish-web/components/ErrorBoundary';
 import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { SEGMENT_NAMES } from '@bufferapp/publish-constants';
@@ -55,7 +54,6 @@ const DraftList = ({
   editMode,
   tabId,
   isLockedProfile,
-  isDisconnectedProfile,
   canStartBusinessTrial,
   hasFirstCommentFlip,
   onImageClick,
@@ -116,7 +114,6 @@ const DraftList = ({
   return (
     <ErrorBoundary>
       <div className={containerStyle}>
-        {isDisconnectedProfile && <ProfilesDisconnectedBanner />}
         <div style={topBarContainerStyle}>
           {tabId === 'drafts' && (
             <div style={composerStyle}>
@@ -191,7 +188,6 @@ DraftList.propTypes = {
   editMode: PropTypes.bool,
   tabId: PropTypes.oneOf(['awaitingApproval', 'pendingApproval', 'drafts']),
   isLockedProfile: PropTypes.bool,
-  isDisconnectedProfile: PropTypes.bool,
   hasFirstCommentFlip: PropTypes.bool,
   onImageClick: PropTypes.func.isRequired,
   onImageClose: PropTypes.func.isRequired,
@@ -207,7 +203,6 @@ DraftList.defaultProps = {
   editMode: false,
   tabId: null,
   isLockedProfile: false,
-  isDisconnectedProfile: false,
   hasFirstCommentFlip: false,
 };
 

--- a/packages/drafts/index.js
+++ b/packages/drafts/index.js
@@ -140,8 +140,6 @@ export default connect(
         editMode: state.drafts.editMode,
         editingPostId: state.drafts.editingPostId,
         isLockedProfile: state.profileSidebar.isLockedProfile,
-        isDisconnectedProfile:
-          state.profileSidebar.selectedProfile.isDisconnected,
         canStartBusinessTrial: state.drafts.canStartBusinessTrial,
         hasFirstCommentFlip: state.appSidebar.user.features
           ? state.appSidebar.user.features.includes('first_comment')

--- a/packages/drafts/index.js
+++ b/packages/drafts/index.js
@@ -25,7 +25,8 @@ const getPostActionString = ({
       isPastDue ? 'was' : 'will be'
     }
       scheduled for ${dateString}${isPastDue ? '' : ' on approval'}.`;
-  } else if (draft.sharedNext) {
+  }
+  if (draft.sharedNext) {
     return `This ${
       isDraftsView ? 'draft' : 'post'
     } will be added to the top of the queue on approval.`;
@@ -139,6 +140,8 @@ export default connect(
         editMode: state.drafts.editMode,
         editingPostId: state.drafts.editingPostId,
         isLockedProfile: state.profileSidebar.isLockedProfile,
+        isDisconnectedProfile:
+          state.profileSidebar.selectedProfile.isDisconnected,
         canStartBusinessTrial: state.drafts.canStartBusinessTrial,
         hasFirstCommentFlip: state.appSidebar.user.features
           ? state.appSidebar.user.features.includes('first_comment')

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -266,7 +266,7 @@
   },
   "profiles-disconnected-banner": {
     "headline": "Uh-oh, we've lost access to this account! Let's reconnect.",
-    "body": "Please make sure that you're logged into this account on the same network, and we'll get you back in business in no time!.",
+    "body": "Please make sure that you're logged into this account on the same network, and we'll get you back in business in no time!",
     "cta": "Reconnect Account"
   },
   "instagram-direct-posting-modal": {

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -264,6 +264,11 @@
     "cta": "Reconnect",
     "reconnecting": "Please wait..."
   },
+  "profiles-disconnected-banner": {
+    "headline": "Uh-oh, we've lost access to this account! Let's reconnect.",
+    "body": "Please make sure that you're logged into this account on the same network, and we'll get you back in business in no time!.",
+    "cta": "Reconnect Account"
+  },
   "instagram-direct-posting-modal": {
     "headline": "Would you like to set up Direct Scheduling for Instagram?",
     "description": "Direct Scheduling allows you to post images and videos to Instagram directly from Buffer, just as you can with any other network.",

--- a/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/index.jsx
+++ b/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/index.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { ErrorBanner } from '@bufferapp/publish-shared-components';
+import { Text } from '@bufferapp/ui';
+
+const TextWithStyles = styled(Text)`
+  margin: 0;
+`;
+
+const ProfilesDisconnectedBanner = ({
+  id,
+  service,
+  translations,
+  onReconnectProfileClick,
+}) => (
+  <ErrorBanner
+    title={translations.headline}
+    content={<TextWithStyles type="p">{translations.body}</TextWithStyles>}
+    onClick={() => onReconnectProfileClick({ id, service })}
+    actionLabel={translations.cta}
+  />
+);
+
+ProfilesDisconnectedBanner.propTypes = {
+  id: PropTypes.string.isRequired,
+  service: PropTypes.string.isRequired,
+  translations: PropTypes.shape({
+    headline: PropTypes.string,
+    body: PropTypes.string,
+    cta: PropTypes.string,
+  }).isRequired,
+  onReconnectProfileClick: PropTypes.func.isRequired,
+};
+
+export default ProfilesDisconnectedBanner;

--- a/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/index.jsx
+++ b/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/index.jsx
@@ -9,7 +9,7 @@ const TextWithStyles = styled(Text)`
 `;
 
 const ProfilesDisconnectedBanner = ({
-  id,
+  profileId,
   service,
   translations,
   onReconnectProfileClick,
@@ -17,13 +17,13 @@ const ProfilesDisconnectedBanner = ({
   <ErrorBanner
     title={translations.headline}
     content={<TextWithStyles type="p">{translations.body}</TextWithStyles>}
-    onClick={() => onReconnectProfileClick({ id, service })}
+    onClick={() => onReconnectProfileClick({ id: profileId, service })}
     actionLabel={translations.cta}
   />
 );
 
 ProfilesDisconnectedBanner.propTypes = {
-  id: PropTypes.string.isRequired,
+  profileId: PropTypes.string.isRequired,
   service: PropTypes.string.isRequired,
   translations: PropTypes.shape({
     headline: PropTypes.string,

--- a/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/story.jsx
+++ b/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/story.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withA11y } from '@storybook/addon-a11y';
+import translations from '@bufferapp/publish-i18n/translations/en-us.json';
+import ProfilesDisconnectedBanner from './index';
+
+storiesOf('ProfilesDisconnectedBanner', module)
+  .addDecorator(withA11y)
+  .add('default', () => (
+    <ProfilesDisconnectedBanner
+      translations={translations['profiles-disconnected-banner']}
+      onReconnectProfileClick={action('on-reconnect-click')}
+    />
+  ));

--- a/packages/profiles-disconnected-banner/index.js
+++ b/packages/profiles-disconnected-banner/index.js
@@ -4,7 +4,7 @@ import ProfilesDisconnectedBanner from './components/ProfilesDisconnectedBanner'
 
 export default connect(
   state => ({
-    id: state.profileSidebar.selectedProfileId,
+    profileId: state.profileSidebar.selectedProfileId,
     service:
       state.profileSidebar.selectedProfile &&
       state.profileSidebar.selectedProfile.service,

--- a/packages/profiles-disconnected-banner/index.js
+++ b/packages/profiles-disconnected-banner/index.js
@@ -1,0 +1,23 @@
+import { connect } from 'react-redux';
+import { actions as profilesDisconnectedModalActions } from '@bufferapp/publish-profiles-disconnected-modal/reducer';
+import ProfilesDisconnectedBanner from './components/ProfilesDisconnectedBanner';
+
+export default connect(
+  state => ({
+    id: state.profileSidebar.selectedProfileId,
+    service:
+      state.profileSidebar.selectedProfile &&
+      state.profileSidebar.selectedProfile.service,
+    translations: state.i18n.translations['profiles-disconnected-banner'],
+  }),
+  dispatch => ({
+    onReconnectProfileClick: ({ id, service }) => {
+      dispatch(
+        profilesDisconnectedModalActions.reconnectProfile({
+          id,
+          service,
+        })
+      );
+    },
+  })
+)(ProfilesDisconnectedBanner);

--- a/packages/profiles-disconnected-banner/index.test.jsx
+++ b/packages/profiles-disconnected-banner/index.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import translations from '@bufferapp/publish-i18n/translations/en-us.json';
+import ProfilesDisconnectedBanner from './index';
+
+const storeFake = state => ({
+  default: () => {},
+  subscribe: () => {},
+  dispatch: () => {},
+  getState: () => ({ ...state }),
+});
+
+const store = storeFake({
+  profileSidebar: {
+    selectedProfileId: 'id1',
+    selectedProfile: {
+      service: 'instagram',
+    },
+  },
+  i18n: {
+    translations: {
+      'profiles-disconnected-banner':
+        translations['profiles-disconnected-banner'],
+    },
+  },
+});
+
+describe('ProfilesDisconnectedBanner', () => {
+  it('should render', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <ProfilesDisconnectedBanner />
+      </Provider>
+    );
+    expect(wrapper.find(ProfilesDisconnectedBanner).length).toBe(1);
+  });
+});

--- a/packages/profiles-disconnected-banner/package.json
+++ b/packages/profiles-disconnected-banner/package.json
@@ -8,8 +8,8 @@
   },
   "author": "ana@buffer.com",
   "dependencies": {
-    "@bufferapp/product-features": "2.0.0",
-    "@bufferapp/publish-tabs": "2.0.0"
+    "@bufferapp/publish-profiles-disconnected-modal": "2.0.0",
+    "@bufferapp/publish-shared-components": "2.0.0"
   },
   "devDependencies": {
   },

--- a/packages/profiles-disconnected-banner/package.json
+++ b/packages/profiles-disconnected-banner/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@bufferapp/publish-profiles-disconnected-banner",
+  "version": "2.0.0",
+  "description": "Banner for disconnected profiles",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint . --ignore-pattern coverage node_modules"
+  },
+  "author": "ana@buffer.com",
+  "dependencies": {
+    "@bufferapp/product-features": "2.0.0",
+    "@bufferapp/publish-tabs": "2.0.0"
+  },
+  "devDependencies": {
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/profiles-disconnected-modal/components/ProfilesDisconnectedModal/index.jsx
+++ b/packages/profiles-disconnected-modal/components/ProfilesDisconnectedModal/index.jsx
@@ -45,7 +45,9 @@ const ProfilesDisconnectedModal = ({
               </div>
               <Button
                 disabled={p.reconnecting}
-                onClick={() => reconnectProfile(p.id, p.service)}
+                onClick={() =>
+                  reconnectProfile({ id: p.id, service: p.service })
+                }
                 size="small"
                 type="primary"
                 label={

--- a/packages/profiles-disconnected-modal/index.js
+++ b/packages/profiles-disconnected-modal/index.js
@@ -10,8 +10,8 @@ export default connect(
   }),
   dispatch => ({
     hideModal: () => dispatch(modalsActions.hideProfilesDisconnectedModal()),
-    reconnectProfile: (id, service) =>
-      dispatch(actions.reconnectProfile(id, service)),
+    reconnectProfile: ({ id, service }) =>
+      dispatch(actions.reconnectProfile({ id, service })),
   })
 )(ProfilesDisconnectedModal);
 

--- a/packages/profiles-disconnected-modal/reducer.js
+++ b/packages/profiles-disconnected-modal/reducer.js
@@ -33,11 +33,10 @@ const reducer = (state = initialState, action) => {
 };
 
 export const actions = {
-  reconnectProfile: (id, service, isIGBusiness) => ({
+  reconnectProfile: ({ id, service }) => ({
     type: actionTypes.RECONNECT_PROFILE,
     id,
     service,
-    isIGBusiness,
   }),
 };
 

--- a/packages/profiles-disconnected-modal/reducer.test.js
+++ b/packages/profiles-disconnected-modal/reducer.test.js
@@ -27,7 +27,7 @@ describe('reducer', () => {
   });
 
   describe('actions creators', () => {
-    expect(actions.reconnectProfile('id', 'service')).toEqual({
+    expect(actions.reconnectProfile({ id: 'id', service: 'service' })).toEqual({
       type: actionTypes.RECONNECT_PROFILE,
       id: 'id',
       service: 'service',

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -9,6 +9,7 @@ import {
 import InstagramDirectPostingModal from '@bufferapp/publish-ig-direct-posting-modal';
 import ComposerPopover from '@bufferapp/publish-composer-popover';
 import LockedProfileNotification from '@bufferapp/publish-locked-profile-notification';
+import ProfilesDisconnectedBanner from '@bufferapp/publish-profiles-disconnected-banner';
 import getErrorBoundary from '@bufferapp/publish-web/components/ErrorBoundary';
 
 import InstagramDirectPostingBanner from '../InstagramDirectPostingBanner';
@@ -64,6 +65,7 @@ const QueuedPosts = ({
   onDirectPostingClick,
   isInstagramLoading,
   isLockedProfile,
+  isDisconnectedProfile,
   isManager,
   hasFirstCommentFlip,
   isBusinessAccount,
@@ -96,7 +98,9 @@ const QueuedPosts = ({
   return (
     <ErrorBoundary>
       <div>
+        {isDisconnectedProfile && <ProfilesDisconnectedBanner />}
         {hasRemindersFlip &&
+          !isDisconnectedProfile &&
           !hasPushNotifications &&
           isInstagramProfile &&
           hasAtLeastOneReminderPost && (
@@ -219,6 +223,7 @@ QueuedPosts.propTypes = {
   onDirectPostingClick: PropTypes.func.isRequired,
   isInstagramLoading: PropTypes.bool,
   isLockedProfile: PropTypes.bool,
+  isDisconnectedProfile: PropTypes.bool,
   hasFirstCommentFlip: PropTypes.bool,
   onCalendarClick: PropTypes.func.isRequired,
   isBusinessAccount: PropTypes.bool,
@@ -240,6 +245,7 @@ QueuedPosts.defaultProps = {
   showInstagramDirectPostingModal: false,
   isInstagramLoading: false,
   isLockedProfile: false,
+  isDisconnectedProfile: false,
   hasFirstCommentFlip: false,
   draggingEnabled: false,
   isManager: false,

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -15,12 +15,12 @@ import QueuedPosts from './components/QueuedPosts';
 
 export default connect(
   (state, ownProps) => {
-    const profileId = ownProps.profileId;
+    const { profileId } = ownProps;
     const profileQueuePosts = state.queue.byProfileId[profileId];
     const profileData = state.profileSidebar.profiles.find(
       p => p.id === ownProps.profileId
     );
-    const isLockedProfile = state.profileSidebar.isLockedProfile;
+    const { isLockedProfile } = state.profileSidebar;
 
     const queuePostsArray =
       profileQueuePosts &&
@@ -83,6 +83,8 @@ export default connect(
           state.modals.showInstagramDirectPostingModal,
         isBusinessOnInstagram: state.queue.isBusinessOnInstagram,
         isInstagramLoading: state.queue.isInstagramLoading,
+        isDisconnectedProfile:
+          state.profileSidebar.selectedProfile.isDisconnected,
         hasFirstCommentFlip: state.appSidebar.user.features
           ? state.appSidebar.user.features.includes('first_comment')
           : false,

--- a/packages/shared-components/ErrorBanner/index.jsx
+++ b/packages/shared-components/ErrorBanner/index.jsx
@@ -9,7 +9,7 @@ const ErrorBannerCard = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 16px 80px;
+  padding: 24px 150px;
   border: 1px solid ${gray};
   box-sizing: border-box;
   border-radius: 2px;

--- a/packages/shared-components/ErrorBanner/index.jsx
+++ b/packages/shared-components/ErrorBanner/index.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Text, Button } from '@bufferapp/ui';
+import { gray, white } from '@bufferapp/ui/style/colors';
+import { Warning } from '@bufferapp/ui/Icon';
+
+const ErrorBannerCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px 80px;
+  border: 1px solid ${gray};
+  box-sizing: border-box;
+  border-radius: 2px;
+  text-align: center;
+  margin-bottom: 24px;
+  position: relative;
+`;
+
+const Triangle = styled.div`
+  position: absolute;
+  border-top: 74px solid #e0364f;
+  border-right: 74px solid transparent;
+  top: 0;
+  left: 0;
+`;
+
+const WarningIcon = styled(Warning)`
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  color: ${white};
+`;
+
+const Title = styled(Text)`
+  margin: 0 0 8px;
+`;
+
+const ButtonWithStyles = styled(Button)`
+  margin-top: 16px;
+`;
+
+const ErrorBanner = ({ title, content, onClick, actionLabel }) => (
+  <ErrorBannerCard>
+    <Triangle />
+    <WarningIcon />
+    <Title type="h3">{title}</Title>
+    {content}
+    {onClick && actionLabel && (
+      <ButtonWithStyles type="primary" onClick={onClick} label={actionLabel} />
+    )}
+  </ErrorBannerCard>
+);
+
+ErrorBanner.propTypes = {
+  title: PropTypes.string.isRequired,
+  content: PropTypes.node.isRequired,
+  onClick: PropTypes.func,
+  actionLabel: PropTypes.string,
+};
+
+ErrorBanner.defaultProps = {
+  onClick: () => {},
+  actionLabel: '',
+};
+
+export default ErrorBanner;

--- a/packages/shared-components/ErrorBanner/story.jsx
+++ b/packages/shared-components/ErrorBanner/story.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withA11y } from '@storybook/addon-a11y';
+import { Text } from '@bufferapp/ui';
+import ErrorBanner from './index';
+
+const TextWithStyles = styled(Text)`
+  margin: 0;
+`;
+
+const content = (
+  <TextWithStyles type="p">
+    Due to Instagram limitations, we cannot auto publish some of your queued
+    posts.
+  </TextWithStyles>
+);
+
+storiesOf('ErrorBanner', module)
+  .addDecorator(withA11y)
+  .add('without button', () => (
+    <ErrorBanner
+      title="Uh-oh! Some of your content can't be published."
+      content={content}
+    />
+  ))
+  .add('with button', () => (
+    <ErrorBanner
+      title="Uh-oh! Some of your content can't be published."
+      content={content}
+      onClick={action('on-click')}
+      actionLabel="Set Up Reminders"
+    />
+  ));

--- a/packages/shared-components/index.js
+++ b/packages/shared-components/index.js
@@ -32,3 +32,4 @@ export Arrow from './Arrow';
 export ComposerSidepanel from './ComposerSidepanel';
 export BannerAdvancedAnalytics from './BannerAdvancedAnalytics';
 export ColorPicker from './ColorPicker';
+export ErrorBanner from './ErrorBanner';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3138,11 +3138,6 @@ app-root-dir@^1.0.2:
   resolved "https://registry.yarnpkg.com/app-root-dir/-/app-root-dir-1.0.2.tgz#38187ec2dea7577fff033ffcb12172692ff6e118"
   integrity sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=
 
-append-field@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/append-field/-/append-field-1.0.0.tgz#1e3440e915f0b1203d23748e78edd7b9b5b43e56"
-  integrity sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=
-
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -5301,14 +5296,6 @@ bunyan@1.8.1:
     mv "~2"
     safe-json-stringify "~1"
 
-busboy@^0.2.11:
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.2.14.tgz#6c2a622efcf47c57bbbe1e2a9c37ad36c7925453"
-  integrity sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=
-  dependencies:
-    dicer "0.2.5"
-    readable-stream "1.1.x"
-
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -5959,7 +5946,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0, concat-stream@^1.5.2, concat-stream@^1.6.0:
+concat-stream@^1.5.0, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -6900,14 +6887,6 @@ detect-port@^1.3.0:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
-
-dicer@0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
-  integrity sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=
-  dependencies:
-    readable-stream "1.1.x"
-    streamsearch "0.1.2"
 
 diff-sequences@^24.9.0:
   version "24.9.0"
@@ -11965,20 +11944,6 @@ msgpack-lite@*, msgpack-lite@^0.1.26:
     int64-buffer "^0.1.9"
     isarray "^1.0.0"
 
-multer@^1.4.1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/multer/-/multer-1.4.2.tgz#2f1f4d12dbaeeba74cb37e623f234bf4d3d2057a"
-  integrity sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==
-  dependencies:
-    append-field "^1.0.0"
-    busboy "^0.2.11"
-    concat-stream "^1.5.2"
-    mkdirp "^0.5.1"
-    object-assign "^4.1.1"
-    on-finished "^2.3.0"
-    type-is "^1.6.4"
-    xtend "^4.0.0"
-
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -12431,7 +12396,7 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-on-finished@2.3.0, on-finished@^2.3.0, on-finished@~2.3.0:
+on-finished@2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
@@ -14876,16 +14841,6 @@ readable-stream@1.1:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@1.1.x:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
 readable-stream@^3.0.6, readable-stream@^3.1.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
@@ -16317,11 +16272,6 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
-streamsearch@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
-  integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
-
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -17074,7 +17024,7 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-type-is@^1.6.4, type-is@~1.6.15, type-is@~1.6.17, type-is@~1.6.18:
+type-is@~1.6.15, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

- Create `<ErrorBanner>` in `shared-components`, so it can be reused.
- Create `<ProfilesDisconnectedBanner>` and dedicated package.
- Add Profiles Disconnected Banner to Reconnect to ~~all tabs (Analytics, Drafts, General Settings, Grid, Past Reminders, Queue, Sent Posts and Stories)~~ the Queue, while we decide what do to in other tabs
<!--- Describe your changes in detail. -->

## Context & Notes
[PUB-2385](https://buffer.atlassian.net/browse/PUB-2385)
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
<img width="1292" alt="Captura de ecrã 2020-01-14, às 15 59 17" src="https://user-images.githubusercontent.com/16758464/72359808-dc064d80-36e6-11ea-9e76-ff99d853a357.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
