### PR TITLE
[PUB-2656] Fix campaign tracking for edit and create campaign

### DIFF
--- a/packages/campaign-form/middleware.js
+++ b/packages/campaign-form/middleware.js
@@ -47,8 +47,7 @@ export default ({ dispatch }) => next => action => {
         campaignId: id,
         campaignName: name,
         campaignColor: color,
-        cta: SEGMENT_NAMES.STORIES_PREVIEW_QUEUE_ADD_NOTE,
-        globalOrganizationId,
+        organizationId: globalOrganizationId,
       };
       dispatch(analyticsActions.trackEvent('Campaign Created', metadata));
       dispatch(
@@ -65,12 +64,12 @@ export default ({ dispatch }) => next => action => {
     }
 
     case `updateCampaign_${dataFetchActionTypes.FETCH_SUCCESS}`: {
-      const { id, name, color, organizationId } = action.result || {};
+      const { id, name, color, globalOrganizationId } = action.result || {};
       const metadata = {
         campaignId: id,
         campaignName: name,
         campaignColor: color,
-        organizationId,
+        organizationId: globalOrganizationId,
       };
       dispatch(analyticsActions.trackEvent('Campaign Edited', metadata));
 

--- a/packages/campaign-form/middleware.test.js
+++ b/packages/campaign-form/middleware.test.js
@@ -1,0 +1,62 @@
+import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
+import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
+import middleware from './middleware';
+import { initialState } from './reducer';
+
+jest.mock('@bufferapp/publish-analytics-middleware');
+
+describe('middleware', () => {
+  const next = jest.fn();
+
+  it('exports middleware', () => {
+    expect(middleware).toBeDefined();
+  });
+
+  describe('tracking', () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => initialState,
+    };
+
+    const expectedObj = {
+      campaignId: 'id1',
+      campaignName: 'Awareness Day',
+      organizationId: '123',
+      campaignColor: 'blue',
+    };
+
+    const result = {
+      id: 'id1',
+      name: 'Awareness Day',
+      globalOrganizationId: '123',
+      color: 'blue',
+    };
+
+    it('tracks edit campaign event', () => {
+      const action = {
+        type: `updateCampaign_${dataFetchActionTypes.FETCH_SUCCESS}`,
+        result,
+      };
+
+      middleware(store)(next)(action);
+      expect(next).toBeCalledWith(action);
+      expect(analyticsActions.trackEvent).toBeCalledWith(
+        'Campaign Edited',
+        expectedObj
+      );
+    });
+    it('tracks create campaign event', () => {
+      const action = {
+        type: `createCampaign_${dataFetchActionTypes.FETCH_SUCCESS}`,
+        result,
+      };
+
+      middleware(store)(next)(action);
+      expect(next).toBeCalledWith(action);
+      expect(analyticsActions.trackEvent).toBeCalledWith(
+        'Campaign Created',
+        expectedObj
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Fix campaign tracking events for edit and create campaign. The organizationId wasn't getting passed correctly. Added some additional tests.  
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2656
To test segment events, 
- Log into segment
- Go to sources
- Click on Publish - Dev or Publish - Production (depending where you're testing)
- Click Debugger and check out event
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
