### PR TITLE
Use default tabId when we don't have previous props

### DIFF
--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -34,10 +34,14 @@ export default hot(
     },
     (dispatch, ownProps) => ({
       onProfileClick: profile => {
-        if (profile && profile.id !== ownProps.profileId) {
+        if (
+          profile &&
+          (profile.id !== ownProps.profileId || ownProps.profileId === null)
+        ) {
+          const tabId = ownProps.tabId ?? 'queue';
           dispatch(
             tabsActions.selectTab({
-              tabId: ownProps.tabId,
+              tabId,
               profileId: profile.id,
             })
           );

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -38,10 +38,9 @@ export default hot(
           profile &&
           (profile.id !== ownProps.profileId || ownProps.profileId === null)
         ) {
-          const tabId = ownProps.tabId ?? 'queue';
           dispatch(
             tabsActions.selectTab({
-              tabId,
+              tabId: ownProps.tabId ?? 'queue',
               profileId: profile.id,
             })
           );

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -4,6 +4,7 @@ import { actions as modalActions } from '@bufferapp/publish-modals';
 import { actions as tabsActions } from '@bufferapp/publish-tabs';
 import { isCampaignsRoute, campaignsPage } from '@bufferapp/publish-routes';
 import ProfileSidebar from './components/ProfileSidebar';
+import { shouldGoToProfile } from './utils';
 import { actions } from './reducer';
 
 const reorderProfilesByUnlocked = profiles =>
@@ -34,10 +35,7 @@ export default hot(
     },
     (dispatch, ownProps) => ({
       onProfileClick: profile => {
-        if (
-          profile &&
-          (profile.id !== ownProps.profileId || ownProps.profileId === null)
-        ) {
+        if (shouldGoToProfile(profile, ownProps)) {
           dispatch(
             tabsActions.selectTab({
               tabId: ownProps.tabId ?? 'queue',

--- a/packages/profile-sidebar/utils/index.js
+++ b/packages/profile-sidebar/utils/index.js
@@ -1,0 +1,12 @@
+function isADifferentProfile(profile, prevProps) {
+  return profile.id !== prevProps.profileId;
+}
+
+const shouldGoToProfile = (profile, prevProps) => {
+  return (
+    profile &&
+    (isADifferentProfile(profile, prevProps) || prevProps.profileId === null)
+  );
+};
+
+export default shouldGoToProfile;


### PR DESCRIPTION
## Description
Since now campaigns is another link at the same level than the rest of
social profiles, we need to take into account the case where the last
selected profile and tab are not available.

## Context & Notes
JIRA ticket: https://buffer.atlassian.net/browse/PUB-2617

## Screenshots
![image](https://user-images.githubusercontent.com/567695/78259071-77e07200-74fc-11ea-9d75-a30321bea30d.png)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
