### PR TITLE
[PUB-2474] Give users access to menu options

### DIFF
--- a/packages/app-shell/reducer.js
+++ b/packages/app-shell/reducer.js
@@ -27,7 +27,8 @@ export default (state = initialState, action) => {
           email: action.result.email,
           name: action.result.name,
         },
-        hideMenuItems: action.result.canSeePaydayPage,
+        hideMenuItems:
+          action.result.canSeePaydayPage && action.result.isOnAwesomePlan,
         showReturnToClassic: action.result.showReturnToClassic,
         showSwitchPlanModal:
           action.result.is_free_user && !action.result.isBusinessTeamMember,


### PR DESCRIPTION
## Description

This change allows users who have the 'awesome_user_can_view_payday_page' feature flip access to the missing menu items, as long as they are not on the Awesome plan.

## Context & Notes
This change is required because Awesome users who upgrade their account are not able to access certain menu items, such as the 'Preferences' menu, blocking them from accessing several settings, including TFA settings.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`