### PR TITLE
[PUB-2568] Update FAQ link in dropdown

### DIFF
--- a/packages/app-shell/components/AppShell/index.jsx
+++ b/packages/app-shell/components/AppShell/index.jsx
@@ -24,7 +24,7 @@ const helpMenuItems = [
     id: '1',
     title: 'FAQ',
     onItemClick: () => {
-      window.location.assign('https://faq.buffer.com/');
+      window.location.assign('https://support.buffer.com/hc/en-us');
     },
   },
   {

--- a/packages/app-shell/components/AppShell/index.jsx
+++ b/packages/app-shell/components/AppShell/index.jsx
@@ -15,14 +15,7 @@ const InvertedReturnIcon = () => (
 const helpMenuItems = [
   {
     id: '1',
-    title: 'Support',
-    onItemClick: () => {
-      window.location.assign(`https://${getURL.getBaseURL()}/support`);
-    },
-  },
-  {
-    id: '1',
-    title: 'FAQ',
+    title: 'Help Center',
     onItemClick: () => {
       window.location.assign('https://support.buffer.com/hc/en-us');
     },


### PR DESCRIPTION
## Description

Update FAQ link under Help dropdown menu. Also removes Support option and renames FAQ to 'Help Center'. 

## Context & Notes
PUB-2568

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`