### PR TITLE
PUB-2540  | RPC Parsing full items response for update types

### DIFF
--- a/packages/campaigns/middleware.js
+++ b/packages/campaigns/middleware.js
@@ -25,7 +25,7 @@ export default ({ dispatch }) => next => action => {
           args: {
             campaignId,
             past: false,
-            basicItems: true,
+            fullItems: false,
           },
         })
       );

--- a/packages/server/parsers/src/campaignParser.js
+++ b/packages/server/parsers/src/campaignParser.js
@@ -44,9 +44,12 @@ const parseDateRange = (startDate, endDate) => {
 };
 
 const parseItem = item => {
-  let updateFields = null;
-  if (item.campaign_item_type === 'update') {
-    updateFields = postParser(item);
+  const itemContent = {};
+  if (item.content) {
+    // We'd need to add the other parsers here (storyGroups)
+    if (item.type === 'update') {
+      itemContent.content = postParser(item.content);
+    }
   }
 
   let sentAt = null;
@@ -60,13 +63,16 @@ const parseItem = item => {
   }
 
   const result = {
+    id: item.id,
+    _id: item.id,
     dueAt: item.due_at,
+    type: item.type,
     serviceType: item.service_type,
     serviceId: item.service_id,
     channelType: item.channel_type,
     ...sentAt,
     ...servicePostId,
-    ...updateFields,
+    ...itemContent,
   };
 
   return result;

--- a/packages/server/parsers/src/campaignParser.js
+++ b/packages/server/parsers/src/campaignParser.js
@@ -1,4 +1,5 @@
 const moment = require('moment-timezone');
+const postParser = require('./postParser');
 
 const parseLastUpdated = updatedAt => {
   const updatedDate = new Date(updatedAt * 1000);
@@ -43,6 +44,11 @@ const parseDateRange = (startDate, endDate) => {
 };
 
 const parseItem = item => {
+  let updateFields = null;
+  if (item.campaign_item_type === 'update') {
+    updateFields = postParser(item);
+  }
+
   let sentAt = null;
   if (item.sent_at) {
     sentAt = { sentAt: item.sent_at };
@@ -60,6 +66,7 @@ const parseItem = item => {
     channelType: item.channel_type,
     ...sentAt,
     ...servicePostId,
+    ...updateFields,
   };
 
   return result;

--- a/packages/server/rpc/campaigns/getCampaign/index.js
+++ b/packages/server/rpc/campaigns/getCampaign/index.js
@@ -10,13 +10,13 @@ const processResponse = response => {
 module.exports = method(
   'getCampaign',
   'gets a single campaign, given the id',
-  async ({ campaignId, past, basicItems }, { session }) => {
+  async ({ campaignId, past, fullItems }, { session }) => {
     const uri = `/1/campaigns/${campaignId}.json`;
     try {
       const response = await get({
         uri,
         session,
-        params: { past, basic_items: basicItems },
+        params: { past, full_items: fullItems },
       });
       const result = processResponse(response);
       return Promise.resolve(result);

--- a/packages/server/rpc/campaigns/getCampaign/index.test.js
+++ b/packages/server/rpc/campaigns/getCampaign/index.test.js
@@ -66,6 +66,39 @@ const CAMPAIGN_WITH_SCHEDULED_ITEMS = {
   success: true,
 };
 
+const CAMPAIGN_WITH_SCHEDULED_ITEMS_FULL = {
+  data: {
+    ...CAMPAIGN.data,
+    scheduled: 2,
+    sent: 1,
+    start_date: 1583946000,
+    end_date: 1585998540,
+    items: [
+      {
+        id: '123',
+        type: 'update',
+        due_at: 1583946000,
+        service_type: 'twitter',
+        service_id: 96414483,
+        channel_type: 'profile',
+        campaign_item_type: 'update',
+        text: 'My Update 1',
+      },
+      {
+        id: '124',
+        type: 'update',
+        due_at: 1585998540,
+        service_type: 'twitter',
+        service_id: 96414483,
+        channel_type: 'profile',
+        campaign_item_type: 'update',
+        text: 'My Update 2',
+      },
+    ],
+  },
+  success: true,
+};
+
 const CAMPAIGN_WITH_SENT_ITEMS = {
   data: {
     ...CAMPAIGN.data,
@@ -124,8 +157,10 @@ describe('RPC | Get campaign', () => {
   });
 
   it('gets the campaign with items with full items correctly', async () => {
-    get.mockReturnValueOnce(Promise.resolve(CAMPAIGN_WITH_SCHEDULED_ITEMS));
-    await geCampaign({ fullItems: true }).then(response => {
+    get.mockReturnValueOnce(
+      Promise.resolve(CAMPAIGN_WITH_SCHEDULED_ITEMS_FULL)
+    );
+    await geCampaign({ past: false, fullItems: true }).then(response => {
       expect(response.id).toBe('123456');
       expect(response.globalOrganizationId).toBe('000111');
       expect(response.name).toBe('My campaign');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Updating changes from endpoint:
- Changing param from `basic_items` to `full_items`
- Parsing full items response for update types

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
Jira Card -> PUB-2540
Related PR -> [API changes PR](https://github.com/bufferapp/buffer-web/pull/16939)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
