### PR TITLE
[PUB-2396] Show upgrade / switch plan  modal at end of pro trial

### DIFF
--- a/packages/switch-plan-modal/components/SwitchPlanModal/index.jsx
+++ b/packages/switch-plan-modal/components/SwitchPlanModal/index.jsx
@@ -2,10 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Divider } from '@bufferapp/components';
-import {
-  Text,
-  Modal,
-} from '@bufferapp/ui';
+import { Text, Modal } from '@bufferapp/ui';
 
 import LockedIcon from '@bufferapp/ui/Icon/Icons/Locked';
 import StripeCreditCardForm from '@bufferapp/publish-credit-card-form';
@@ -56,17 +53,11 @@ const getButtonText = ({ plan, translations }) => {
 class SwitchPlanModal extends React.Component {
   constructor() {
     super();
-
     this.onSecondaryAction = this.onSecondaryAction.bind(this);
   }
 
   onSecondaryAction() {
-    const {
-      hideModal,
-      cancelTrial,
-      hasExpiredProTrial,
-    } = this.props;
-
+    const { hideModal, cancelTrial, hasExpiredProTrial } = this.props;
     if (hasExpiredProTrial) {
       cancelTrial();
     } else {
@@ -87,16 +78,21 @@ class SwitchPlanModal extends React.Component {
     } = this.props;
 
     return (
-      <Modal
-        wide
-        dismissible={dismissible}
-      >
+      <Modal wide dismissible={dismissible}>
         <div style={{ height: 'auto' }}>
           <div style={{ width: '600px', padding: '0px 20px 25px' }}>
-            {isPro(plan) && <PlanDescriptors {...translations.proDescriptors} />}
-            {isPremium(plan) && <PlanDescriptors {...translations.premiumDescriptors} />}
-            {isSoloPremium(plan) && <PlanDescriptors {...translations.soloPremiumDescriptors} />}
-            {isSmallBusiness(plan) && <PlanDescriptors {...translations.businessDescriptors} />}
+            {isPro(plan) && (
+              <PlanDescriptors {...translations.proDescriptors} />
+            )}
+            {isPremium(plan) && (
+              <PlanDescriptors {...translations.premiumDescriptors} />
+            )}
+            {isSoloPremium(plan) && (
+              <PlanDescriptors {...translations.soloPremiumDescriptors} />
+            )}
+            {isSmallBusiness(plan) && (
+              <PlanDescriptors {...translations.businessDescriptors} />
+            )}
 
             <Divider marginTop="" marginBottom="1.5rem" />
 
@@ -148,7 +144,9 @@ class SwitchPlanModal extends React.Component {
             </div>
             <StripeCreditCardForm
               buttonLabel={
-                validating ? translations.validating : getButtonText({ plan, translations })
+                validating
+                  ? translations.validating
+                  : getButtonText({ plan, translations })
               }
               closeButtonLabel={translations.close}
               closeAction={this.onSecondaryAction}
@@ -165,6 +163,7 @@ SwitchPlanModal.propTypes = {
   translations: PropTypes.object.isRequired, // eslint-disable-line
   cycle: PropTypes.string.isRequired,
   plan: PropTypes.string,
+  isPromo: PropTypes.bool,
   storeValue: PropTypes.func.isRequired,
   validating: PropTypes.bool.isRequired,
   selectCycle: PropTypes.func.isRequired,
@@ -181,6 +180,7 @@ SwitchPlanModal.defaultProps = {
   hasExpiredProTrial: false,
   dismissible: false,
   plan: 'pro',
+  isPromo: false,
 };
 
 export default SwitchPlanModal;

--- a/packages/trial-complete-modal/middleware.js
+++ b/packages/trial-complete-modal/middleware.js
@@ -30,11 +30,27 @@ export default ({ getState, dispatch }) => next => action => {
         }
       };
 
-      window.location.assign(
-        `${getURL.getBillingURL({
-          cta: ctaName(),
-        })}`
-      );
+      /** For business trials send them to the billing page */
+      if (hasExpiredBusinessTrial) {
+        window.location.assign(
+          `${getURL.getBillingURL({
+            cta: ctaName(),
+          })}`
+        );
+        return;
+      }
+
+      /** For pro trials show the upgrade/switch plan modal */
+      if (hasExpiredProTrial) {
+        dispatch(modalActions.hideTrialCompleteModal());
+        dispatch(
+          modalActions.showSwitchPlanModal({
+            plan: 'pro',
+            source: ctaName(),
+            isPromo: false,
+          })
+        );
+      }
       break;
     }
     default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

https://buffer.atlassian.net/browse/PUB-2396

This PR shows the upgrade/switch plan modal instead of taking the Pro trialists to the billing page (since it's promoting B4B and not the Pro upgrade.)

<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`