### PR TITLE
PUB-2616  | Fix close composer in campaigns page

### DIFF
--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -36,7 +36,11 @@ export default connect(
         dispatch(actions.handleCloseComposer());
       },
       onComposerOverlayClick: () => {
-        dispatch(modalsActions.showCloseComposerConfirmationModal());
+        dispatch(
+          modalsActions.showCloseComposerConfirmationModal({
+            page: 'campaigns',
+          })
+        );
       },
       onCreatePostClick: campaignId => {
         dispatch(actions.handleOpenComposer({ campaignId, editMode: false }));

--- a/packages/campaign/middleware.js
+++ b/packages/campaign/middleware.js
@@ -4,7 +4,6 @@ import {
 } from '@bufferapp/async-data-fetch';
 import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
 import { actions as notificationActions } from '@bufferapp/notifications';
-import { actions as profileSidebarActions } from '@bufferapp/publish-profile-sidebar/reducer';
 import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { campaignsPage } from '@bufferapp/publish-routes';
 import { actionTypes } from './reducer';

--- a/packages/close-composer-confirmation-modal/middleware.js
+++ b/packages/close-composer-confirmation-modal/middleware.js
@@ -3,16 +3,17 @@ import { actions as draftsActions } from '@bufferapp/publish-drafts/reducer';
 import { actions as modalsActions } from '@bufferapp/publish-modals/reducer';
 import { actions as storiesActions } from '@bufferapp/publish-stories/reducer';
 import { actions as remindersActions } from '@bufferapp/publish-past-reminders/reducer';
+import { actions as campaignsActions } from '@bufferapp/publish-campaign/reducer';
 import { actions as storyGroupComposerActions } from '@bufferapp/publish-story-group-composer/reducer';
 import { actionTypes } from './reducer';
 
 export default ({ dispatch, getState }) => next => action => {
   next(action);
-  const { tabId } = getState().tabs;
+  const { page } = getState().modals;
 
   switch (action.type) {
     case actionTypes.CLOSE_COMPOSER_AND_CONFIRMATION_MODAL:
-      switch (tabId) {
+      switch (page) {
         case 'stories':
           dispatch(storyGroupComposerActions.resetStoryGroupState());
           dispatch(storiesActions.handleCloseStoriesComposer());
@@ -27,6 +28,9 @@ export default ({ dispatch, getState }) => next => action => {
         case 'drafts':
         case 'awaitingApproval':
           dispatch(draftsActions.handleComposerCreateSuccess());
+          break;
+        case 'campaigns':
+          dispatch(campaignsActions.handleCloseComposer());
           break;
         default:
           break;

--- a/packages/drafts/index.js
+++ b/packages/drafts/index.js
@@ -240,7 +240,11 @@ export default connect(
       );
     },
     onComposerOverlayClick: () => {
-      dispatch(modalsActions.showCloseComposerConfirmationModal());
+      dispatch(
+        modalsActions.showCloseComposerConfirmationModal({
+          page: ownProps.tabId || 'drafts',
+        })
+      );
     },
   })
 )(DraftList);

--- a/packages/modals/reducer.js
+++ b/packages/modals/reducer.js
@@ -265,7 +265,7 @@ export const actions = {
   hideCloseComposerConfirmationModal: () => ({
     type: actionTypes.HIDE_CLOSE_COMPOSER_CONFIRMATION_MODAL,
   }),
-  showCloseComposerConfirmationModal: ({ page = 'queue' }) => ({
+  showCloseComposerConfirmationModal: ({ page }) => ({
     type: actionTypes.SHOW_CLOSE_COMPOSER_CONFIRMATION_MODAL,
     page,
   }),

--- a/packages/modals/reducer.js
+++ b/packages/modals/reducer.js
@@ -16,6 +16,7 @@ export const initialState = {
   showCloseComposerConfirmationModal: false,
   modalToShowLater: null,
   showDeleteCampaignModal: false,
+  page: 'queue',
 };
 
 export const actionTypes = keyWrapper('MODALS', {
@@ -170,6 +171,7 @@ export default (state = initialState, action) => {
       return {
         ...state,
         showCloseComposerConfirmationModal: true,
+        page: action.page,
       };
     case actionTypes.HIDE_DELETE_CAMPAIGN_MODAL:
       return {
@@ -263,8 +265,9 @@ export const actions = {
   hideCloseComposerConfirmationModal: () => ({
     type: actionTypes.HIDE_CLOSE_COMPOSER_CONFIRMATION_MODAL,
   }),
-  showCloseComposerConfirmationModal: () => ({
+  showCloseComposerConfirmationModal: ({ page = 'queue' }) => ({
     type: actionTypes.SHOW_CLOSE_COMPOSER_CONFIRMATION_MODAL,
+    page,
   }),
   hideDeleteCampaignModal: () => ({
     type: actionTypes.HIDE_DELETE_CAMPAIGN_MODAL,

--- a/packages/modals/reducer.test.js
+++ b/packages/modals/reducer.test.js
@@ -1,6 +1,6 @@
 import reducer, { initialState, actions } from './reducer';
 
-describe('reducer', () => {
+describe('Modals | reducer', () => {
   it('should return initial state', () => {
     const action = { type: 'INIT' };
     expect(reducer(undefined, action)).toEqual(initialState);
@@ -163,7 +163,7 @@ describe('reducer', () => {
     });
     it('should show close composer confirmation modal', () => {
       expect(
-        reducer(initialState, actions.showCloseComposerConfirmationModal())
+        reducer(initialState, actions.showCloseComposerConfirmationModal({ page: 'queue' }))
       ).toEqual(
         Object.assign(initialState, {
           showCloseComposerConfirmationModal: true,

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -204,7 +204,9 @@ export default connect(
       );
     },
     onComposerOverlayClick: () => {
-      dispatch(modalsActions.showCloseComposerConfirmationModal());
+      dispatch(
+        modalsActions.showCloseComposerConfirmationModal({ page: 'queue' })
+      );
     },
     onCheckInstagramBusinessClick: () => {
       dispatch(

--- a/packages/story-group-composer/index.js
+++ b/packages/story-group-composer/index.js
@@ -40,9 +40,13 @@ export default connect(
       ...options,
     };
   },
-  dispatch => ({
+  (dispatch, ownProps) => ({
     onOverlayClick: () => {
-      dispatch(modalsActions.showCloseComposerConfirmationModal());
+      dispatch(
+        modalsActions.showCloseComposerConfirmationModal({
+          page: ownProps.type,
+        })
+      );
     },
     onCreateStoryGroup: (scheduledAt, shareNow = false) => {
       dispatch(actions.setScheduleLoading(true));


### PR DESCRIPTION
## Description
Fixes closing the composer in campaigns page, sending a param instead of the tabId.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
JIRA card -> PUB-2616

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
