### PR TITLE
[PUB-2345] User parser treats Awesome migrating users as Pro

### DIFF
--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -6,6 +6,16 @@ const isOnBusinessPlan = trialPlan =>
     plan => plan === trialPlan
   );
 
+// The following two methods are being used for Awesome customers
+// who are being migrated to Pro. These customers will technically
+// still have their plan set to Awesome but will receive all of
+// the features Pro users receive.
+const getPlan = (plan, isAwesomeMigratingUser) =>
+  isAwesomeMigratingUser ? 'pro' : plan;
+
+const getPlanCode = (planCode, isAwesomeMigratingUser) =>
+  isAwesomeMigratingUser ? 5 : planCode;
+
 module.exports = userData => ({
   id: userData.id,
   email: userData.email,
@@ -15,8 +25,14 @@ module.exports = userData => ({
   tags: userData.tags,
   hasTwentyFourHourTimeFormat: userData.twentyfour_hour_time,
   imageDimensionsKey: userData.imagedimensions_key,
-  plan: userData.plan,
-  planCode: userData.plan_code,
+  plan: getPlan(
+    userData.plan,
+    userData.features.includes('awesome_pro_forced_upgrade_batch_1')
+  ),
+  planCode: getPlanCode(
+    userData.plan_code,
+    userData.features.includes('awesome_pro_forced_upgrade_batch_1')
+  ),
   is_business_user: userData.plan_code >= 8 && userData.plan_code <= 19,
   is_free_user: userData.plan === 'free',
   messages: userData.messages || [],

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -27,11 +27,13 @@ module.exports = userData => ({
   imageDimensionsKey: userData.imagedimensions_key,
   plan: getPlan(
     userData.plan,
-    userData.features.includes('awesome_pro_forced_upgrade_batch_1')
+    userData.features.includes('awesome_pro_forced_upgrade_batch_1') ||
+      userData.features.includes('test_awesome_pro_forced_upgrade_batch_1')
   ),
   planCode: getPlanCode(
     userData.plan_code,
-    userData.features.includes('awesome_pro_forced_upgrade_batch_1')
+    userData.features.includes('awesome_pro_forced_upgrade_batch_1') ||
+      userData.features.includes('test_awesome_pro_forced_upgrade_batch_1')
   ),
   is_business_user: userData.plan_code >= 8 && userData.plan_code <= 19,
   is_free_user: userData.plan === 'free',


### PR DESCRIPTION
## Description

Changes the user parser to parse Awesome users who are being migrated to the Pro plan as Pro users, so that they receive Pro features in NP.

## Context & Notes
[https://buffer.atlassian.net/browse/PUB-2345](https://buffer.atlassian.net/browse/PUB-2345)

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`