### PR TITLE
[PUB-2560] Add analyze report view tracking and small refactors

### DIFF
--- a/packages/campaign/components/ViewCampaign/Header/index.jsx
+++ b/packages/campaign/components/ViewCampaign/Header/index.jsx
@@ -23,7 +23,6 @@ const Header = ({
   translations,
   campaignDetails,
   hideAnalyzeReport,
-  hasPosts,
   onCreatePostClick,
   onDeleteCampaignClick,
   onEditCampaignClick,
@@ -36,28 +35,32 @@ const Header = ({
         <Text type="h1">{campaignDetails.name}</Text>
       </Title>
       <SubText>
-        {hasPosts && (
-          <Details>
+        <Details>
+          {campaignDetails.dateRange && (
             <Group>
               <Icon>
                 <CalendarIcon size="medium" />
               </Icon>
               <Text type="p">{campaignDetails.dateRange}</Text>
             </Group>
-            <Group>
-              <Icon>
-                <ClockIcon size="medium" />
-              </Icon>
-              <Text type="p">{campaignDetails.scheduled}</Text>
-            </Group>
-            <Group>
-              <Icon>
-                <ListIcon size="medium" />
-              </Icon>
-              <Text type="p">{campaignDetails.sent}</Text>
-            </Group>
-          </Details>
-        )}
+          )}
+          <Group>
+            <Icon>
+              <ClockIcon size="medium" />
+            </Icon>
+            <Text type="p">
+              {campaignDetails.scheduled} {translations.scheduled}
+            </Text>
+          </Group>
+          <Group>
+            <Icon>
+              <ListIcon size="medium" />
+            </Icon>
+            <Text type="p">
+              {campaignDetails.sent} {translations.sent}
+            </Text>
+          </Group>
+        </Details>
         <Text type="p">
           <LastUpdated>{campaignDetails.lastUpdated}</LastUpdated>
         </Text>
@@ -100,7 +103,7 @@ const Header = ({
           onClick={() => {
             goToAnalyzeReport();
           }}
-          disabled={!hasPosts}
+          disabled={!campaignDetails.dateRange}
           label={translations.viewReport}
         />
       )}
@@ -114,6 +117,8 @@ Header.propTypes = {
     createPost: PropTypes.string,
     editCampaign: PropTypes.string,
     deleteCampaign: PropTypes.string,
+    sent: PropTypes.string,
+    scheduled: PropTypes.string,
   }).isRequired,
   campaignDetails: PropTypes.shape({
     name: PropTypes.string,
@@ -123,7 +128,6 @@ Header.propTypes = {
     sent: PropTypes.number,
     lastUpdated: PropTypes.string,
   }).isRequired,
-  hasPosts: PropTypes.bool.isRequired,
   hideAnalyzeReport: PropTypes.bool.isRequired,
   onCreatePostClick: PropTypes.func.isRequired,
   onDeleteCampaignClick: PropTypes.func.isRequired,

--- a/packages/campaign/components/ViewCampaign/Header/index.jsx
+++ b/packages/campaign/components/ViewCampaign/Header/index.jsx
@@ -95,7 +95,7 @@ const Header = ({
           },
         ]}
       />
-      {hideAnalyzeReport && (
+      {!hideAnalyzeReport && (
         <Button
           type="secondary"
           icon={<ArrowRightIcon />}

--- a/packages/campaign/components/ViewCampaign/Header/index.jsx
+++ b/packages/campaign/components/ViewCampaign/Header/index.jsx
@@ -22,7 +22,7 @@ import {
 const Header = ({
   translations,
   campaignDetails,
-  isUsingPublishAsTeamMember,
+  hideAnalyzeReport,
   hasPosts,
   onCreatePostClick,
   onDeleteCampaignClick,
@@ -92,7 +92,7 @@ const Header = ({
           },
         ]}
       />
-      {!isUsingPublishAsTeamMember && (
+      {hideAnalyzeReport && (
         <Button
           type="secondary"
           icon={<ArrowRightIcon />}
@@ -124,7 +124,7 @@ Header.propTypes = {
     lastUpdated: PropTypes.string,
   }).isRequired,
   hasPosts: PropTypes.bool.isRequired,
-  isUsingPublishAsTeamMember: PropTypes.bool.isRequired,
+  hideAnalyzeReport: PropTypes.bool.isRequired,
   onCreatePostClick: PropTypes.func.isRequired,
   onDeleteCampaignClick: PropTypes.func.isRequired,
   onEditCampaignClick: PropTypes.func.isRequired,

--- a/packages/campaign/components/ViewCampaign/Header/story.jsx
+++ b/packages/campaign/components/ViewCampaign/Header/story.jsx
@@ -18,7 +18,7 @@ storiesOf('Campaigns|ViewCampaignHeader', module)
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
       hasPosts
-      isUsingPublishAsTeamMember
+      hideAnalyzeReport
     />
   ))
   .add('Campaign view header without posts', () => (
@@ -30,7 +30,7 @@ storiesOf('Campaigns|ViewCampaignHeader', module)
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
       hasPosts={false}
-      isUsingPublishAsTeamMember
+      hideAnalyzeReport
     />
   ))
   .add('Campaign view header as team member', () => (
@@ -42,6 +42,6 @@ storiesOf('Campaigns|ViewCampaignHeader', module)
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
       hasPosts={false}
-      isUsingPublishAsTeamMember={false}
+      hideAnalyzeReport={false}
     />
   ));

--- a/packages/campaign/components/ViewCampaign/Header/story.jsx
+++ b/packages/campaign/components/ViewCampaign/Header/story.jsx
@@ -4,8 +4,14 @@ import { action } from '@storybook/addon-actions';
 import { withA11y } from '@storybook/addon-a11y';
 import translations from '@bufferapp/publish-i18n/translations/en-us.json';
 import campaignDetails from '../story';
-
 import Header from './index';
+
+const campaignWithoutDaterange = {
+  ...campaignDetails,
+  dateRange: null,
+  sent: 0,
+  scheduled: 0,
+};
 
 storiesOf('Campaigns|ViewCampaignHeader', module)
   .addDecorator(withA11y)
@@ -17,19 +23,17 @@ storiesOf('Campaigns|ViewCampaignHeader', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
-      hasPosts
       hideAnalyzeReport
     />
   ))
-  .add('Campaign view header without posts', () => (
+  .add('Campaign view header without a date range', () => (
     <Header
-      campaignDetails={campaignDetails}
+      campaignDetails={campaignWithoutDaterange}
       translations={translations.campaigns.viewCampaign}
       onCreatePostClick={action('create post')}
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
-      hasPosts={false}
       hideAnalyzeReport
     />
   ))
@@ -41,7 +45,6 @@ storiesOf('Campaigns|ViewCampaignHeader', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
-      hasPosts={false}
       hideAnalyzeReport={false}
     />
   ));

--- a/packages/campaign/components/ViewCampaign/Header/story.jsx
+++ b/packages/campaign/components/ViewCampaign/Header/story.jsx
@@ -23,7 +23,7 @@ storiesOf('Campaigns|ViewCampaignHeader', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
-      hideAnalyzeReport
+      hideAnalyzeReport={false}
     />
   ))
   .add('Campaign view header without a date range', () => (
@@ -34,7 +34,7 @@ storiesOf('Campaigns|ViewCampaignHeader', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
-      hideAnalyzeReport
+      hideAnalyzeReport={false}
     />
   ))
   .add('Campaign view header as team member', () => (
@@ -45,6 +45,6 @@ storiesOf('Campaigns|ViewCampaignHeader', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
-      hideAnalyzeReport={false}
+      hideAnalyzeReport
     />
   ));

--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -56,7 +56,6 @@ const ViewCampaign = ({
     <Container>
       <Header
         campaignDetails={campaign}
-        hasPosts={campaignHasPosts}
         hideAnalyzeReport={hideAnalyzeReport}
         translations={translations}
         onCreatePostClick={onCreatePostClick}

--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -23,7 +23,7 @@ const ViewCampaign = ({
   campaign,
   showComposer,
   isLoading,
-  isUsingPublishAsTeamMember,
+  hideAnalyzeReport,
   translations,
   onCreatePostClick,
   onDeleteCampaignClick,
@@ -57,7 +57,7 @@ const ViewCampaign = ({
       <Header
         campaignDetails={campaign}
         hasPosts={campaignHasPosts}
-        isUsingPublishAsTeamMember={isUsingPublishAsTeamMember}
+        hideAnalyzeReport={hideAnalyzeReport}
         translations={translations}
         onCreatePostClick={onCreatePostClick}
         onDeleteCampaignClick={onDeleteCampaignClick}
@@ -115,7 +115,7 @@ ViewCampaign.propTypes = {
   translations: PropTypes.object.isRequired, // eslint-disable-line
   campaign: PropTypes.object.isRequired, // eslint-disable-line
   campaignPosts: PropTypes.array, // eslint-disable-line
-  isUsingPublishAsTeamMember: PropTypes.bool.isRequired,
+  hideAnalyzeReport: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
   onCreatePostClick: PropTypes.func.isRequired,
   onDeleteCampaignClick: PropTypes.func.isRequired,

--- a/packages/campaign/components/ViewCampaign/story.jsx
+++ b/packages/campaign/components/ViewCampaign/story.jsx
@@ -49,7 +49,7 @@ storiesOf('Campaigns|ViewCampaign', module)
       onComposerCreateSuccess={action('composer create success')}
       onComposerOverlayClick={action('composer overlay')}
       campaignId="id"
-      isUsingPublishAsTeamMember
+      hideAnalyzeReport
       hasCampaignsFlip
       isLoading={false}
       showComposer={false}
@@ -67,7 +67,7 @@ storiesOf('Campaigns|ViewCampaign', module)
       onComposerCreateSuccess={action('composer create success')}
       onComposerOverlayClick={action('composer overlay')}
       campaignId="id"
-      isUsingPublishAsTeamMember
+      hideAnalyzeReport
       hasCampaignsFlip
       isLoading={false}
       showComposer={false}

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
 import { campaignEdit } from '@bufferapp/publish-routes';
 import { actions } from './reducer';
@@ -32,8 +31,8 @@ export default connect(
     onDeleteCampaignClick: campaign => {
       dispatch(modalsActions.showDeleteCampaignModal(campaign));
     },
-    goToAnalyzeReport: () => {
-      window.location.assign(`${getURL.getAnalyzeReportUrl()}`);
+    goToAnalyzeReport: campaign => {
+      dispatch(actions.goToAnalyzeReport(campaign));
     },
     onEditCampaignClick: campaignId => {
       if (campaignId) {

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -11,8 +11,7 @@ export default connect(
       campaign: state.campaign.campaign,
       showComposer: state.campaign.showComposer,
       translations: state.i18n.translations.campaigns.viewCampaign,
-      isUsingPublishAsTeamMember:
-        state.appSidebar.user.isUsingPublishAsTeamMember,
+      hideAnalyzeReport: state.appSidebar.user.isUsingPublishAsTeamMember,
       isLoading: state.campaign.isLoading,
       campaignId: state.campaign?.campaignId || ownProps.match?.params?.id,
       hasCampaignsFlip: state.appSidebar.user.features

--- a/packages/campaign/middleware.js
+++ b/packages/campaign/middleware.js
@@ -2,12 +2,15 @@ import {
   actions as dataFetchActions,
   actionTypes as dataFetchActionTypes,
 } from '@bufferapp/async-data-fetch';
+import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
 import { actions as notificationActions } from '@bufferapp/notifications';
+import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { campaignsPage } from '@bufferapp/publish-routes';
 import { actionTypes } from './reducer';
 
-export default ({ dispatch }) => next => action => {
+export default ({ dispatch, getState }) => next => action => {
   next(action);
+  const state = getState();
   switch (action.type) {
     case actionTypes.FETCH_CAMPAIGN: {
       const { campaignId, past, fullItems } = action;
@@ -22,6 +25,19 @@ export default ({ dispatch }) => next => action => {
           },
         })
       );
+      break;
+    }
+
+    case actionTypes.GO_TO_ANALYZE_REPORT: {
+      const { id, name } = action.campaign;
+      const { organizationId } = state.profileSidebar.selectedProfile;
+      const metadata = {
+        campaignId: id,
+        campaignName: name,
+        organizationId,
+      };
+      dispatch(analyticsActions.trackEvent('Campaign Report Viewed', metadata));
+      window.location.assign(`${getURL.getAnalyzeReportUrl()}`);
       break;
     }
 

--- a/packages/campaign/middleware.test.js
+++ b/packages/campaign/middleware.test.js
@@ -57,4 +57,42 @@ describe('middleware', () => {
       })
     );
   });
+  it('tracks view report event and redirects to analyze report', () => {
+    const hostname = 'publish.local.buffer.com';
+    const url = 'https://analyze.local.buffer.com/reports';
+    window.location.assign = jest.fn();
+    window.location.hostname = hostname;
+
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        campaignView: initialState,
+        profileSidebar: {
+          selectedProfile: {
+            organizationId: '123',
+          },
+        },
+      }),
+    };
+    const action = {
+      type: actionTypes.GO_TO_ANALYZE_REPORT,
+      campaign: { id: 'id1', name: 'Awareness Day' },
+    };
+    const expectedObj = {
+      campaignId: 'id1',
+      campaignName: 'Awareness Day',
+      organizationId: '123',
+    };
+
+    middleware(store)(next)(action);
+
+    expect(next).toBeCalledWith(action);
+
+    expect(analyticsActions.trackEvent).toBeCalledWith(
+      'Campaign Report Viewed',
+      expectedObj
+    );
+    expect(window.location.assign).toHaveBeenCalledWith(url);
+    window.location.assign.mockRestore();
+  });
 });

--- a/packages/campaign/middleware.test.js
+++ b/packages/campaign/middleware.test.js
@@ -1,7 +1,10 @@
 import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 import { actionTypes as notificationActionTypes } from '@bufferapp/notifications';
+import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
 import middleware from './middleware';
 import { actionTypes, initialState } from './reducer';
+
+jest.mock('@bufferapp/publish-analytics-middleware');
 
 describe('middleware', () => {
   const next = jest.fn();

--- a/packages/campaign/reducer.js
+++ b/packages/campaign/reducer.js
@@ -5,6 +5,7 @@ export const actionTypes = keyWrapper('CAMPAIGN_VIEW', {
   FETCH_CAMPAIGN: 0,
   OPEN_COMPOSER: 0,
   CLOSE_COMPOSER: 0,
+  GO_TO_ANALYZE_REPORT: 0,
 });
 
 export const initialState = {
@@ -65,5 +66,9 @@ export const actions = {
     type: actionTypes.FETCH_CAMPAIGN,
     campaignId,
     past,
+  }),
+  goToAnalyzeReport: campaign => ({
+    type: actionTypes.GO_TO_ANALYZE_REPORT,
+    campaign,
   }),
 };

--- a/packages/campaign/reducer.test.js
+++ b/packages/campaign/reducer.test.js
@@ -142,5 +142,13 @@ describe('reducer', () => {
       };
       expect(actions.handleCloseComposer()).toEqual(expectedAction);
     });
+    it('creates a GO_TO_ANALYZE_REPORT action', () => {
+      const campaign = {};
+      const expectedAction = {
+        type: actionTypes.GO_TO_ANALYZE_REPORT,
+        campaign,
+      };
+      expect(actions.goToAnalyzeReport(campaign)).toEqual(expectedAction);
+    });
   });
 });

--- a/packages/campaigns-list/components/ListCampaigns/List/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/List/index.jsx
@@ -16,7 +16,7 @@ const List = ({
   goToAnalyzeReport,
   onDeleteCampaignClick,
   onEditCampaignClick,
-  isUsingPublishAsTeamMember,
+  hideAnalyzeReport,
 }) => {
   const listItems = campaigns.map((campaign, index) => (
     <ListItem
@@ -27,7 +27,7 @@ const List = ({
       onDeleteCampaignClick={onDeleteCampaignClick}
       onEditCampaignClick={onEditCampaignClick}
       goToAnalyzeReport={goToAnalyzeReport}
-      isUsingPublishAsTeamMember={isUsingPublishAsTeamMember}
+      hideAnalyzeReport={hideAnalyzeReport}
       isEvenItem={index % 2 === 0}
     />
   ));
@@ -41,7 +41,7 @@ List.propTypes = {
   onDeleteCampaignClick: PropTypes.func.isRequired,
   onViewCampaignClick: PropTypes.func.isRequired,
   goToAnalyzeReport: PropTypes.func.isRequired,
-  isUsingPublishAsTeamMember: PropTypes.bool.isRequired,
+  hideAnalyzeReport: PropTypes.bool.isRequired,
 };
 
 export default List;

--- a/packages/campaigns-list/components/ListCampaigns/List/story.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/List/story.jsx
@@ -55,6 +55,6 @@ storiesOf('Campaigns|ListCampaigns', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
-      isUsingPublishAsTeamMember={false}
+      hideAnalyzeReport={false}
     />
   ));

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
@@ -20,7 +20,7 @@ import {
 const ListItem = ({
   campaign,
   isEvenItem,
-  isUsingPublishAsTeamMember,
+  hideAnalyzeReport,
   onEditCampaignClick,
   onDeleteCampaignClick,
   onViewCampaignClick,
@@ -92,14 +92,16 @@ const ListItem = ({
       <ButtonWrapper>
         <Button
           onClick={
-            isUsingPublishAsTeamMember
+            hideAnalyzeReport
               ? viewCampaignSelectItem.selectedItemClick
-              : goToAnalyzeReport
+              : () => {
+                  goToAnalyzeReport(campaign);
+                }
           }
           type="secondary"
           isSplit
           label={
-            isUsingPublishAsTeamMember
+            hideAnalyzeReport
               ? translations.viewCampaign
               : translations.viewReport
           }
@@ -110,7 +112,7 @@ const ListItem = ({
             return false;
           }}
           items={
-            isUsingPublishAsTeamMember
+            hideAnalyzeReport
               ? selectItems
               : [viewCampaignSelectItem, ...selectItems]
           }
@@ -142,7 +144,7 @@ ListItem.propTypes = {
   onDeleteCampaignClick: PropTypes.func.isRequired,
   onEditCampaignClick: PropTypes.func.isRequired,
   goToAnalyzeReport: PropTypes.func.isRequired,
-  isUsingPublishAsTeamMember: PropTypes.bool.isRequired,
+  hideAnalyzeReport: PropTypes.bool.isRequired,
   isEvenItem: PropTypes.bool.isRequired,
 };
 

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/story.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/story.jsx
@@ -37,7 +37,7 @@ storiesOf('Campaigns|ListItem', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
-      isUsingPublishAsTeamMember={false}
+      hideAnalyzeReport={false}
     />
   ))
   .add('Team member view of campaign list item', () => (
@@ -49,7 +49,7 @@ storiesOf('Campaigns|ListItem', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
-      isUsingPublishAsTeamMember
+      hideAnalyzeReport
     />
   ))
   .add('Campaign list item with gray background', () => (
@@ -61,7 +61,7 @@ storiesOf('Campaigns|ListItem', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
-      isUsingPublishAsTeamMember={false}
+      hideAnalyzeReport={false}
     />
   ))
   .add('Campaign list item without any posts', () => (
@@ -73,6 +73,6 @@ storiesOf('Campaigns|ListItem', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       goToAnalyzeReport={action('go to analyze report')}
-      isUsingPublishAsTeamMember={false}
+      hideAnalyzeReport={false}
     />
   ));

--- a/packages/campaigns-list/components/ListCampaigns/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/index.jsx
@@ -27,7 +27,7 @@ const ListCampaigns = ({
   onViewCampaignClick,
   goToAnalyzeReport,
   onOpenCreateCampaignClick,
-  isUsingPublishAsTeamMember,
+  hideAnalyzeReport,
   hasCampaignsFlip,
   fetchCampaigns,
   isLoading,
@@ -71,7 +71,7 @@ const ListCampaigns = ({
         onViewCampaignClick={onViewCampaignClick}
         goToAnalyzeReport={goToAnalyzeReport}
         translations={translations.viewCampaign}
-        isUsingPublishAsTeamMember={isUsingPublishAsTeamMember}
+        hideAnalyzeReport={hideAnalyzeReport}
       />
     </Container>
   );
@@ -85,7 +85,7 @@ ListCampaigns.propTypes = {
   onDeleteCampaignClick: PropTypes.func,
   onViewCampaignClick: PropTypes.func,
   goToAnalyzeReport: PropTypes.func,
-  isUsingPublishAsTeamMember: PropTypes.bool.isRequired,
+  hideAnalyzeReport: PropTypes.bool.isRequired,
   hasCampaignsFlip: PropTypes.bool.isRequired,
   fetchCampaigns: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,

--- a/packages/campaigns-list/index.js
+++ b/packages/campaigns-list/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
-import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { actions as modalsActions } from '@bufferapp/publish-modals/reducer';
+import { actions as campaignActions } from '@bufferapp/publish-campaign/reducer';
 import {
   campaignEdit,
   campaignCreate,
@@ -33,8 +33,8 @@ export default connect(
     onDeleteCampaignClick: campaign => {
       dispatch(modalsActions.showDeleteCampaignModal(campaign));
     },
-    goToAnalyzeReport: () => {
-      window.location.assign(`${getURL.getAnalyzeReportUrl()}`);
+    goToAnalyzeReport: campaign => {
+      dispatch(campaignActions.goToAnalyzeReport(campaign));
     },
     onEditCampaignClick: campaignId => {
       if (campaignId) {

--- a/packages/campaigns-list/index.js
+++ b/packages/campaigns-list/index.js
@@ -14,8 +14,7 @@ export default connect(
     return {
       campaigns: state.campaignsList.campaigns,
       translations: state.i18n.translations.campaigns,
-      isUsingPublishAsTeamMember:
-        state.appSidebar.user.isUsingPublishAsTeamMember,
+      hideAnalyzeReport: state.appSidebar.user.isUsingPublishAsTeamMember,
       isLoading: state.campaignsList.isLoading,
       hasCampaignsFlip: state.appSidebar.user.features
         ? state.appSidebar.user.features.includes('campaigns')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Add tracking when a user clicks on on view analyze report in campaigns.
- Refactor `isTeamMemberUsingPublish` to `hideAnalyzeReport`
- In campaign view header, disable view report if dateRange is null.
- Display sent & scheduled in campaign view header even if value is 0.
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2560

- Made some changes to campaign view header after working on a similar component with list campaigns. I was able to clarify a few things with Lauren, and we do want to show sent & scheduled even it's zero. 

- Date range is a better indicator on whether view report should be disabled. Even if a campaign has no posts, they may still have sent posts for the report. I confirmed with Maya that dateRange will be null if there have been 0 posts added to a campaign. 

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
