### PR TITLE
PUB-2611  | Adding logic for composer within list campaigns view

### DIFF
--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -43,6 +43,9 @@ const ViewCampaign = ({
   onComposerCreateSuccess,
   onComposerOverlayClick,
   hasCampaignsFlip,
+  editMode,
+  onEditClick,
+  fetchCampaigns,
 }) => {
   if (!hasCampaignsFlip) {
     window.location = getURL.getPublishUrl();
@@ -52,6 +55,10 @@ const ViewCampaign = ({
   useEffect(() => {
     fetchCampaign({ campaignId });
   }, [campaignId]);
+
+  useEffect(() => {
+    fetchCampaigns();
+  }, []);
   // State
   const [listView, toggleView] = useState('scheduled');
 
@@ -81,9 +88,9 @@ const ViewCampaign = ({
       {showComposer && (
         <ComposerPopover
           onSave={onComposerCreateSuccess}
-          type="queue"
+          type="campaign"
           onComposerOverlayClick={onComposerOverlayClick}
-          editMode={false}
+          editMode={editMode}
         />
       )}
       {campaignHasPosts ? (
@@ -100,7 +107,7 @@ const ViewCampaign = ({
           <QueueItems
             items={campaignPosts}
             onDeleteConfirmClick={null}
-            onEditClick={null}
+            onEditClick={onEditClick}
             onShareNowClick={null}
             draggable={false}
             type="post"
@@ -140,7 +147,10 @@ ViewCampaign.propTypes = {
   showComposer: PropTypes.bool.isRequired,
   onComposerCreateSuccess: PropTypes.func.isRequired,
   onComposerOverlayClick: PropTypes.func.isRequired,
+  onEditClick: PropTypes.func.isRequired,
+  fetchCampaigns: PropTypes.func.isRequired,
   hasCampaignsFlip: PropTypes.bool.isRequired,
+  editMode: PropTypes.bool.isRequired,
 };
 
 export default ViewCampaign;

--- a/packages/campaign/components/ViewCampaign/story.jsx
+++ b/packages/campaign/components/ViewCampaign/story.jsx
@@ -106,6 +106,7 @@ const actions = {
   onDeleteCampaignClick: action('delete campaign'),
   onEditCampaignClick: action('edit campaign'),
   fetchCampaign: action('fetch campaign'),
+  fetchCampaigns: action('fetch campaigns'),
   goToAnalyzeReport: action('go to analyze report'),
   onComposerCreateSuccess: action('composer sucess'),
   onComposerOverlayClick: action('composer overlay click'),

--- a/packages/campaign/components/ViewCampaign/story.jsx
+++ b/packages/campaign/components/ViewCampaign/story.jsx
@@ -45,6 +45,7 @@ storiesOf('Campaigns|ViewCampaign', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       fetchCampaign={action('fetch campaign')}
+      fetchCampaigns={action('fetch campaigns')}
       goToAnalyzeReport={action('go to analyze report')}
       onComposerCreateSuccess={action('composer create success')}
       onComposerOverlayClick={action('composer overlay')}
@@ -63,6 +64,7 @@ storiesOf('Campaigns|ViewCampaign', module)
       onDeleteCampaignClick={action('delete campaign')}
       onEditCampaignClick={action('edit campaign')}
       fetchCampaign={action('fetch campaign')}
+      fetchCampaigns={action('fetch campaigns')}
       goToAnalyzeReport={action('go to analyze report')}
       onComposerCreateSuccess={action('composer create success')}
       onComposerOverlayClick={action('composer overlay')}

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
 import { formatPostLists } from '@bufferapp/publish-queue/util';
 import { campaignEdit } from '@bufferapp/publish-routes';
+import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 import { actions } from './reducer';
 import ViewCampaign from './components/ViewCampaign';
 
@@ -52,6 +53,22 @@ export default connect(
     },
     fetchCampaign: ({ campaignId, past }) => {
       dispatch(actions.fetchCampaign({ campaignId, past, fullItems: true }));
+    },
+    fetchCampaigns: () => {
+      dispatch(
+        dataFetchActions.fetch({
+          name: 'getCampaignsList',
+          args: {},
+        })
+      );
+    },
+    onEditClick: post => {
+      dispatch(
+        actions.handleEditClick({
+          post: post.post,
+          profileId: post.post.profileId,
+        })
+      );
     },
   })
 )(ViewCampaign);

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -66,10 +66,17 @@ export default connect(
     },
     postActions: {
       onEditClick: post => {
+        const { profileId } = post.post;
+
+        dispatch(
+          actions.handleSelectProfile({
+            profileId,
+          })
+        );
         dispatch(
           actions.handleOpenComposer({
             post: post.post,
-            profileId: post.post.profileId,
+            profileId,
             editMode: true,
           })
         );

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -66,17 +66,10 @@ export default connect(
     },
     postActions: {
       onEditClick: post => {
-        const { profileId } = post.post;
-
-        dispatch(
-          actions.handleSelectProfile({
-            profileId,
-          })
-        );
         dispatch(
           actions.handleOpenComposer({
             post: post.post,
-            profileId,
+            profileId: post.post.profileId,
             editMode: true,
           })
         );

--- a/packages/campaign/middleware.js
+++ b/packages/campaign/middleware.js
@@ -52,19 +52,6 @@ export default ({ dispatch, getState }) => next => action => {
       dispatch(campaignsPage.goTo());
       break;
 
-    case actionTypes.SELECT_PROFILE: {
-      const { profiles } = getState().profileSidebar;
-      const { profileId } = action;
-      const profile = profiles.find(p => p.id === profileId);
-
-      dispatch(
-        profileSidebarActions.selectProfile({
-          profile,
-        })
-      );
-      break;
-    }
-
     default:
       break;
   }

--- a/packages/campaign/middleware.js
+++ b/packages/campaign/middleware.js
@@ -4,6 +4,7 @@ import {
 } from '@bufferapp/async-data-fetch';
 import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
 import { actions as notificationActions } from '@bufferapp/notifications';
+import { actions as profileSidebarActions } from '@bufferapp/publish-profile-sidebar/reducer';
 import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { campaignsPage } from '@bufferapp/publish-routes';
 import { actionTypes } from './reducer';
@@ -50,6 +51,19 @@ export default ({ dispatch, getState }) => next => action => {
       );
       dispatch(campaignsPage.goTo());
       break;
+
+    case actionTypes.SELECT_PROFILE: {
+      const { profiles } = getState().profileSidebar;
+      const { profileId } = action;
+      const profile = profiles.find(p => p.id === profileId);
+
+      dispatch(
+        profileSidebarActions.selectProfile({
+          profile,
+        })
+      );
+      break;
+    }
 
     default:
       break;

--- a/packages/campaign/reducer.js
+++ b/packages/campaign/reducer.js
@@ -16,7 +16,6 @@ export const actionTypes = keyWrapper('CAMPAIGN_VIEW', {
   POST_IMAGE_CLOSED: 0,
   POST_CONFIRMED_DELETE: 0,
   POST_SHARE_NOW: 0,
-  SELECT_PROFILE: 0,
 });
 
 export const initialState = {
@@ -27,6 +26,7 @@ export const initialState = {
   showComposer: false,
   editMode: false,
   editingPostId: null,
+  selectedProfileId: null,
   campaigns: [],
 };
 
@@ -76,6 +76,7 @@ export default (state = initialState, action) => {
         showComposer: true,
         editMode: action.editMode || false,
         editingPostId: action.updateId || null,
+        selectedProfileId: action.profileId || null,
       };
     }
     case actionTypes.CLOSE_COMPOSER: {
@@ -303,10 +304,6 @@ export const actions = {
     type: actionTypes.POST_IMAGE_CLOSED,
     updateId: post.id,
     post,
-    profileId,
-  }),
-  handleSelectProfile: ({ profileId }) => ({
-    type: actionTypes.SELECT_PROFILE,
     profileId,
   }),
 };

--- a/packages/campaign/reducer.js
+++ b/packages/campaign/reducer.js
@@ -1,5 +1,6 @@
 import keyWrapper from '@bufferapp/keywrapper';
 import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
+import { sortCampaignsByUpdatedAt } from '@bufferapp/publish-queue/reducer';
 
 export const actionTypes = keyWrapper('CAMPAIGN_VIEW', {
   FETCH_CAMPAIGN: 0,
@@ -10,9 +11,13 @@ export const actionTypes = keyWrapper('CAMPAIGN_VIEW', {
 
 export const initialState = {
   campaign: {},
+  campaignPosts: [],
   isLoading: false,
   campaignId: null,
   showComposer: false,
+  editMode: false,
+  editingPostId: '',
+  campaigns: [],
 };
 
 export default (state = initialState, action) => {
@@ -41,14 +46,22 @@ export default (state = initialState, action) => {
       return {
         ...state,
         showComposer: true,
+        editMode: action.editMode || false,
+        editingPostId: action.updateId || '',
       };
     }
     case actionTypes.CLOSE_COMPOSER: {
       return {
         ...state,
         showComposer: false,
+        editMode: false,
       };
     }
+    case `getCampaignsList_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      return {
+        ...state,
+        campaigns: sortCampaignsByUpdatedAt(action.result),
+      };
     default:
       return state;
   }
@@ -71,5 +84,12 @@ export const actions = {
   goToAnalyzeReport: campaign => ({
     type: actionTypes.GO_TO_ANALYZE_REPORT,
     campaign,
+  }),
+  handleEditClick: ({ post, profileId }) => ({
+    type: actionTypes.OPEN_COMPOSER,
+    updateId: post.id,
+    editMode: true,
+    post,
+    profileId,
   }),
 };

--- a/packages/campaign/reducer.js
+++ b/packages/campaign/reducer.js
@@ -16,6 +16,7 @@ export const actionTypes = keyWrapper('CAMPAIGN_VIEW', {
   POST_IMAGE_CLOSED: 0,
   POST_CONFIRMED_DELETE: 0,
   POST_SHARE_NOW: 0,
+  SELECT_PROFILE: 0,
 });
 
 export const initialState = {
@@ -302,6 +303,10 @@ export const actions = {
     type: actionTypes.POST_IMAGE_CLOSED,
     updateId: post.id,
     post,
+    profileId,
+  }),
+  handleSelectProfile: ({ profileId }) => ({
+    type: actionTypes.SELECT_PROFILE,
     profileId,
   }),
 };

--- a/packages/composer-popover/components/ComposerWrapper/index.jsx
+++ b/packages/composer-popover/components/ComposerWrapper/index.jsx
@@ -45,6 +45,15 @@ export default connect(
               : state.queue.byProfileId[selectedProfileId].posts[postId],
           };
           break;
+        case 'campaign': {
+          const posts = state.campaign.campaign.items;
+          const post = posts.find(p => p.id === postId);
+          options = {
+            editMode: state.campaign.editMode,
+            post: post?.content || {},
+          };
+          break;
+        }
         case 'sent':
           options = {
             editMode: state.sent.editMode,

--- a/packages/composer-popover/components/ComposerWrapper/index.jsx
+++ b/packages/composer-popover/components/ComposerWrapper/index.jsx
@@ -17,15 +17,27 @@ const ConnectedComposer = props => (
   </Suspense>
 );
 
+const getProfiles = (state, selectedProfileId) => {
+  let { profiles } = state.profileSidebar;
+
+  if (selectedProfileId) {
+    profiles = profiles.map(profile => ({
+      ...profile,
+      open: profile.id === selectedProfileId,
+    }));
+  }
+
+  return profiles;
+};
+
 export default connect(
   (state, ownProps) => {
     if (state.appSidebar && state.profileSidebar) {
       const { type } = ownProps;
-      const {
+      let {
         profileSidebar: { selectedProfileId },
       } = state;
       const postId = state[type].editingPostId;
-
       let options = {};
 
       switch (type) {
@@ -48,6 +60,8 @@ export default connect(
         case 'campaign': {
           const posts = state.campaign.campaignPosts;
           const post = posts.find(p => p.id === postId);
+          ({ selectedProfileId } = state.campaign);
+
           options = {
             editMode: state.campaign.editMode,
             post: post?.content || {},
@@ -78,7 +92,7 @@ export default connect(
       }
       return {
         userData: state.appSidebar.user,
-        profiles: state.profileSidebar.profiles,
+        profiles: getProfiles(state, selectedProfileId),
         enabledApplicationModes: state.temporaryBanner.enabledApplicationModes,
         environment: state.environment.environment,
         editMode: false,

--- a/packages/composer-popover/components/ComposerWrapper/index.jsx
+++ b/packages/composer-popover/components/ComposerWrapper/index.jsx
@@ -51,6 +51,7 @@ export default connect(
           options = {
             editMode: state.campaign.editMode,
             post: post?.content || {},
+            initialCampaignId: state.campaign.campaign?.id || null,
           };
           break;
         }

--- a/packages/composer/composer/utils/DataImportUtils.js
+++ b/packages/composer/composer/utils/DataImportUtils.js
@@ -253,6 +253,7 @@ const DataImportUtils = {
 
         const isPrefillingExistingUpdate =
           update.id && Object.keys(update).length > 0;
+        const defaultCampaignDetails = metaData.campaignDetails || null;
 
         meta = Object.assign({}, metaData, {
           isPrefillingExistingUpdate,
@@ -303,7 +304,7 @@ const DataImportUtils = {
           locationId: update.service_geolocation_id || null,
           locationName: update.service_geolocation_name || null,
           userTags: update.service_user_tags || null,
-          campaignDetails: update.campaignDetails || null,
+          campaignDetails: update.campaignDetails || defaultCampaignDetails,
           facebookMentionEntities: update.entities || null,
           commentEnabled: update.commentEnabled,
           commentText: update.commentText || null,

--- a/packages/composer/interfaces/buffer-publish.jsx
+++ b/packages/composer/interfaces/buffer-publish.jsx
@@ -33,6 +33,7 @@ const ComposerWrapper = ({
   selectedProfileId,
   tabId,
   campaigns,
+  initialCampaignId,
 }) => {
   const getSaveButtons = () => {
     if (editMode) return ['SAVE'];
@@ -73,6 +74,10 @@ const ComposerWrapper = ({
 
   const subprofileId = post ? post.subprofile_id : undefined;
 
+  const initialCampaignDetails = initialCampaignId
+    ? { id: initialCampaignId }
+    : undefined;
+
   const metaData = {
     application: 'WEB_DASHBOARD',
     environment: `${environment === 'development' ? 'local' : 'production'}`,
@@ -103,7 +108,7 @@ const ComposerWrapper = ({
     tabId,
     emptySlotMode,
     draftMode,
-    campaignDetails: post?.campaignDetails ?? undefined,
+    campaignDetails: post?.campaignDetails || initialCampaignDetails,
     campaigns: campaigns ?? undefined,
   };
   const formattedData = DataImportUtils.formatInputData({

--- a/packages/story-group-composer/utils/AddStory.test.js
+++ b/packages/story-group-composer/utils/AddStory.test.js
@@ -42,6 +42,10 @@ describe('Add Story Utils', () => {
       expect(format).toEqual(unixDate);
     });
     it('returns today unix date when scheduledAt is undefined', () => {
+      moment.unix = function() {
+        return '+052207-02-16T12:57:35.000';
+      };
+
       const format = getMomentTime({
         scheduledAt: undefined,
       });
@@ -49,6 +53,10 @@ describe('Add Story Utils', () => {
       expect(format).toEqual(unixDate);
     });
     it('returns today unix date when scheduledAt is null', () => {
+      moment.unix = function() {
+        return '+052207-02-16T12:57:35.000';
+      };
+
       const format = getMomentTime({
         scheduledAt: null,
       });

--- a/packages/story-group-composer/utils/AddStory.test.js
+++ b/packages/story-group-composer/utils/AddStory.test.js
@@ -47,10 +47,6 @@ describe('Add Story Utils', () => {
       expect(format).toEqual(unixDate);
     });
     it('returns today unix date when scheduledAt is undefined', () => {
-      moment.unix = function() {
-        return '+052207-02-16T12:57:35.000';
-      };
-
       const format = getMomentTime({
         scheduledAt: undefined,
       });
@@ -58,10 +54,6 @@ describe('Add Story Utils', () => {
       expect(format).toEqual(unixDate);
     });
     it('returns today unix date when scheduledAt is null', () => {
-      moment.unix = function() {
-        return '+052207-02-16T12:57:35.000';
-      };
-
       const format = getMomentTime({
         scheduledAt: null,
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
In Campaign View:
- On create post list all campaigns and auto-select the campaign
- On create post selects the first profile by default and schedules a new post.
- On edit post opens composer with the selected post (profile selected and post details)

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
JIRA card: PUB-2611

## Screenshots
**Create post**

![Screen Recording 2020-03-30 at 07 17 PM](https://user-images.githubusercontent.com/988972/77941858-17aebd80-72bb-11ea-9028-cbd3ec55069f.gif)

**Update post**

![Screen Recording 2020-03-30 at 07 18 PM](https://user-images.githubusercontent.com/988972/77942030-58a6d200-72bb-11ea-9727-853597019dae.gif)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
