### PR TITLE
Change way we reset state to prevent react rendering crash

### DIFF
--- a/packages/composer/composer/components/App.jsx
+++ b/packages/composer/composer/components/App.jsx
@@ -200,6 +200,7 @@ class App extends React.Component {
     onNewPublish: PropTypes.bool,
     options: PropTypes.shape({
       canSelectProfiles: PropTypes.bool.isRequired,
+      prevPreserveStateOnClose: PropTypes.bool.isRequired,
       preserveStateOnClose: PropTypes.bool.isRequired,
       saveButtons: PropTypes.arrayOf(
         PropTypes.oneOf(Object.keys(SaveButtonTypes))
@@ -327,19 +328,15 @@ class App extends React.Component {
       onNewPublish,
     } = this.props;
 
-    const { preserveStateOnClose } = options;
-    const {
-      preserveStateOnClose: prevPreserveStateOnClose = false,
-    } = AppStore.getOptions();
+    const { preserveStateOnClose, prevPreserveStateOnClose = false } = options;
 
     /**
-     * options.preserveStateOnClose is used to reset the composers' state on close.
-     * However, if options.preserveStateOnClose is true in a previous app instance,
-     * since stores are singletons, we'll need to reset the composers' state on load
-     * if the new instance has `options.preserveStateOnClose === false`
+     * When `options.prevPreserveStateOnClose === false` let's reset the data.
+     * (This ensures the state from editing a post doesn't remain when clicking
+     * to compose a new one.)
      */
     if (
-      preserveStateOnClose === false &&
+      prevPreserveStateOnClose === false &&
       preserveStateOnClose !== prevPreserveStateOnClose
     ) {
       AppInitActionCreators.resetData();

--- a/packages/composer/interfaces/buffer-publish.jsx
+++ b/packages/composer/interfaces/buffer-publish.jsx
@@ -60,14 +60,15 @@ const ComposerWrapper = ({
     bootstrappedListener = true;
   }
 
+  // Get the 'preserve state' setting from the last time the composer was open
   const prevPreserveStateOnClose = AppStore.getOptions().preserveStateOnClose;
-  if (prevPreserveStateOnClose === false) AppInitActionCreators.resetData();
 
   const options = {
     canSelectProfiles: !editMode && !emptySlotMode,
     saveButtons,
     position: { margin: '0 auto' },
     onSave,
+    prevPreserveStateOnClose,
     preserveStateOnClose: emptySlotMode ? false : preserveStateOnClose,
     sentPost,
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

* See Slack thread: https://buffer.slack.com/archives/C0258B5CR/p1585691371180100
* The way I came to this fix was by an error that was showing locally (it is silenced in prod) about not calling setState in a render function. By using chrome debugger, I saw that calling `AppInitActionCreators.resetData();` in the `buffer-publish.jsx`'s ComposerWrapper we were basically doing that.
* To solve I moved the resetting of state inside the composer. In fact logic for that was already there, but it needed to look at a different prop to reset correctly. (This probably worked for buffer-web, when this composer code was used there.)

What confuses me is why this seemed to only show up now? 🤔 

<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`