### PR TITLE
Refactor fetching the campaigns in the queue

### DIFF
--- a/packages/past-reminders/components/PastRemindersPosts/index.jsx
+++ b/packages/past-reminders/components/PastRemindersPosts/index.jsx
@@ -122,11 +122,11 @@ const PastRemindersPosts = ({
     );
   }
 
-  if (hasCampaignsFeature) {
-    useEffect(() => {
+  useEffect(() => {
+    if (hasCampaignsFeature) {
       fetchCampaigns();
-    }, []);
-  }
+    }
+  }, []);
 
   return (
     <ErrorBoundary>

--- a/packages/past-reminders/components/PastRemindersPosts/index.jsx
+++ b/packages/past-reminders/components/PastRemindersPosts/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { PostLists, EmptyState } from '@bufferapp/publish-shared-components';
@@ -100,6 +100,8 @@ const PastRemindersPosts = ({
   showStoriesComposer,
   isDisconnectedProfile,
   onClosePreviewClick,
+  hasCampaignsFeature,
+  fetchCampaigns,
 }) => {
   if (loading) {
     return (
@@ -118,6 +120,12 @@ const PastRemindersPosts = ({
         heroImgSize={{ width: '270px', height: '150px' }}
       />
     );
+  }
+
+  if (hasCampaignsFeature) {
+    useEffect(() => {
+      fetchCampaigns();
+    }, []);
   }
 
   return (
@@ -190,6 +198,8 @@ PastRemindersPosts.propTypes = {
   userData: PropTypes.shape({
     tags: PropTypes.arrayOf(PropTypes.string),
   }),
+  hasCampaignsFeature: PropTypes.bool.isRequired,
+  fetchCampaigns: PropTypes.func.isRequired,
 };
 
 PastRemindersPosts.defaultProps = {

--- a/packages/past-reminders/index.js
+++ b/packages/past-reminders/index.js
@@ -1,6 +1,7 @@
 // component vs. container https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0
 import { connect } from 'react-redux';
 import { actions as previewActions } from '@bufferapp/publish-story-preview';
+import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 // load the presentational component
 import { actions } from './reducer';
 import PastRemindersWrapper from './components/PastRemindersWrapper';
@@ -67,6 +68,9 @@ export default connect(
           state.profileSidebar.selectedProfile.isDisconnected,
         userData: state.appSidebar.user,
         showStoryPreview: state.pastReminders.showStoryPreview,
+        hasCampaignsFeature: state.appSidebar.user.features
+          ? state.appSidebar.user.features.includes('campaigns')
+          : false,
       };
     }
     return {};
@@ -164,6 +168,14 @@ export default connect(
     },
     onClosePreviewClick: () => {
       dispatch(actions.handleClosePreviewClick());
+    },
+    fetchCampaigns: () => {
+      dispatch(
+        dataFetchActions.fetch({
+          name: 'getCampaignsList',
+          args: {},
+        })
+      );
     },
   })
 )(PastRemindersWrapper);

--- a/packages/past-reminders/reducer.js
+++ b/packages/past-reminders/reducer.js
@@ -255,6 +255,10 @@ export default (state = initialState, action) => {
         ...state,
         showStoryPreview: false,
       };
+    case `getCampaignsList_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      return {
+        ...state,
+      };
     default:
       return state;
   }

--- a/packages/past-reminders/reducer.js
+++ b/packages/past-reminders/reducer.js
@@ -256,6 +256,7 @@ export default (state = initialState, action) => {
         showStoryPreview: false,
       };
     case `getCampaignsList_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      // This is a WIP to save campaigns and fetch thos in the composer
       return {
         ...state,
       };

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -75,6 +75,7 @@ const QueuedPosts = ({
   onSetRemindersClick,
   onCampaignTagClick,
   hasCampaignsFeature,
+  fetchCampaigns,
 }) => {
   if (loading) {
     return (
@@ -94,6 +95,12 @@ const QueuedPosts = ({
 
   if (isLockedProfile) {
     return <LockedProfileNotification />;
+  }
+
+  if (hasCampaignsFeature) {
+    useEffect(() => {
+      fetchCampaigns();
+    }, []);
   }
 
   return (
@@ -227,6 +234,8 @@ QueuedPosts.propTypes = {
   hasFirstCommentFlip: PropTypes.bool,
   onCalendarClick: PropTypes.func.isRequired,
   isBusinessAccount: PropTypes.bool,
+  hasCampaignsFeature: PropTypes.bool.isRequired,
+  fetchCampaigns: PropTypes.func.isRequired,
 };
 
 QueuedPosts.defaultProps = {

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -97,11 +97,11 @@ const QueuedPosts = ({
     return <LockedProfileNotification />;
   }
 
-  if (hasCampaignsFeature) {
-    useEffect(() => {
+  useEffect(() => {
+    if (hasCampaignsFeature) {
       fetchCampaigns();
-    }, []);
-  }
+    }
+  }, []);
 
   return (
     <ErrorBoundary>

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -241,6 +241,14 @@ export default connect(
         openCalendarWindow(ownProps.profileId, weekOrMonth);
       }
     },
+    fetchCampaigns: () => {
+      dispatch(
+        dataFetchActions.fetch({
+          name: 'getCampaignsList',
+          args: {},
+        })
+      );
+    },
   })
 )(QueuedPosts);
 

--- a/packages/queue/middleware.js
+++ b/packages/queue/middleware.js
@@ -249,21 +249,6 @@ export default ({ dispatch, getState }) => next => action => {
       break;
     }
 
-    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`: {
-      const hasCampaignsFeature =
-        action.result?.features?.includes('campaigns') ?? false;
-
-      if (hasCampaignsFeature) {
-        dispatch(
-          dataFetchActions.fetch({
-            name: 'getCampaignsList',
-            args: {},
-          })
-        );
-      }
-      break;
-    }
-
     default:
       break;
   }

--- a/packages/queue/reducer.js
+++ b/packages/queue/reducer.js
@@ -438,6 +438,7 @@ export default (state = initialState, action) => {
       };
 
     case `getCampaignsList_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      // This is a WIP to save campaigns and fetch thos in the composer
       return {
         ...state,
       };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
## Description
<!--- Describe your changes in detail. -->
Refactor fetching the campaigns to happen only in the queue and past reminders

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
Related Jira Card PUB-2518

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
