### PR TITLE
[PUB-2478] Upgrade ui version

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@bufferapp/dragme": "0.2.2",
     "@bufferapp/react-images-loaded": "1.1.0-fork.0",
     "@bufferapp/react-simple-dropdown": "3.3.0",
-    "@bufferapp/ui": "5.26.0",
+    "@bufferapp/ui": "5.27.0",
     "@hot-loader/react-dom": "16.9.0",
     "@storybook/addon-a11y": "5.1.11",
     "@storybook/addon-actions": "5.1.11",

--- a/packages/campaigns/components/CampaignForm/index.jsx
+++ b/packages/campaigns/components/CampaignForm/index.jsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Link } from '@bufferapp/components';
-import { Text, Input, Button } from '@bufferapp/ui';
+import { Text, Input, Button, Link } from '@bufferapp/ui';
 import { SimpleColorPicker } from '@bufferapp/publish-shared-components';
 import { borderRadius } from '@bufferapp/ui/style/borders';
 import { View } from '@bufferapp/ui/Icon';
@@ -63,12 +62,6 @@ const Notice = styled.div`
 const NoticeText = styled(Text)`
   margin: 0 0 0 8px;
   color: ${grayDark};
-`;
-
-const LinkText = styled(Text)`
-  color: ${blue};
-  margin: 0;
-  display: inline-block;
 `;
 
 /* List of colors for the color picker */
@@ -145,9 +138,9 @@ const CampaignForm = ({
             <NoticeText type="p" color={grayDark}>
               <b>{translations.notice1}</b>
               {translations.notice2}
-              {/* To be replaced by BDS Link, when we create one that's an anchor. FAQ link also has to be replaced */}
-              <Link href="https://faq.buffer.com/" unstyled newTab>
-                <LinkText type="p">{translations.notice3}</LinkText>
+              {/* FAQ link has to be replaced */}
+              <Link href="https://faq.buffer.com/" newTab>
+                {translations.notice3}
               </Link>
               {translations.notice4}
             </NoticeText>

--- a/packages/campaigns/components/CampaignForm/story.jsx
+++ b/packages/campaigns/components/CampaignForm/story.jsx
@@ -6,7 +6,7 @@ import translations from '@bufferapp/publish-i18n/translations/en-us.json';
 
 import CampaignForm from './index';
 
-storiesOf('Campaigns|CreateCampaign', module)
+storiesOf('Campaigns|CampaignForm', module)
   .addDecorator(withA11y)
   .add('default', () => (
     <CampaignForm

--- a/packages/campaigns/components/ListCampaigns/EmptyState/index.jsx
+++ b/packages/campaigns/components/ListCampaigns/EmptyState/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Text, Button } from '@bufferapp/ui';
+import { Text, Button, Link } from '@bufferapp/ui';
 import { StepList } from '@bufferapp/publish-shared-components';
 
 const EmptyStateContainer = styled.div`
@@ -16,6 +16,11 @@ const Content = styled.div`
 const Image = styled.img`
   object-fit: contain;
   width: 100%;
+`;
+
+const LinkWithStyles = styled(Link)`
+  display: inline-block;
+  padding: 16px;
 `;
 
 const EmptyState = ({ translations, onOpenCreateCampaignClick }) => {
@@ -42,16 +47,12 @@ const EmptyState = ({ translations, onOpenCreateCampaignClick }) => {
             label={createCampaign}
             onClick={onOpenCreateCampaignClick}
           />
-          {/* To be replaced by BDS Link, when we create one that's an anchor and not a button */}
-          <Button
-            type="link"
-            size="large"
-            label={learnMore}
-            // Update FAQ link when it's ready
-            onClick={() => {
-              window.location.assign('https://faq.buffer.com/');
-            }}
-          />
+          <LinkWithStyles
+            href="https://faq.buffer.com/" // Update FAQ link when it's ready
+            newTab
+          >
+            {learnMore}
+          </LinkWithStyles>
         </div>
       </Content>
       <Image

--- a/packages/campaigns/components/ViewCampaign/EmptyState/index.jsx
+++ b/packages/campaigns/components/ViewCampaign/EmptyState/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Text, Button } from '@bufferapp/ui';
+import { Text, Button, Link } from '@bufferapp/ui';
 import { gray } from '@bufferapp/ui/style/colors';
 
 const Container = styled.div`
@@ -26,8 +26,9 @@ const SubText = styled.div`
   }
 `;
 
-const LinkButton = styled.div`
-  margin-top: 10px;
+const LinkWithStyles = styled(Link)`
+  display: inline-block;
+  padding: 16px;
 `;
 
 const EmptyState = ({
@@ -67,9 +68,12 @@ const EmptyState = ({
         },
       ]}
     />
-    <LinkButton>
-      <Button label={translations.learnMore} type="link" />
-    </LinkButton>
+    <LinkWithStyles
+      href="https://faq.buffer.com/" // Update FAQ link when it's ready
+      newTab
+    >
+      {translations.learnMore}
+    </LinkWithStyles>
   </Container>
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,10 +2134,10 @@
     "@bufferapp/nav-sidebar" "^1.11.0"
     numeral "2.0.6"
 
-"@bufferapp/ui@5.26.0":
-  version "5.26.0"
-  resolved "https://registry.yarnpkg.com/@bufferapp/ui/-/ui-5.26.0.tgz#7d3812b8077ed0be6003ef16390a3c4923045dec"
-  integrity sha512-CDE8Auv/lFXhNsyR1cAFZ1Hqnj3K3dPLdwss6TkaQ8UqCGdY//9n1LoB+hb1q4VeSCeUYsLzSgKm4hAX+etZlQ==
+"@bufferapp/ui@5.27.0":
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/@bufferapp/ui/-/ui-5.27.0.tgz#790e166dc14dc0ade6901a955aafd71d265e0768"
+  integrity sha512-Ybpqt3jU6+6Vq6lAhGyDKjP2fy65CXDBQBvodwGJLkg0VtpHFM6qwiudM5dO44G7ELsENz2mk36QeVU+jRM/fA==
   dependencies:
     "@reach/tooltip" "0.6.2"
     immutability-helper "^2.9.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Update bufferapp/ui to version 5.27.0, to get the new Link Component.
- Replace Campaign Link Buttons by Link Components.
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2478
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
