### PR TITLE
[PUB-2570] Adapt pusher events for sent campaign

### DIFF
--- a/packages/app-pages/components/PagesWithSidebar/index.jsx
+++ b/packages/app-pages/components/PagesWithSidebar/index.jsx
@@ -32,10 +32,7 @@ const PagesWithSidebar = () => {
             render={props => <CampaignForm {...props} editMode />}
           />
           <Route path={campaignScheduled.route} component={ViewCampaign} />
-          <Route
-            path={campaignSent.route}
-            render={props => <ViewCampaign {...props} sentView />}
-          />
+          <Route path={campaignSent.route} component={ViewCampaign} />
           <Route path={campaignsPage.route} component={ListCampaigns} />
         </Switch>
       </ScrollableContainer>

--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -51,7 +51,7 @@ const ViewCampaign = ({
   useEffect(() => {
     const params = sentView ? { campaignId, past: true } : { campaignId };
     actions.fetchCampaign(params);
-  }, [campaignId, sentView]);
+  }, [campaignId, page]);
 
   useEffect(() => {
     actions.fetchCampaigns();

--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -140,7 +140,7 @@ ViewCampaign.propTypes = {
   campaignId: PropTypes.string.isRequired,
   showComposer: PropTypes.bool.isRequired,
   editMode: PropTypes.bool.isRequired,
-  page: PropTypes.oneOf(['scheduled', 'sent', 'null']).isRequired,
+  page: PropTypes.oneOf(['scheduled', 'sent', null]).isRequired,
   hasCampaignsFlip: PropTypes.bool.isRequired,
   actions: PropTypes.shape({
     onCreatePostClick: PropTypes.func.isRequired,

--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -39,12 +39,14 @@ const ViewCampaign = ({
   editMode,
   actions,
   postActions,
-  sentView,
+  page,
 }) => {
+  const sentView = page === 'sent';
   if (!hasCampaignsFlip) {
     window.location = getURL.getPublishUrl();
     return null;
   }
+
   // Fetch Data
   useEffect(() => {
     const params = sentView ? { campaignId, past: true } : { campaignId };
@@ -56,7 +58,6 @@ const ViewCampaign = ({
   }, []);
 
   // Conditions
-  const selectedtTabId = sentView ? 'sent' : 'scheduled';
   const campaignHasPosts =
     (!sentView && campaign?.scheduled > 0) || (sentView && campaign?.sent > 0);
 
@@ -85,7 +86,7 @@ const ViewCampaign = ({
       {/* Navigation */}
       <nav role="navigation">
         <Tabs
-          selectedTabId={selectedtTabId}
+          selectedTabId={page}
           onTabClick={tabId => actions.onTabClick({ tabId, campaignId })}
         >
           <Tab tabId="scheduled">{translations.scheduled}</Tab>
@@ -139,7 +140,7 @@ ViewCampaign.propTypes = {
   campaignId: PropTypes.string.isRequired,
   showComposer: PropTypes.bool.isRequired,
   editMode: PropTypes.bool.isRequired,
-  sentView: PropTypes.bool,
+  page: PropTypes.oneOf(['scheduled', 'sent', 'null']).isRequired,
   hasCampaignsFlip: PropTypes.bool.isRequired,
   actions: PropTypes.shape({
     onCreatePostClick: PropTypes.func.isRequired,
@@ -162,10 +163,6 @@ ViewCampaign.propTypes = {
     onImageClickPrev: PropTypes.func.isRequired,
     onImageClickNext: PropTypes.func.isRequired,
   }).isRequired,
-};
-
-ViewCampaign.defaultProps = {
-  sentView: false,
 };
 
 export default ViewCampaign;

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -29,13 +29,12 @@ export default connect(
       hideAnalyzeReport: state.appSidebar.user.isUsingPublishAsTeamMember,
       isLoading: state.campaign.isLoading,
       campaignId: ownProps.match?.params?.id || state.campaign?.campaignId,
-      sentView: ownProps.sentView,
+      page: state.campaign.page,
       hasCampaignsFlip: state.appSidebar.user.features
         ? state.appSidebar.user.features.includes('campaigns')
         : false,
     };
   },
-
   dispatch => ({
     actions: {
       onComposerCreateSuccess: () => {

--- a/packages/campaign/reducer.js
+++ b/packages/campaign/reducer.js
@@ -1,9 +1,15 @@
 import keyWrapper from '@bufferapp/keywrapper';
+import { LOCATION_CHANGE } from 'connected-react-router';
 import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import {
   sortCampaignsByUpdatedAt,
   actionTypes as queueActionTypes,
 } from '@bufferapp/publish-queue/reducer';
+import {
+  getParams,
+  campaignScheduled,
+  campaignSent,
+} from '@bufferapp/publish-routes';
 
 export const actionTypes = keyWrapper('CAMPAIGN_VIEW', {
   FETCH_CAMPAIGN: 0,
@@ -28,6 +34,7 @@ export const initialState = {
   editingPostId: null,
   selectedProfileId: null,
   campaigns: [],
+  page: null,
 };
 
 const postReducer = ({ campaignPosts, action, newState }) => {
@@ -48,6 +55,24 @@ const postReducer = ({ campaignPosts, action, newState }) => {
 
 export default (state = initialState, action) => {
   switch (action.type) {
+    case LOCATION_CHANGE: {
+      const { pathname } = action.payload.location;
+      const scheduledParams = getParams({
+        pathname,
+        route: campaignScheduled.route,
+      });
+      const sentParams = getParams({ pathname, route: campaignSent.route });
+      const currentSingleCampaignPage = () => {
+        if (scheduledParams) return 'scheduled';
+        if (sentParams) return 'sent';
+        return null;
+      };
+      return {
+        ...state,
+        campaignId: scheduledParams?.id || sentParams?.id,
+        page: currentSingleCampaignPage(),
+      };
+    }
     case `getCampaign_${dataFetchActionTypes.FETCH_START}`: {
       const { id } = state.campaign;
       // Not showing a loader when the campaign stored in the state is the same.
@@ -97,10 +122,12 @@ export default (state = initialState, action) => {
       };
     // Pusher events
     case queueActionTypes.POST_UPDATED: {
+      const inScheduledPage = state.page === 'scheduled';
       const postCampaignId = action?.post?.campaignDetails?.id;
       if (
         postCampaignId === state.campaign?.id &&
-        typeof postCampaignId === 'string'
+        typeof postCampaignId === 'string' &&
+        inScheduledPage
       ) {
         const newCampaignPosts = state.campaignPosts.map(post => {
           if (post.id === action.post.id) {
@@ -122,10 +149,12 @@ export default (state = initialState, action) => {
       return state;
     }
     case queueActionTypes.POST_CREATED: {
+      const inScheduledPage = state.page === 'scheduled';
       const postCampaignId = action?.post?.campaignDetails?.id;
       if (
         postCampaignId === state.campaign?.id &&
-        typeof postCampaignId === 'string'
+        typeof postCampaignId === 'string' &&
+        inScheduledPage
       ) {
         const campaignPost = {
           _id: action.post.id,
@@ -146,10 +175,12 @@ export default (state = initialState, action) => {
       return state;
     }
     case queueActionTypes.POST_DELETED: {
+      const inScheduledPage = state.page === 'scheduled';
       const postCampaignId = action?.post?.campaignDetails?.id;
       if (
         postCampaignId === state.campaign?.id &&
-        typeof postCampaignId === 'string'
+        typeof postCampaignId === 'string' &&
+        inScheduledPage
       ) {
         const newCampaignPosts = state.campaignPosts.filter(
           post => post.id !== action.post.id
@@ -166,14 +197,28 @@ export default (state = initialState, action) => {
       return state;
     }
     case queueActionTypes.POST_SENT: {
+      const inScheduledPage = state.page === 'scheduled';
+      const inSentPage = state.page === 'sent';
       const postCampaignId = action?.post?.campaignDetails?.id;
       if (
         postCampaignId === state.campaign?.id &&
-        typeof postCampaignId === 'string'
+        typeof postCampaignId === 'string' &&
+        (inScheduledPage || inSentPage)
       ) {
-        const newCampaignPosts = state.campaignPosts.filter(
+        const campaignPostsFiltered = state.campaignPosts.filter(
           post => post.id !== action.post.id
         );
+        const campaignPost = {
+          _id: action.post.id,
+          id: action.post.id,
+          dueAt: action.post.due_at,
+          type: action.post.type,
+          content: action.post,
+        };
+        const newCampaignPosts = () => {
+          if (inScheduledPage) return campaignPostsFiltered;
+          if (inSentPage) return [...state.campaignPosts, campaignPost];
+        };
         return {
           ...state,
           campaign: {
@@ -181,7 +226,7 @@ export default (state = initialState, action) => {
             scheduled: state.campaign.scheduled - 1,
             sent: state.campaign.sent + 1,
           },
-          campaignPosts: newCampaignPosts,
+          campaignPosts: newCampaignPosts(),
         };
       }
       return state;

--- a/packages/campaign/reducer.test.js
+++ b/packages/campaign/reducer.test.js
@@ -1,4 +1,5 @@
 import deepFreeze from 'deep-freeze';
+import { LOCATION_CHANGE } from 'connected-react-router';
 import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import { actionTypes as queueActionTypes } from '@bufferapp/publish-queue/reducer';
 import reducer, { actions, initialState, actionTypes } from './reducer';
@@ -15,6 +16,52 @@ describe('reducer', () => {
 
     // When state is undefined, it's supposed to return initial state
     expect(reducer(undefined, action)).toEqual(initialState);
+  });
+
+  it('handles LOCATION_CHANGE action when navigates to scheduled campaigns page', () => {
+    const stateBefore = {
+      ...initialState,
+      page: null,
+    };
+    const stateAfter = {
+      ...initialState,
+      page: 'scheduled',
+      campaignId: 'id1',
+    };
+    const action = {
+      type: LOCATION_CHANGE,
+      payload: {
+        location: {
+          pathname: '/campaigns/id1/scheduled',
+        },
+      },
+    };
+    deepFreeze(stateBefore);
+    deepFreeze(action);
+    expect(reducer(stateBefore, action)).toEqual(stateAfter);
+  });
+
+  it('handles LOCATION_CHANGE action when navigates to sent campaigns page', () => {
+    const stateBefore = {
+      ...initialState,
+      page: null,
+    };
+    const stateAfter = {
+      ...initialState,
+      page: 'sent',
+      campaignId: 'id1',
+    };
+    const action = {
+      type: LOCATION_CHANGE,
+      payload: {
+        location: {
+          pathname: '/campaigns/id1/sent',
+        },
+      },
+    };
+    deepFreeze(stateBefore);
+    deepFreeze(action);
+    expect(reducer(stateBefore, action)).toEqual(stateAfter);
   });
 
   it('handles getCampaign_FETCH_START action', () => {
@@ -302,6 +349,7 @@ describe('reducer', () => {
       campaignPosts: [
         { id: 'id1', content: { campaignDetails: { id: 'campaignId' } } },
       ],
+      page: 'scheduled',
     };
     const stateAfter = {
       ...initialState,
@@ -316,6 +364,7 @@ describe('reducer', () => {
           content: { id: 'id2', campaignDetails: { id: 'campaignId' } },
         },
       ],
+      page: 'scheduled',
     };
     const action = {
       type: queueActionTypes.POST_CREATED,
@@ -333,6 +382,7 @@ describe('reducer', () => {
       campaignPosts: [
         { id: 'id1', content: { campaignDetails: { id: 'campaignId' } } },
       ],
+      page: 'scheduled',
     };
     const stateAfter = {
       ...initialState,
@@ -340,6 +390,7 @@ describe('reducer', () => {
       campaignPosts: [
         { id: 'id1', content: { campaignDetails: { id: 'campaignId' } } },
       ],
+      page: 'scheduled',
     };
     const action = {
       type: queueActionTypes.POST_CREATED,
@@ -350,7 +401,7 @@ describe('reducer', () => {
     expect(reducer(stateBefore, action)).toEqual(stateAfter);
   });
 
-  it('handles POST_UPDATED action', () => {
+  it('handles POST_UPDATED action if on scheduled tab', () => {
     const stateBefore = {
       ...initialState,
       campaign: { id: 'campaignId' },
@@ -360,6 +411,7 @@ describe('reducer', () => {
           content: { text: 'Old Post', campaignDetails: { id: 'campaignId' } },
         },
       ],
+      page: 'scheduled',
     };
     const stateAfter = {
       ...initialState,
@@ -374,6 +426,7 @@ describe('reducer', () => {
           },
         },
       ],
+      page: 'scheduled',
     };
     const action = {
       type: queueActionTypes.POST_UPDATED,
@@ -384,7 +437,7 @@ describe('reducer', () => {
     expect(reducer(stateBefore, action)).toEqual(stateAfter);
   });
 
-  it('handles POST_DELETED action', () => {
+  it('handles POST_DELETED action if on scheduled tab', () => {
     const stateBefore = {
       ...initialState,
       campaign: { id: 'campaignId', scheduled: 1, sent: 0 },
@@ -392,11 +445,13 @@ describe('reducer', () => {
         { id: 'id1', campaignDetails: { id: 'campaignId' } },
         { id: 'id2', campaignDetails: { id: 'campaignId' } },
       ],
+      page: 'scheduled',
     };
     const stateAfter = {
       ...initialState,
       campaign: { id: 'campaignId', scheduled: 0, sent: 0 },
       campaignPosts: [{ id: 'id1', campaignDetails: { id: 'campaignId' } }],
+      page: 'scheduled',
     };
     const action = {
       type: queueActionTypes.POST_DELETED,
@@ -407,7 +462,7 @@ describe('reducer', () => {
     expect(reducer(stateBefore, action)).toEqual(stateAfter);
   });
 
-  it('handles POST_SENT action', () => {
+  it('handles POST_SENT action if on scheduled tab', () => {
     const stateBefore = {
       ...initialState,
       campaign: { id: 'campaignId', scheduled: 1, sent: 0 },
@@ -415,11 +470,44 @@ describe('reducer', () => {
         { id: 'id1', campaignDetails: { id: 'campaignId' } },
         { id: 'id2', campaignDetails: { id: 'campaignId' } },
       ],
+      page: 'scheduled',
     };
     const stateAfter = {
       ...initialState,
       campaign: { id: 'campaignId', scheduled: 0, sent: 1 },
       campaignPosts: [{ id: 'id1', campaignDetails: { id: 'campaignId' } }],
+      page: 'scheduled',
+    };
+    const action = {
+      type: queueActionTypes.POST_SENT,
+      post: { id: 'id2', campaignDetails: { id: 'campaignId' } },
+    };
+    deepFreeze(stateBefore);
+    deepFreeze(action);
+    expect(reducer(stateBefore, action)).toEqual(stateAfter);
+  });
+
+  it('handles POST_SENT action if on sent tab', () => {
+    const stateBefore = {
+      ...initialState,
+      campaign: { id: 'campaignId', scheduled: 1, sent: 0 },
+      campaignPosts: [{ id: 'id1', campaignDetails: { id: 'campaignId' } }],
+      page: 'sent',
+    };
+    const stateAfter = {
+      ...initialState,
+      campaign: { id: 'campaignId', scheduled: 0, sent: 1 },
+      campaignPosts: [
+        { id: 'id1', campaignDetails: { id: 'campaignId' } },
+        {
+          id: 'id2',
+          _id: 'id2',
+          dueAt: undefined,
+          type: undefined,
+          content: { id: 'id2', campaignDetails: { id: 'campaignId' } },
+        },
+      ],
+      page: 'sent',
     };
     const action = {
       type: queueActionTypes.POST_SENT,

--- a/packages/routes/index.js
+++ b/packages/routes/index.js
@@ -1,4 +1,5 @@
 import { push } from 'connected-react-router';
+import { matchPath } from 'react-router-dom';
 
 const profileRouteRegex = /profile\/(\w+)\/tab\/(\w+)(?:\/(\w+))?/;
 export const getProfilePageParams = ({ path }) => {
@@ -55,6 +56,13 @@ export const getPreferencePageParams = ({ path }) => {
   return {
     preferenceId: match[1],
   };
+};
+
+export const getParams = ({ pathname, route }) => {
+  const matchProfile = matchPath(pathname, {
+    path: route,
+  });
+  return (matchProfile && matchProfile.params) || null;
 };
 
 export const campaignsPage = {

--- a/packages/routes/index.test.js
+++ b/packages/routes/index.test.js
@@ -7,8 +7,7 @@ import {
   childTabRoute,
   generatePreferencePageRoute,
   getPreferencePageParams,
-  getCampaignPageParams,
-  getCampaignUrlMatch,
+  getParams,
 } from './index';
 
 describe('publish-routes', () => {
@@ -95,6 +94,18 @@ describe('publish-routes', () => {
       expect(getPreferencePageParams({ path })).toEqual({
         preferenceId,
       });
+    });
+  });
+  describe('getParams from matching route', () => {
+    it('returns id params from path', () => {
+      const pathname = '/campaigns/id1/scheduled';
+      const route = '/campaigns/:id/scheduled/';
+      expect(getParams({ pathname, route })).toEqual({ id: 'id1' });
+    });
+    it('returns null if path does not match route', () => {
+      const pathname = '/campaigns/scheduled';
+      const route = '/campaigns/:id/scheduled/';
+      expect(getParams({ pathname, route })).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Get single campaign page through the router change.
- Update campaign state after post pusher events only when user is in single campaign pages.
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2570
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
