### PR TITLE
Fixing ui state for non errored posts being shown as errored

### DIFF
--- a/packages/server/parsers/src/postParser.js
+++ b/packages/server/parsers/src/postParser.js
@@ -42,7 +42,10 @@ const getPostActionString = ({ post }) => {
   return `This post ${post.sent_at ? 'was' : 'will be'} sent ${dateString}.`;
 };
 
-const getPostError = error => {
+const getPostError = ({error, status}) => {
+  if (status !== 'error') {
+    return null;
+  }
   const isObject = typeof error === 'object' && error !== null;
   return isObject ? error.text || '' : error || '';
 };
@@ -50,8 +53,8 @@ const getPostError = error => {
 const getPostDetails = ({ post }) => ({
   postAction: getPostActionString({ post }),
   isRetweet: post.retweet !== undefined,
-  error: getPostError(post.error),
-  errorLink: post.error && post.error.link ? post.error.link : null,
+  error: getPostError({ error: post.error, status: post.status }),
+  errorLink: post.status === 'error' && post.error && post.error.link ? post.error.link : null,
   isCustomScheduled: post.scheduled_at ? true : false,
   isInstagramReminder:
     post.profile_service === 'instagram' && !post.can_send_direct


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Fixing ui state for non errored posts being shown as errored

Users with previously errored posts are still seeing errors in the UI, even though the status has been cleared from errored to not. We need to reflect this in the UI state correctly

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
