### PR TITLE
Fix `react-dnd` error by not propagating Dropzone drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vendor.css
 *.map
 *.vscode
 dist
+standalone-session.json

--- a/packages/UploadZone/components/UploadZone/index.jsx
+++ b/packages/UploadZone/components/UploadZone/index.jsx
@@ -65,9 +65,15 @@ class UploadZone extends React.Component {
   };
 
   onDrop = (files, rejected, event) => {
-    // stop event propagation
-    // if we dont' do this, file drops can propogate up to react-dnd
-    // and throw errors in the console; https://github.com/react-dnd/react-dnd/issues/457
+    /*
+     * Stop event propagation.
+     * If we dont' do this, file drops may propogate up from Dropzone to `react-dnd`
+     * and throw errors in the console; https://github.com/react-dnd/react-dnd/issues/457
+     *
+     * This was happening with the story groups composer when dropping a file on
+     * one of the cards. (Though the error wasn't crashing the app; it just added
+     * noise to our Bugsnag reporting.)
+     */
     event.stopPropagation();
 
     const { disabled } = this.props;

--- a/packages/UploadZone/components/UploadZone/index.jsx
+++ b/packages/UploadZone/components/UploadZone/index.jsx
@@ -64,7 +64,12 @@ class UploadZone extends React.Component {
     this.dropzone.open();
   };
 
-  onDrop = files => {
+  onDrop = (files, rejected, event) => {
+    // stop event propagation
+    // if we dont' do this, file drops can propogate up to react-dnd
+    // and throw errors in the console; https://github.com/react-dnd/react-dnd/issues/457
+    event.stopPropagation();
+
     const { disabled } = this.props;
     if (disabled) return;
 
@@ -215,6 +220,7 @@ class UploadZone extends React.Component {
     return (
       <div>
         <DropzoneWithStyles
+          onDragOver={event => event.stopPropagation()}
           onDrop={this.onDrop}
           activeClassName={classNames && classNames.uploadZoneActive}
           disabledClassName={classNames && classNames.uploadZoneDisabled}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

If we don't do this, file drops may propagate up from Dropzone to `react-dnd` and throw errors in the console (see https://github.com/react-dnd/react-dnd/issues/457)

This was happening with the story groups composer when dropping a file on one of the cards. (Though the error wasn't crashing the app; it just added noise to our Bugsnag reporting.)


