### PR TITLE
[PUB-2474] Menu items for migrated Awesome users

### DIFF
--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -109,7 +109,12 @@ module.exports = userData => ({
   showReturnToClassic: userData.has_np_app_switcher,
   helpScoutConfig: userData.helpscout_beacon_params,
   isBusinessTeamMember: userData.is_business_team_member,
-  isOnAwesomePlan: userData.plan === 'awesome',
+  isOnAwesomePlan:
+    userData.plan === 'awesome' &&
+    !(
+      userData.features.includes('awesome_pro_forced_upgrade_batch_1') ||
+      userData.features.includes('test_awesome_pro_forced_upgrade_batch_1')
+    ),
   isAwesomePromoUser:
     userData.features.includes('legacy_awesome_monthly_promotion') &&
     userData.plan === 'awesome',


### PR DESCRIPTION
## Description

Add check to userParser to ensure Awesome customers who are migrating to Pro can see all of New Publish's menu options.

## Context & Notes
[https://buffer.atlassian.net/browse/PUB-2474](https://buffer.atlassian.net/browse/PUB-2474)

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`