### PR TITLE
Fix "Invalid Timeslot" on "Share Again"

### DIFF
--- a/packages/composer-popover/components/ComposerWrapper/index.jsx
+++ b/packages/composer-popover/components/ComposerWrapper/index.jsx
@@ -52,6 +52,7 @@ export default connect(
             post: {
               ...state.sent.byProfileId[selectedProfileId].posts[postId],
               scheduled_at: null,
+              pinned: null,
             },
           };
           break;
@@ -59,8 +60,11 @@ export default connect(
           options = {
             editMode: state.pastReminders.editMode,
             sentPost: true,
-            post:
-              state.pastReminders.byProfileId[selectedProfileId].posts[postId],
+            post: {
+              ...state.pastReminders.byProfileId[selectedProfileId].posts[postId],
+              scheduled_at: null,
+              pinned: null,
+            }, 
           };
           break;
         default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

User's encounter an "Invalid timeslot" message when using "Share Again" from Analytics or Past Reminders when a the original update had a 'scheduled_at' or 'pinned' set.

This makes sure that pinned is 'null' from Analytics and both 'scheduled_at' and 'pinned' are null from pastReminders.

Based on this change: https://buffer.atlassian.net/browse/PUB-1709

## Context & Notes

Related to:
- https://buffer.atlassian.net/browse/PUB-2476
- https://buffer.atlassian.net/browse/PUB-2163

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
