### PR TITLE
[PUB-2612] Check editMode prop when dispatching edit campaign action

### DIFF
--- a/packages/campaign-form/components/CampaignForm/index.jsx
+++ b/packages/campaign-form/components/CampaignForm/index.jsx
@@ -162,6 +162,7 @@ const CampaignForm = ({
                 campaignId,
                 colorSelected,
                 campaignName,
+                editMode,
                 orgId: campaign?.globalOrganizationId,
               })
             }

--- a/packages/campaign-form/index.js
+++ b/packages/campaign-form/index.js
@@ -27,8 +27,9 @@ export default connect(
       colorSelected,
       campaignName,
       orgId,
+      editMode,
     }) => {
-      if (campaignId) {
+      if (editMode) {
         dispatch(
           actions.handleEditCampaignClick({
             id: campaignId,

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/style.js
@@ -14,7 +14,7 @@ export const Color = styled.div`
   max-width: 12px;
   width: 100%;
   border-radius: 50%;
-  position: fixed;
+  position: absolute;
   background-color: ${props => props.color};
   margin: 7px 10px 0px 0px;
 `;
@@ -41,6 +41,7 @@ export const StyledLink = styled(Link)`
   display: inline-flex;
   text-decoration: none;
   color: ${grayDarker};
+  position: relative;
   :hover {
     transition: color 150ms ease-in;
     color: ${blue};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Check if user is in edit mode to decide whether to dispatch edit campaign action. This prevents campaigns getting overwritten.
- Fix campaign color position on scroll. 
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2612
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
