### PR TITLE
[PUB-2642] Keep campaigns button selected in all campaigns pages

### DIFF
--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -49,8 +49,10 @@ const ViewCampaign = ({
 
   // Fetch Data
   useEffect(() => {
-    const params = sentView ? { campaignId, past: true } : { campaignId };
-    actions.fetchCampaign(params);
+    if (page) {
+      const params = sentView ? { campaignId, past: true } : { campaignId };
+      actions.fetchCampaign(params);
+    }
   }, [campaignId, page]);
 
   useEffect(() => {

--- a/packages/delete-campaign-modal/middleware.js
+++ b/packages/delete-campaign-modal/middleware.js
@@ -2,7 +2,7 @@ import {
   actions as dataFetchActions,
   actionTypes as dataFetchActionTypes,
 } from '@bufferapp/async-data-fetch';
-import { isCampaignsRoute, campaignsPage } from '@bufferapp/publish-routes';
+import { getMatch, campaignsPage } from '@bufferapp/publish-routes';
 import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
 import { actions as notificationActions } from '@bufferapp/notifications';
 import { actions as modalActions } from '@bufferapp/publish-modals/reducer';
@@ -41,7 +41,12 @@ export default ({ dispatch, getState }) => next => action => {
         organizationId,
       };
       dispatch(analyticsActions.trackEvent('Campaign Deleted', metadata));
-      if (!isCampaignsRoute({ path: state.router.location.pathname })) {
+      const inCampaignsPage =
+        getMatch({
+          pathname: state.router?.location?.pathname,
+          route: campaignsPage.route,
+        })?.isExact === true;
+      if (!inCampaignsPage) {
         dispatch(campaignsPage.goTo());
       }
       break;

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader/root';
 import { actions as modalActions } from '@bufferapp/publish-modals';
 import { actions as tabsActions } from '@bufferapp/publish-tabs';
-import { isCampaignsRoute, campaignsPage } from '@bufferapp/publish-routes';
+import { getMatch, campaignsPage } from '@bufferapp/publish-routes';
 import ProfileSidebar from './components/ProfileSidebar';
 import { shouldGoToProfile } from './utils';
 import { actions } from './reducer';
@@ -28,8 +28,9 @@ export default hot(
         hasCampaignsFlip: state.appSidebar.user.features
           ? state.appSidebar.user.features.includes('campaigns')
           : false,
-        isCampaignsSelected: isCampaignsRoute({
-          path: state.router?.location?.pathname,
+        isCampaignsSelected: !!getMatch({
+          pathname: state.router?.location?.pathname,
+          route: campaignsPage.route,
         }),
       };
     },

--- a/packages/routes/index.js
+++ b/packages/routes/index.js
@@ -58,11 +58,14 @@ export const getPreferencePageParams = ({ path }) => {
   };
 };
 
-export const getParams = ({ pathname, route }) => {
-  const matchProfile = matchPath(pathname, {
+export const getMatch = ({ pathname, route }) =>
+  matchPath(pathname, {
     path: route,
   });
-  return (matchProfile && matchProfile.params) || null;
+
+export const getParams = ({ pathname, route }) => {
+  const match = getMatch({ pathname, route });
+  return match?.params || null;
 };
 
 export const campaignsPage = {
@@ -90,4 +93,3 @@ export const campaignSent = {
   route: '/campaigns/:id/sent/',
   goTo: ({ campaignId }) => push(`/campaigns/${campaignId}/sent`),
 };
-export const isCampaignsRoute = ({ path }) => path === campaignsPage.route;

--- a/packages/routes/index.test.js
+++ b/packages/routes/index.test.js
@@ -8,6 +8,7 @@ import {
   generatePreferencePageRoute,
   getPreferencePageParams,
   getParams,
+  getMatch,
 } from './index';
 
 describe('publish-routes', () => {
@@ -96,6 +97,28 @@ describe('publish-routes', () => {
       });
     });
   });
+
+  describe('getMatch from matching route', () => {
+    it('returns details from path', () => {
+      const pathname = '/campaigns/id1/scheduled';
+      const route = '/campaigns/:id/scheduled/';
+      const pathDetails = {
+        isExact: true,
+        params: {
+          id: 'id1',
+        },
+        path: route,
+        url: pathname,
+      };
+      expect(getMatch({ pathname, route })).toEqual(pathDetails);
+    });
+    it('returns null if path does not match route', () => {
+      const pathname = '/campaigns/scheduled';
+      const route = '/campaigns/:id/scheduled/';
+      expect(getMatch({ pathname, route })).toEqual(null);
+    });
+  });
+
   describe('getParams from matching route', () => {
     it('returns id params from path', () => {
       const pathname = '/campaigns/id1/scheduled';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Keep campaigns button selected in all campaigns pages
Using matchPath from react-router instead of a method just for campaigns
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2642
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
