### PR TITLE
PUB-2511 | Fetching user's main organization, that will be valid for Campaigns V1

### DIFF
--- a/packages/campaigns/components/CampaignsPage/index.jsx
+++ b/packages/campaigns/components/CampaignsPage/index.jsx
@@ -8,7 +8,12 @@ const CREATE_CAMPAIGN = 'createCampaign';
 const VIEW_CAMPAIGNS = 'viewCampaigns';
 
 /* Component */
-const CampaignsPage = ({ translations, campaigns, onCreateCampaignClick }) => {
+const CampaignsPage = ({
+  translations,
+  campaigns,
+  onCreateCampaignClick,
+  isSaving,
+}) => {
   const [viewMode, setViewMode] = useState(VIEW_CAMPAIGNS);
   return (
     <React.Fragment>
@@ -20,6 +25,7 @@ const CampaignsPage = ({ translations, campaigns, onCreateCampaignClick }) => {
       )}
       {viewMode === CREATE_CAMPAIGN && (
         <CreateCampaign
+          isSaving={isSaving}
           translations={translations.createCampaign}
           onCreateCampaignClick={onCreateCampaignClick}
           onCancelClick={() => setViewMode(VIEW_CAMPAIGNS)}
@@ -33,6 +39,7 @@ CampaignsPage.propTypes = {
   translations: PropTypes.object.isRequired, // eslint-disable-line
   campaigns: PropTypes.array, // eslint-disable-line
   onCreateCampaignClick: PropTypes.func.isRequired,
+  isSaving: PropTypes.bool.isRequired,
 };
 
 export default CampaignsPage;

--- a/packages/campaigns/components/CreateCampaign/index.jsx
+++ b/packages/campaigns/components/CreateCampaign/index.jsx
@@ -87,6 +87,7 @@ const CreateCampaign = ({
   translations,
   onCreateCampaignClick,
   onCancelClick,
+  isSaving,
 }) => {
   // State
   const [campaignName, setName] = useState('');
@@ -156,7 +157,7 @@ const CreateCampaign = ({
           size="large"
           label={translations.saveCampaign}
           onClick={() => onCreateCampaignClick({ colorSelected, campaignName })}
-          disabled={isSubmitButtonDisabled}
+          disabled={isSubmitButtonDisabled || isSaving}
           fullWidth
         />
         <Button
@@ -187,6 +188,7 @@ CreateCampaign.propTypes = {
   }).isRequired,
   onCreateCampaignClick: PropTypes.func.isRequired,
   onCancelClick: PropTypes.func.isRequired,
+  isSaving: PropTypes.bool.isRequired,
 };
 
 export default CreateCampaign;

--- a/packages/campaigns/index.js
+++ b/packages/campaigns/index.js
@@ -7,11 +7,15 @@ export default connect(
   state => ({
     campaigns: [],
     translations: state.i18n.translations.campaigns,
+    isSaving: state.campaigns.isSaving,
   }),
   dispatch => ({
-    onCreateCampaignClick: ({ colorSelected, name }) => {
+    onCreateCampaignClick: ({ colorSelected, campaignName }) => {
       dispatch(
-        actions.handleCreateCampaignClick({ name, color: colorSelected })
+        actions.handleCreateCampaignClick({
+          name: campaignName,
+          color: colorSelected,
+        })
       );
     },
   })

--- a/packages/campaigns/middleware.js
+++ b/packages/campaigns/middleware.js
@@ -11,9 +11,27 @@ import { actionTypes } from './reducer';
 export default ({ dispatch, getState }) => next => action => {
   next(action);
   switch (action.type) {
+    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`: {
+      const hasCampaignsFlip =
+        getState().appSidebar.user.features?.includes('campaigns') || false;
+
+      if (hasCampaignsFlip) {
+        console.log('FETCHING MAIN ORG ', hasCampaignsFlip);
+        /*
+        dispatch(
+          dataFetchActions.fetch({
+            name: 'getUserMainOrganization',
+            args: {},
+          })
+          );
+        */
+      }
+      break;
+    }
     case actionTypes.CREATE_CAMPAIGN: {
       const { name, color } = action;
       const { mainOrganization } = getState().user;
+      // const { mainOrganization } = getState().campaigns;
       const organizationId = mainOrganization?._id;
       dispatch(
         dataFetchActions.fetch({

--- a/packages/campaigns/middleware.js
+++ b/packages/campaigns/middleware.js
@@ -12,14 +12,15 @@ export default ({ dispatch, getState }) => next => action => {
   switch (action.type) {
     case actionTypes.CREATE_CAMPAIGN: {
       const { name, color } = action;
-      const { id } = getState().user;
+      const { mainOrganization } = getState().user;
+      const organizationId = mainOrganization?._id;
       dispatch(
         dataFetchActions.fetch({
           name: 'createCampaign',
           args: {
             name,
             color,
-            id,
+            organizationId,
           },
         })
       );

--- a/packages/campaigns/middleware.js
+++ b/packages/campaigns/middleware.js
@@ -16,22 +16,29 @@ export default ({ dispatch, getState }) => next => action => {
         getState().appSidebar.user.features?.includes('campaigns') || false;
 
       if (hasCampaignsFlip) {
-        console.log('FETCHING MAIN ORG ', hasCampaignsFlip);
-        /*
         dispatch(
           dataFetchActions.fetch({
-            name: 'getUserMainOrganization',
+            name: 'getMainOrganization',
             args: {},
           })
-          );
-        */
+        );
       }
       break;
     }
+
+    case `getMainOrganization_${dataFetchActionTypes.FETCH_FAIL}`:
+      dispatch(
+        notificationActions.createNotification({
+          notificationType: 'error',
+          message: action.error,
+        })
+      );
+      break;
+
     case actionTypes.CREATE_CAMPAIGN: {
       const { name, color } = action;
-      const { mainOrganization } = getState().user;
-      // const { mainOrganization } = getState().campaigns;
+      const { mainOrganization } = getState().campaigns;
+
       const organizationId = mainOrganization?._id;
       dispatch(
         dataFetchActions.fetch({
@@ -72,6 +79,7 @@ export default ({ dispatch, getState }) => next => action => {
         })
       );
       break;
+
     case actionTypes.HANDLE_CAMPAIGN_ROUTED: {
       // const { campaignId } = action;
       dispatch(profileSidebarActions.handleCampaignsClick());

--- a/packages/campaigns/reducer.js
+++ b/packages/campaigns/reducer.js
@@ -25,7 +25,7 @@ export default (state = initialState, action) => {
         isSaving: false,
       };
     case `getMainOrganization_${dataFetchActionTypes.FETCH_SUCCESS}`: {
-      const mainOrganization = action.result;
+      const { mainOrganization, isOrgAdmin } = action.result;
 
       return {
         ...state,

--- a/packages/campaigns/reducer.js
+++ b/packages/campaigns/reducer.js
@@ -8,6 +8,7 @@ export const actionTypes = keyWrapper('CAMPAIGNS', {
 
 export const initialState = {
   isSaving: false,
+  mainOrganization: {},
 };
 
 export default (state = initialState, action) => {
@@ -23,6 +24,19 @@ export default (state = initialState, action) => {
         ...state,
         isSaving: false,
       };
+    case `getUserMainOrganization_${dataFetchActionTypes.FETCH_SUCCESS}`: {
+      console.log('Main org is', action);
+      /*
+      const { mainOrganization } = action.result;
+      return {
+        ...state,
+        mainOrganization,
+      };
+      */
+      return {
+        ...state,
+      };
+    }
     default:
       return state;
   }

--- a/packages/campaigns/reducer.js
+++ b/packages/campaigns/reducer.js
@@ -25,7 +25,7 @@ export default (state = initialState, action) => {
         isSaving: false,
       };
     case `getMainOrganization_${dataFetchActionTypes.FETCH_SUCCESS}`: {
-      const { mainOrganization, isOrgAdmin } = action.result;
+      const { mainOrganization = {}, isOrgAdmin } = action.result || {};
 
       return {
         ...state,

--- a/packages/campaigns/reducer.js
+++ b/packages/campaigns/reducer.js
@@ -24,17 +24,12 @@ export default (state = initialState, action) => {
         ...state,
         isSaving: false,
       };
-    case `getUserMainOrganization_${dataFetchActionTypes.FETCH_SUCCESS}`: {
-      console.log('Main org is', action);
-      /*
-      const { mainOrganization } = action.result;
+    case `getMainOrganization_${dataFetchActionTypes.FETCH_SUCCESS}`: {
+      const mainOrganization = action.result;
+
       return {
         ...state,
         mainOrganization,
-      };
-      */
-      return {
-        ...state,
       };
     }
     default:

--- a/packages/campaigns/reducer.js
+++ b/packages/campaigns/reducer.js
@@ -1,13 +1,27 @@
 import keyWrapper from '@bufferapp/keywrapper';
+import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 
 export const actionTypes = keyWrapper('CAMPAIGNS', {
   CREATE_CAMPAIGN: 0,
 });
 
-export const initialState = {};
+export const initialState = {
+  isSaving: false,
+};
 
 export default (state = initialState, action) => {
   switch (action.type) {
+    case actionTypes.CREATE_CAMPAIGN: {
+      return {
+        ...state,
+        isSaving: true,
+      };
+    }
+    case `createCampaign_${dataFetchActionTypes.FETCH_FAIL}`:
+      return {
+        ...state,
+        isSaving: false,
+      };
     default:
       return state;
   }

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -6,6 +6,11 @@ const isOnBusinessPlan = trialPlan =>
     plan => plan === trialPlan
   );
 
+const getMainOrganization = mainOrg => {
+  if (mainOrg) return mainOrg;
+  return null;
+};
+
 // The following two methods are being used for Awesome customers
 // who are being migrated to Pro. These customers will technically
 // still have their plan set to Awesome but will receive all of
@@ -121,4 +126,6 @@ module.exports = userData => ({
   hasAccessToUserTag: userData.is_pro_and_up_org_user, // this includes team members
   isAnalyzeCustomer: userData.is_analyze_customer,
   canSeePaydayPage: userData.features.includes('awesome_user_can_visit_payday'),
+  organizations: userData.organizations,
+  mainOrganization: getMainOrganization(userData.main_organization),
 });

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -6,11 +6,6 @@ const isOnBusinessPlan = trialPlan =>
     plan => plan === trialPlan
   );
 
-const getMainOrganization = mainOrg => {
-  if (mainOrg) return mainOrg;
-  return null;
-};
-
 // The following two methods are being used for Awesome customers
 // who are being migrated to Pro. These customers will technically
 // still have their plan set to Awesome but will receive all of
@@ -126,6 +121,4 @@ module.exports = userData => ({
   hasAccessToUserTag: userData.is_pro_and_up_org_user, // this includes team members
   isAnalyzeCustomer: userData.is_analyze_customer,
   canSeePaydayPage: userData.features.includes('awesome_user_can_visit_payday'),
-  organizations: userData.organizations,
-  mainOrganization: getMainOrganization(userData.main_organization),
 });

--- a/packages/server/rpc/campaigns/getMainOrganization/index.js
+++ b/packages/server/rpc/campaigns/getMainOrganization/index.js
@@ -23,6 +23,8 @@ module.exports = method(
       throw err;
     }
     result = JSON.parse(result);
-    return Promise.resolve(result.data);
+    result.mainOrganization = result.data.main_organization;
+    result.isOrgAdmin = result.data.is_org_admin;
+    return Promise.resolve(result);
   }
 );

--- a/packages/server/rpc/campaigns/getMainOrganization/index.js
+++ b/packages/server/rpc/campaigns/getMainOrganization/index.js
@@ -1,0 +1,28 @@
+const { method, createError } = require('@bufferapp/buffer-rpc');
+const rp = require('request-promise');
+
+module.exports = method(
+  'getMainOrganization',
+  'gets main organization for logged user',
+  async (_, { session }) => {
+    let result;
+    try {
+      result = await rp({
+        uri: `${process.env.API_ADDR}/1/campaigns/user_main_organization.json`,
+        method: 'GET',
+        strictSSL: !(process.env.NODE_ENV === 'development'),
+        qs: {
+          access_token: session.publish.accessToken,
+        },
+      });
+    } catch (err) {
+      if (err.error) {
+        const { message } = JSON.parse(err.error);
+        throw createError({ message });
+      }
+      throw err;
+    }
+    result = JSON.parse(result);
+    return Promise.resolve(result.data);
+  }
+);

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -75,6 +75,7 @@ const removeUserTag = require('./removeUserTag');
 const awesomeToProUpgradeDetails = require('./awesomeToProUpgradeDetails');
 const createCampaign = require('./campaigns/create');
 const updateCampaign = require('./campaigns/update');
+const getMainOrganization = require('./campaigns/getMainOrganization');
 
 // Analytics from Analyze -- Delete when we switch to Analyze
 const average = require('./analytics/average');
@@ -160,6 +161,7 @@ module.exports = rpc(
   deleteCustomLinkMethod,
   createCampaign,
   updateCampaign,
+  getMainOrganization,
 
   // Analyze RPC
   average,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
When creating a new Campaign, it should be associated to one organization, this would mean, the user should be able to choose the organization and assign it to a Campaign.

These changes are to automatically fetch that organization_id from the user endpoint.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
Jira tickets:
- PUB-2504
- PUB-2511

Related [PR](https://github.com/bufferapp/buffer-web/pull/16890)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
