### PR TITLE
Remove Help Scout Beacon from Publish dashboard

### DIFF
--- a/packages/server/index.html
+++ b/packages/server/index.html
@@ -202,7 +202,6 @@
   {{{showModalScript}}}
   {{{intercomScript}}}
   {{{segmentScript}}}
-  {{{helpScoutScript}}}
   {{{iterateScript}}}
   {{{userScript}}}
   {{{bufferData}}}

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -168,12 +168,6 @@ const intercomScript = `
 </script>
 `;
 
-const helpScoutScript = `
-<script>
-    !function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
-</script>
-`;
-
 const segmentScript = `<script>
       window.PRODUCT_TRACKING_KEY = 'publish';
       window.CLIENT_NAME = 'publishWeb';
@@ -267,7 +261,6 @@ const getHtml = ({
     .replace('{{{appcues}}}', isProduction ? appcuesScript : '')
     .replace('{{{intercomScript}}}', intercomScript)
     .replace('{{{iterateScript}}}', isProduction ? iterateScript : '')
-    .replace('{{{helpScoutScript}}}', helpScoutScript)
     .replace('{{{userScript}}}', getUserScript({ id: userId }))
     .replace('{{{favicon}}}', getFaviconCode({ cacheBust: 'v1' }))
     .replace('{{{segmentScript}}}', segmentScript)

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -107,7 +107,6 @@ module.exports = userData => ({
   orgUserCount: userData.org_user_count,
   profileCount: userData.profile_usage,
   showReturnToClassic: userData.has_np_app_switcher,
-  helpScoutConfig: userData.helpscout_beacon_params,
   isBusinessTeamMember: userData.is_business_team_member,
   isOnAwesomePlan:
     userData.plan === 'awesome' &&

--- a/packages/thirdParty/components/Loader/index.jsx
+++ b/packages/thirdParty/components/Loader/index.jsx
@@ -3,11 +3,10 @@ import PropTypes from 'prop-types';
 
 import RouteMonitor from '../RouteMonitor';
 
-const Loader = ({ appCues, intercom, helpScoutBeacon, location }) => (
+const Loader = ({ appCues, intercom, location }) => (
   <RouteMonitor
     appCues={appCues}
     intercom={intercom}
-    helpScoutBeacon={helpScoutBeacon}
     pathname={location.pathname}
   />
 );
@@ -21,9 +20,6 @@ Loader.propTypes = {
     inProgress: PropTypes.bool,
   }).isRequired,
   intercom: PropTypes.shape({
-    loaded: PropTypes.bool,
-  }).isRequired,
-  helpScoutBeacon: PropTypes.shape({
     loaded: PropTypes.bool,
   }).isRequired,
 };

--- a/packages/thirdParty/components/RouteMonitor/index.jsx
+++ b/packages/thirdParty/components/RouteMonitor/index.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { getProfilePageParams } from '@bufferapp/publish-routes';
 
-function RouteMonitor({ pathname, appCues, intercom, helpScoutBeacon }) {
+function RouteMonitor({ pathname, appCues, intercom }) {
   useEffect(() => {
     // Appcues triggers the display of content on page load.
     // Calling the Appcues.page() method will notify Appcues that
@@ -24,11 +24,6 @@ function RouteMonitor({ pathname, appCues, intercom, helpScoutBeacon }) {
     if (intercom && intercom.loaded && window && window.Intercom) {
       window.Intercom('update');
     }
-
-    // Let HelpScout Beacon know when we've changed pages
-    if (helpScoutBeacon && helpScoutBeacon.loaded && window && window.Beacon) {
-      window.Beacon('suggest');
-    }
   }, [pathname]);
   return null;
 }
@@ -42,9 +37,6 @@ RouteMonitor.propTypes = {
   intercom: PropTypes.shape({
     loaded: PropTypes.bool,
   }),
-  helpScoutBeacon: PropTypes.shape({
-    loaded: PropTypes.bool,
-  }),
 };
 
 RouteMonitor.defaultProps = {
@@ -54,9 +46,6 @@ RouteMonitor.defaultProps = {
     inProgress: false,
   },
   intercom: {
-    loaded: false,
-  },
-  helpScoutBeacon: {
     loaded: false,
   },
 };

--- a/packages/thirdParty/constants.js
+++ b/packages/thirdParty/constants.js
@@ -1,4 +1,2 @@
-export const HELPSCOUT_ID = 'a618e01e-dee2-482d-bec5-484d9efbba10';
-
 export const APPCUES_PRO_TRIAL_FLOW_ID = '-LhERLvIRXmAWzBBwMSe';
 export const APPCUES_PRO_TRIAL_TEST_FLOW_ID = '-LhnfxNU-GC8yO3ie0jN';

--- a/packages/thirdParty/index.js
+++ b/packages/thirdParty/index.js
@@ -11,7 +11,6 @@ export default connect(state => {
   return {
     appCues: state.thirdparty.appCues,
     intercom: state.thirdparty.intercom,
-    helpScoutBeacon: state.thirdparty.helpScoutBeacon,
     modalsShowing,
     userId:
       state.appSidebar && state.appSidebar.user && state.appSidebar.user.id,

--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -11,8 +11,6 @@ import { LOCATION_CHANGE } from 'connected-react-router';
 import { actions as modalReducers } from '@bufferapp/publish-modals/reducer';
 import { actionTypes } from './reducer';
 
-import { HELPSCOUT_ID } from './constants';
-
 const checkExtensionInstalled = () => {
   /**
    * We place this marker in the DOM (server/index.html) and the Buffer Extension
@@ -45,10 +43,6 @@ export default ({ dispatch, getState }) => next => action => {
     case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
       dispatch({ type: actionTypes.FULLSTORY, result: action.result });
       dispatch({ type: actionTypes.APPCUES, result: action.result });
-      if (!action.result.isOnAwesomePlan) {
-        // Context: https://buffer.atlassian.net/browse/PUB-2004
-        dispatch({ type: actionTypes.HELPSCOUT_BEACON, result: action.result });
-      }
       dispatch({ type: actionTypes.ITERATE, result: action.result });
       break;
 
@@ -173,30 +167,6 @@ export default ({ dispatch, getState }) => next => action => {
             window.Appcues.on('flow_aborted', dispatchAppcuesFinished);
           }
         }
-      }
-      break;
-    case actionTypes.APPCUES_STARTED:
-      const beaconDiv = document.querySelector('beacon-container');
-      beaconDiv.style.display = 'none';
-      break;
-    case actionTypes.APPCUES_FINISHED:
-      beaconDiv.style.display = '';
-      break;
-    case actionTypes.HELPSCOUT_BEACON:
-      if (window && window.Beacon) {
-        const { name, email, helpScoutConfig } = action.result;
-
-        window.Beacon('init', HELPSCOUT_ID);
-        window.Beacon('identify', {
-          name, // current user's name
-          email, // current user's email
-        });
-        // Pass config parameters from the user object in the API.
-        window.Beacon('config', JSON.parse(helpScoutConfig));
-        dispatch({
-          type: actionTypes.HELPSCOUT_BEACON_LOADED,
-          loaded: true,
-        });
       }
       break;
     case 'COMPOSER_EVENT': {

--- a/packages/thirdParty/middleware.test.js
+++ b/packages/thirdParty/middleware.test.js
@@ -3,7 +3,6 @@ import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch
 import { actionTypes } from './reducer';
 
 import middleware from './middleware';
-import { HELPSCOUT_ID } from './constants';
 
 global.FS = {
   identify: jest.fn(),
@@ -14,8 +13,6 @@ global.Appcues = {
   track: jest.fn(),
   on: jest.fn(),
 };
-
-global.Beacon = jest.fn();
 
 global.Intercom = jest.fn();
 
@@ -28,7 +25,6 @@ const mockUser = {
   orgUserCount: 2,
   profileCount: 3,
   is_business_user: true,
-  helpScoutConfig: '{ "param1": true, "param2": 24 }',
   tags: [],
 };
 
@@ -41,7 +37,6 @@ const mockFreeUser = {
   orgUserCount: 2,
   profileCount: 3,
   is_free_user: true,
-  helpScoutConfig: '{ "param1": true, "param2": 24 }',
   tags: [],
 };
 
@@ -110,10 +105,6 @@ describe('middleware', () => {
     middleware(store)(next)(action);
     expect(store.dispatch).toHaveBeenCalledWith({
       type: actionTypes.APPCUES,
-      result: mockUser,
-    });
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: actionTypes.HELPSCOUT_BEACON,
       result: mockUser,
     });
     expect(store.dispatch).toHaveBeenCalledWith({
@@ -257,33 +248,6 @@ describe('middleware', () => {
     });
   });
 
-  it('marks HelpScout as loaded and identifies the user with HelpScout', () => {
-    const action = {
-      type: actionTypes.HELPSCOUT_BEACON,
-      result: mockUser,
-    };
-    middleware(store)(next)(action);
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: actionTypes.HELPSCOUT_BEACON_LOADED,
-      loaded: true,
-    });
-    // We call window.Beacon 3 times:
-    expect(global.Beacon.mock.calls.length).toBe(3);
-    // The first one to register us with the  ID
-    expect(global.Beacon.mock.calls[0]).toEqual(['init', HELPSCOUT_ID]);
-
-    // The second one to identify the user
-    expect(global.Beacon.mock.calls[1]).toEqual([
-      'identify',
-      { name: mockUser.name, email: mockUser.email },
-    ]);
-
-    // The third one with the params obtained from the API
-    expect(global.Beacon.mock.calls[2]).toEqual([
-      'config',
-      JSON.parse(mockUser.helpScoutConfig),
-    ]);
-  });
   it('sends event to appcues when user adds a post in the composer', () => {
     const action = {
       type: 'COMPOSER_EVENT',

--- a/packages/thirdParty/reducer.js
+++ b/packages/thirdParty/reducer.js
@@ -8,15 +8,12 @@ export const actionTypes = keyWrapper('thirdparty', {
   APPCUES_STARTED: 0,
   APPCUES_FINISHED: 0,
   INTERCOM_LOADED: 0,
-  HELPSCOUT_BEACON: 0,
-  HELPSCOUT_BEACON_LOADED: 0,
   ITERATE: 0,
 });
 
 const initialState = {
   appCues: { loaded: false, inProgress: false },
   intercom: { loaded: false },
-  helpScoutBeacon: { loaded: false },
 };
 
 export default (state = initialState, action) => {
@@ -45,11 +42,6 @@ export default (state = initialState, action) => {
         },
       };
 
-    case actionTypes.HELPSCOUT_BEACON_LOADED:
-      return {
-        ...state,
-        helpScoutBeacon: { loaded: action.loaded },
-      };
     case `intercom_${dataFetchActionTypes.FETCH_SUCCESS}`:
       return {
         ...state,


### PR DESCRIPTION
## Description

Advocacy are moving our FAQ articles over to Zendesk. This is one of the last stages involved in removing our Help Scout integration. For this reason, we will no longer need the Help Scout Beacon widget in the publish dashboard. This PR removes all code associated with Beacon and Help Scout in Publish

## Context & Notes

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
