### PR TITLE
[PUB-2387] Change data source for hideAppShell

### DIFF
--- a/packages/app-shell/index.js
+++ b/packages/app-shell/index.js
@@ -19,7 +19,7 @@ export default connect(
     showManageTeam: state.appShell.showManageTeam,
     showStartProTrial: state.appShell.showStartProTrial,
     hideAppShell:
-      !state.appShell.sawOnboardingPage &&
+      state.onboarding.canSeeOnboardingPage &&
       state.router.location.pathname === newBusinessTrialistsRoute,
   }),
 

--- a/packages/app-shell/reducer.js
+++ b/packages/app-shell/reducer.js
@@ -16,7 +16,6 @@ export const initialState = {
   },
   bannerKey: null,
   bannerOptions: undefined,
-  sawOnboardingPage: true,
 };
 
 export default (state = initialState, action) => {
@@ -34,9 +33,6 @@ export default (state = initialState, action) => {
         showManageTeam: !action.result.is_free_user,
         showStartProTrial:
           action.result.canStartProTrial && !action.result.isBusinessTeamMember,
-        sawOnboardingPage:
-          action.result.messages &&
-          action.result.messages.includes('user_saw_onboarding_page'),
       };
     case actionTypes.SET_BANNER_OPTIONS:
       return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Change data source for hideAppShell, to get the state from onboarding instead of the user request.
<!--- Describe your changes in detail. -->

## Context & Notes
AppShell was not displayed for the first time for business trialists. During the Onboarding of a Business Trialist, when a user skips the step, we store a message in the user - `user_saw_onboarding_page`. The AppShell is listening to user_sucess to check if the message exists, but the user request was made prior to us storing the message.
It's safer to get the info from the onboarding state - it sets the value manually when the user skips the step, and the remaining times it gets it from the user request.
https://buffer.atlassian.net/browse/PUB-2387
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
