### PR TITLE
[PUB-2609] Change campaign title to link in list item

### DIFF
--- a/packages/campaigns-list/components/ListCampaigns/EmptyState/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/EmptyState/index.jsx
@@ -68,6 +68,7 @@ const EmptyState = ({ translations, onOpenCreateCampaignClick }) => {
 EmptyState.propTypes = {
   translations: PropTypes.shape({
     title: PropTypes.string.isRequired,
+    subtext: PropTypes.string.isRequired,
     step1: PropTypes.string.isRequired,
     step2: PropTypes.string.isRequired,
     step3: PropTypes.string.isRequired,

--- a/packages/campaigns-list/components/ListCampaigns/List/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/List/index.jsx
@@ -19,7 +19,7 @@ const List = ({
   onEditCampaignClick,
   hideAnalyzeReport,
 }) => {
-  const listItems = campaigns.map((campaign, index) => (
+  const listItems = campaigns.map(campaign => (
     <ListItem
       key={campaign.id}
       translations={translations}

--- a/packages/campaigns-list/components/ListCampaigns/List/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/List/index.jsx
@@ -29,7 +29,6 @@ const List = ({
       onEditCampaignClick={onEditCampaignClick}
       goToAnalyzeReport={goToAnalyzeReport}
       hideAnalyzeReport={hideAnalyzeReport}
-      isEvenItem={index % 2 === 0}
     />
   ));
   return <StyledList>{listItems}</StyledList>;

--- a/packages/campaigns-list/components/ListCampaigns/List/story.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/List/story.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withA11y } from '@storybook/addon-a11y';
+import { MemoryRouter } from 'react-router-dom';
 import translations from '@bufferapp/publish-i18n/translations/en-us.json';
 
 import List from './index';
@@ -46,6 +47,7 @@ const campaigns = [
 ];
 
 storiesOf('Campaigns|ListCampaigns', module)
+  .addDecorator(getStory => <MemoryRouter>{getStory()}</MemoryRouter>)
   .addDecorator(withA11y)
   .add('List of campaigns', () => (
     <List

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
@@ -5,6 +5,8 @@ import { Text, Button } from '@bufferapp/ui';
 import ClockIcon from '@bufferapp/ui/Icon/Icons/Clock';
 import ListIcon from '@bufferapp/ui/Icon/Icons/List';
 import CalendarIcon from '@bufferapp/ui/Icon/Icons/Calendar';
+import Link from '@bufferapp/ui/Link';
+import { campaignScheduled } from '@bufferapp/publish-routes';
 
 import {
   ButtonWrapper,
@@ -50,12 +52,18 @@ const ListItem = ({
     },
   };
 
+  const campaignRoute = campaignScheduled.getRoute({
+    campaignId: campaign.id,
+  });
+
   return (
     <Container isEvenItem={isEvenItem}>
       <LeftWrapper>
         <Title>
           <Color color={campaign.color} />
-          <Text type="h3">{campaign.name}</Text>
+          <Link href={campaignRoute}>
+            <Text type="h3">{campaign.name}</Text>
+          </Link>
         </Title>
         <Text type="p">
           <LastUpdated>{campaign.lastUpdated}</LastUpdated>

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
@@ -17,11 +17,11 @@ import {
   Icon,
   LeftWrapper,
   LastUpdated,
+  StyledLink,
 } from './style';
 
 const ListItem = ({
   campaign,
-  isEvenItem,
   hideAnalyzeReport,
   onEditCampaignClick,
   onDeleteCampaignClick,
@@ -57,13 +57,13 @@ const ListItem = ({
   });
 
   return (
-    <Container isEvenItem={isEvenItem}>
+    <Container>
       <LeftWrapper>
         <Title>
           <Color color={campaign.color} />
-          <Link href={campaignRoute}>
-            <Text type="h3">{campaign.name}</Text>
-          </Link>
+          <Text type="h3">
+            <StyledLink href={campaignRoute}>{campaign.name}</StyledLink>
+          </Text>
         </Title>
         <Text type="p">
           <LastUpdated>{campaign.lastUpdated}</LastUpdated>
@@ -153,7 +153,6 @@ ListItem.propTypes = {
   onEditCampaignClick: PropTypes.func.isRequired,
   goToAnalyzeReport: PropTypes.func.isRequired,
   hideAnalyzeReport: PropTypes.bool.isRequired,
-  isEvenItem: PropTypes.bool.isRequired,
 };
 
 export default ListItem;

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
@@ -11,7 +11,6 @@ import {
   ButtonWrapper,
   Color,
   Container,
-  Title,
   Group,
   Icon,
   LeftWrapper,
@@ -58,12 +57,10 @@ const ListItem = ({
   return (
     <Container>
       <LeftWrapper>
-        <Title>
+        <StyledLink to={campaignRoute}>
           <Color color={campaign.color} />
-          <Text type="h3">
-            <StyledLink href={campaignRoute}>{campaign.name}</StyledLink>
-          </Text>
-        </Title>
+          <Text type="h3">{campaign.name}</Text>
+        </StyledLink>
         <Text type="p">
           <LastUpdated>{campaign.lastUpdated}</LastUpdated>
         </Text>

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
@@ -5,7 +5,6 @@ import { Text, Button } from '@bufferapp/ui';
 import ClockIcon from '@bufferapp/ui/Icon/Icons/Clock';
 import ListIcon from '@bufferapp/ui/Icon/Icons/List';
 import CalendarIcon from '@bufferapp/ui/Icon/Icons/Calendar';
-import Link from '@bufferapp/ui/Link';
 import { campaignScheduled } from '@bufferapp/publish-routes';
 
 import {

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/story.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/story.jsx
@@ -14,7 +14,7 @@ const campaign = {
   scheduled: 8,
   sent: 0,
   lastUpdated: 'Last updated 12 days ago',
-  campaignId: '2',
+  id: '2',
 };
 
 const campaignWithoutPosts = {
@@ -24,7 +24,7 @@ const campaignWithoutPosts = {
   scheduled: 0,
   sent: 0,
   lastUpdated: 'Last updated yesterday',
-  campaignId: '3',
+  id: '3',
 };
 
 storiesOf('Campaigns|ListItem', module)

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/story.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/story.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withA11y } from '@storybook/addon-a11y';
+import { MemoryRouter } from 'react-router-dom';
 import translations from '@bufferapp/publish-i18n/translations/en-us.json';
 
 import ListItem from './index';
@@ -28,6 +29,7 @@ const campaignWithoutPosts = {
 
 storiesOf('Campaigns|ListItem', module)
   .addDecorator(withA11y)
+  .addDecorator(getStory => <MemoryRouter>{getStory()}</MemoryRouter>)
   .add('Owner view of campaign list item', () => (
     <ListItem
       campaign={campaign}

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
@@ -7,7 +7,7 @@ import {
   blue,
 } from '@bufferapp/ui/style/colors';
 import { fontWeightMedium } from '@bufferapp/ui/style/fonts';
-import Link from '@bufferapp/ui/Link';
+import { Link } from 'react-router-dom';
 
 export const Color = styled.div`
   height: 12px;
@@ -36,19 +36,17 @@ export const LastUpdated = styled.span`
   color: ${grayDark};
 `;
 
-export const Title = styled.div`
-  h3 {
-    margin: 0px;
-  }
-  display: flex;
-`;
-
 export const StyledLink = styled(Link)`
+  display: flex;
+  text-decoration: none;
   color: ${grayDarker};
-  font-size: 18px;
   :hover {
     transition: color 150ms ease-in;
     color: ${blue};
+  }
+  h3 {
+    color: inherit;
+    margin: 0px;
   }
 `;
 

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
@@ -14,6 +14,7 @@ export const Color = styled.div`
   max-width: 12px;
   width: 100%;
   border-radius: 50%;
+  position: fixed;
   background-color: ${props => props.color};
   margin: 7px 10px 0px 0px;
 `;
@@ -37,7 +38,7 @@ export const LastUpdated = styled.span`
 `;
 
 export const StyledLink = styled(Link)`
-  display: flex;
+  display: inline-flex;
   text-decoration: none;
   color: ${grayDarker};
   :hover {
@@ -46,7 +47,7 @@ export const StyledLink = styled(Link)`
   }
   h3 {
     color: inherit;
-    margin: 0px;
+    margin: 0px 0px 0px 20px;
   }
 `;
 

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
@@ -1,5 +1,10 @@
 import styled from 'styled-components';
-import { grayDark, grayLight, grayLighter } from '@bufferapp/ui/style/colors';
+import {
+  grayDark,
+  grayLight,
+  grayLighter,
+  blue,
+} from '@bufferapp/ui/style/colors';
 import { fontWeightMedium } from '@bufferapp/ui/style/fonts';
 
 export const Color = styled.div`
@@ -32,6 +37,9 @@ export const LastUpdated = styled.span`
 export const Title = styled.div`
   h3 {
     margin: 0px;
+    :hover {
+      color: ${blue};
+    }
   }
   display: flex;
 `;

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
@@ -1,11 +1,13 @@
 import styled from 'styled-components';
 import {
   grayDark,
+  grayDarker,
   grayLight,
   grayLighter,
   blue,
 } from '@bufferapp/ui/style/colors';
 import { fontWeightMedium } from '@bufferapp/ui/style/fonts';
+import Link from '@bufferapp/ui/Link';
 
 export const Color = styled.div`
   height: 12px;
@@ -37,12 +39,17 @@ export const LastUpdated = styled.span`
 export const Title = styled.div`
   h3 {
     margin: 0px;
-    :hover {
-      transition: color 150ms ease-in;
-      color: ${blue};
-    }
   }
   display: flex;
+`;
+
+export const StyledLink = styled(Link)`
+  color: ${grayDarker};
+  font-size: 18px;
+  :hover {
+    transition: color 150ms ease-in;
+    color: ${blue};
+  }
 `;
 
 export const Group = styled.div`

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
@@ -38,6 +38,7 @@ export const Title = styled.div`
   h3 {
     margin: 0px;
     :hover {
+      transition: color 150ms ease-in;
       color: ${blue};
     }
   }

--- a/packages/routes/index.js
+++ b/packages/routes/index.js
@@ -74,6 +74,7 @@ export const campaignEdit = {
 
 export const campaignScheduled = {
   route: '/campaigns/:id/scheduled/',
+  getRoute: ({ campaignId }) => `/campaigns/${campaignId}/scheduled`,
   goTo: ({ campaignId }) => push(`/campaigns/${campaignId}/scheduled`),
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Add a link to the campaign title in the campaign list. If clicked, redirect to the view campaign page.
- Remove references to `isEvenItem` (no longer being used)
<!--- Describe your changes in detail. -->

## Context & Notes
Hey Ana, I added a getRoute method to routes. Is the campaignScheduled.routes property mainly for documentation? 
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
https://buffer.atlassian.net/browse/PUB-2609

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
