### PR TITLE
[PUB-2570] Add posts skeleton

### DIFF
--- a/packages/campaign/components/ViewCampaign/ExamplePost/index.jsx
+++ b/packages/campaign/components/ViewCampaign/ExamplePost/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import {
   Circle,
   CircleWrapper,
@@ -14,31 +14,39 @@ import {
   Square,
 } from './style';
 
-const ExamplePost = () => {
+const ExamplePost = ({ displaySkeleton }) => {
   return (
     <Container>
       <Header>
         <CircleWrapper>
-          <Circle />
+          <Circle displaySkeleton={displaySkeleton} />
           <SmallCircle />
         </CircleWrapper>
         <LineWrapper>
-          <Line width="87px" />
+          <Line displaySkeleton={displaySkeleton} width="87px" />
         </LineWrapper>
       </Header>
       <Content>
         <LinesWrapper>
-          <Line />
-          <Line width="400px" />
+          <Line displaySkeleton={displaySkeleton} />
+          <Line displaySkeleton={displaySkeleton} width="400px" />
         </LinesWrapper>
-        <Square />
+        <Square displaySkeleton={displaySkeleton} />
       </Content>
       <Footer>
-        <Line width="408px" />
-        <Line height="30px" width="100px" />
+        <Line displaySkeleton={displaySkeleton} width="408px" />
+        <Line displaySkeleton={displaySkeleton} height="30px" width="100px" />
       </Footer>
     </Container>
   );
+};
+
+ExamplePost.propTypes = {
+  displaySkeleton: PropTypes.bool,
+};
+
+ExamplePost.defaultProps = {
+  displaySkeleton: false,
 };
 
 export default ExamplePost;

--- a/packages/campaign/components/ViewCampaign/ExamplePost/story.jsx
+++ b/packages/campaign/components/ViewCampaign/ExamplePost/story.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withA11y } from '@storybook/addon-a11y';
+
+import ExamplePost from './index';
+
+storiesOf('Campaigns|ViewCampaign/ExamplePost', module)
+  .addDecorator(withA11y)
+  .add('default', () => <ExamplePost />)
+  .add('loading skeleton', () => <ExamplePost displaySkeleton />);

--- a/packages/campaign/components/ViewCampaign/ExamplePost/style.js
+++ b/packages/campaign/components/ViewCampaign/ExamplePost/style.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { gray, grayLighter } from '@bufferapp/ui/style/colors';
+import { skeletonStyles } from '@bufferapp/publish-shared-components';
 
 export const Container = styled.div`
   display: flex;
@@ -15,6 +16,7 @@ export const Circle = styled.div`
   border-radius: 50%;
   background-color: ${grayLighter};
   margin-right: 8px;
+  ${props => props.displaySkeleton && skeletonStyles}
 `;
 
 export const SmallCircle = styled.div`
@@ -28,6 +30,7 @@ export const SmallCircle = styled.div`
   justify-content: center;
   align-items: center;
   background-color: ${grayLighter};
+  ${props => props.displaySkeleton && skeletonStyles}
 `;
 
 export const CircleWrapper = styled.div`
@@ -40,6 +43,7 @@ export const Square = styled.div`
   background-color: ${grayLighter};
   margin-left: 10px;
   border-radius: 4px;
+  ${props => props.displaySkeleton && skeletonStyles}
 `;
 
 export const Header = styled.div`
@@ -55,6 +59,7 @@ export const Line = styled.div`
   width: ${props => (props.width ? props.width : '100%')};
   height: ${props => (props.height ? props.height : '10px')};
   background-color: ${grayLighter};
+  ${props => props.displaySkeleton && skeletonStyles}
 `;
 
 export const Content = styled.div`

--- a/packages/campaign/components/ViewCampaign/SkeletonPosts/index.jsx
+++ b/packages/campaign/components/ViewCampaign/SkeletonPosts/index.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled, { css, keyframes } from 'styled-components';
+import ExamplePost from '../ExamplePost';
+
+const pulse = keyframes`
+  0% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+`;
+
+const animation = () =>
+  css`
+    ${pulse} 2s ease infinite forwards;
+  `;
+
+const Container = styled.div`
+  > * {
+    animation: ${animation};
+    opacity: 0;
+  }
+
+  > :nth-child(2) {
+    animation-delay: 0.5s;
+  }
+`;
+
+const SkeletonPosts = () => {
+  return (
+    <Container>
+      <ExamplePost displaySkeleton />
+      <ExamplePost displaySkeleton />
+    </Container>
+  );
+};
+
+export default SkeletonPosts;

--- a/packages/campaign/components/ViewCampaign/SkeletonPosts/story.jsx
+++ b/packages/campaign/components/ViewCampaign/SkeletonPosts/story.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withA11y } from '@storybook/addon-a11y';
+
+import SkeletonPosts from './index';
+
+storiesOf('Campaigns|ViewCampaign/SkeletonPosts', module)
+  .addDecorator(withA11y)
+  .add('default', () => <SkeletonPosts />);

--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -6,6 +6,7 @@ import ComposerPopover from '@bufferapp/publish-composer-popover';
 import TabTag from '@bufferapp/publish-tabs/components/TabTag';
 import { getURL } from '@bufferapp/publish-server/formatters/src';
 import Header from './Header';
+import SkeletonPosts from './SkeletonPosts';
 import EmptyStateCampaign from './EmptyState';
 
 /* Styles */
@@ -78,14 +79,17 @@ const ViewCampaign = ({
         </Tabs>
       </nav>
       {/* Content */}
-      <EmptyStateCampaign
-        hideAnalyzeReport={hideAnalyzeReport}
-        translations={translations}
-        campaign={campaign}
-        actions={actions}
-        sentView={sentView}
-      />
-      {campaignHasPosts && (
+      {isLoading && <SkeletonPosts />}
+      {!isLoading && (
+        <EmptyStateCampaign
+          hideAnalyzeReport={hideAnalyzeReport}
+          translations={translations}
+          campaign={campaign}
+          actions={actions}
+          sentView={sentView}
+        />
+      )}
+      {!isLoading && campaignHasPosts && (
         <QueueItems
           items={campaignPosts}
           onDeleteConfirmClick={postActions.onDeleteConfirmClick}

--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -20,7 +20,7 @@ const ViewCampaign = ({
   campaign,
   campaignPosts,
   isLoading,
-  notLoadingHeader,
+  hideSkeletonHeader,
   hideAnalyzeReport,
   translations,
   campaignId,
@@ -64,7 +64,7 @@ const ViewCampaign = ({
         onDeleteCampaignClick={actions.onDeleteCampaignClick}
         onEditCampaignClick={actions.onEditCampaignClick}
         goToAnalyzeReport={actions.goToAnalyzeReport}
-        isLoading={isLoading && !notLoadingHeader}
+        isLoading={isLoading && !hideSkeletonHeader}
       />
       {/* Navigation */}
       <nav role="navigation">
@@ -124,7 +124,7 @@ ViewCampaign.propTypes = {
   campaignPosts: PropTypes.array, // eslint-disable-line
   hideAnalyzeReport: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  notLoadingHeader: PropTypes.bool.isRequired,
+  hideSkeletonHeader: PropTypes.bool.isRequired,
   campaignId: PropTypes.string.isRequired,
   showComposer: PropTypes.bool.isRequired,
   editMode: PropTypes.bool.isRequired,

--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -20,6 +20,7 @@ const ViewCampaign = ({
   campaign,
   campaignPosts,
   isLoading,
+  notLoadingHeader,
   hideAnalyzeReport,
   translations,
   campaignId,
@@ -63,7 +64,7 @@ const ViewCampaign = ({
         onDeleteCampaignClick={actions.onDeleteCampaignClick}
         onEditCampaignClick={actions.onEditCampaignClick}
         goToAnalyzeReport={actions.goToAnalyzeReport}
-        isLoading={isLoading}
+        isLoading={isLoading && !notLoadingHeader}
       />
       {/* Navigation */}
       <nav role="navigation">
@@ -123,6 +124,7 @@ ViewCampaign.propTypes = {
   campaignPosts: PropTypes.array, // eslint-disable-line
   hideAnalyzeReport: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
+  notLoadingHeader: PropTypes.bool.isRequired,
   campaignId: PropTypes.string.isRequired,
   showComposer: PropTypes.bool.isRequired,
   editMode: PropTypes.bool.isRequired,

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -29,7 +29,7 @@ export default connect(
       translations: state.i18n.translations.campaigns.viewCampaign,
       hideAnalyzeReport: state.appSidebar.user.isUsingPublishAsTeamMember,
       isLoading: state.campaign.isLoading,
-      notLoadingHeader: state.campaign.notLoadingHeader,
+      hideSkeletonHeader: state.campaign.hideSkeletonHeader,
       campaignId: ownProps.match?.params?.id || state.campaign?.campaignId,
       page: state.campaign.page,
       hasCampaignsFlip: state.appSidebar.user.features

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -29,6 +29,7 @@ export default connect(
       translations: state.i18n.translations.campaigns.viewCampaign,
       hideAnalyzeReport: state.appSidebar.user.isUsingPublishAsTeamMember,
       isLoading: state.campaign.isLoading,
+      notLoadingHeader: state.campaign.notLoadingHeader,
       campaignId: ownProps.match?.params?.id || state.campaign?.campaignId,
       page: state.campaign.page,
       hasCampaignsFlip: state.appSidebar.user.features

--- a/packages/campaign/reducer.js
+++ b/packages/campaign/reducer.js
@@ -28,7 +28,7 @@ export const initialState = {
   campaign: {},
   campaignPosts: [],
   isLoading: true,
-  notLoadingHeader: false,
+  hideSkeletonHeader: false,
   campaignId: null,
   showComposer: false,
   editMode: false,
@@ -77,14 +77,14 @@ export default (state = initialState, action) => {
         campaignId,
         page: currentSingleCampaignPage(),
         isLoading: true,
-        notLoadingHeader: !isFirstTimeLoading,
+        hideSkeletonHeader: !isFirstTimeLoading,
       };
     }
     case `getCampaign_${dataFetchActionTypes.FETCH_FAIL}`: {
       return {
         ...state,
         isLoading: false,
-        notLoadingHeader: false,
+        hideSkeletonHeader: false,
       };
     }
     case `getCampaign_${dataFetchActionTypes.FETCH_SUCCESS}`: {
@@ -96,7 +96,7 @@ export default (state = initialState, action) => {
         campaignId: campaign.id,
         campaignPosts: (fullItems && items) || [],
         isLoading: false,
-        notLoadingHeader: false,
+        hideSkeletonHeader: false,
       };
     }
     case actionTypes.OPEN_COMPOSER: {

--- a/packages/campaign/reducer.js
+++ b/packages/campaign/reducer.js
@@ -28,6 +28,7 @@ export const initialState = {
   campaign: {},
   campaignPosts: [],
   isLoading: true,
+  notLoadingHeader: false,
   campaignId: null,
   showComposer: false,
   editMode: false,
@@ -67,25 +68,23 @@ export default (state = initialState, action) => {
         if (sentParams) return 'sent';
         return null;
       };
-      return {
-        ...state,
-        campaignId: scheduledParams?.id || sentParams?.id,
-        page: currentSingleCampaignPage(),
-      };
-    }
-    case `getCampaign_${dataFetchActionTypes.FETCH_START}`: {
+      const campaignId = scheduledParams?.id || sentParams?.id;
       const { id } = state.campaign;
-      // Not showing a loader when the campaign stored in the state is the same.
-      const isFirstTimeLoading = id !== action.args?.campaignId;
+      // Not showing a header loader when the campaign stored in the state is the same.
+      const isFirstTimeLoading = id !== campaignId;
       return {
         ...state,
-        isLoading: isFirstTimeLoading,
+        campaignId,
+        page: currentSingleCampaignPage(),
+        isLoading: true,
+        notLoadingHeader: !isFirstTimeLoading,
       };
     }
     case `getCampaign_${dataFetchActionTypes.FETCH_FAIL}`: {
       return {
         ...state,
         isLoading: false,
+        notLoadingHeader: false,
       };
     }
     case `getCampaign_${dataFetchActionTypes.FETCH_SUCCESS}`: {
@@ -97,6 +96,7 @@ export default (state = initialState, action) => {
         campaignId: campaign.id,
         campaignPosts: (fullItems && items) || [],
         isLoading: false,
+        notLoadingHeader: false,
       };
     }
     case actionTypes.OPEN_COMPOSER: {

--- a/packages/campaign/reducer.test.js
+++ b/packages/campaign/reducer.test.js
@@ -22,11 +22,13 @@ describe('reducer', () => {
     const stateBefore = {
       ...initialState,
       page: null,
+      isLoading: false,
     };
     const stateAfter = {
       ...initialState,
       page: 'scheduled',
       campaignId: 'id1',
+      isLoading: true,
     };
     const action = {
       type: LOCATION_CHANGE,
@@ -45,11 +47,21 @@ describe('reducer', () => {
     const stateBefore = {
       ...initialState,
       page: null,
+      isLoading: false,
+      notLoadingHeader: false,
+      campaign: {
+        id: 'id1',
+      },
     };
     const stateAfter = {
       ...initialState,
       page: 'sent',
       campaignId: 'id1',
+      campaign: {
+        id: 'id1',
+      },
+      isLoading: true,
+      notLoadingHeader: true,
     };
     const action = {
       type: LOCATION_CHANGE,
@@ -57,48 +69,6 @@ describe('reducer', () => {
         location: {
           pathname: '/campaigns/id1/sent',
         },
-      },
-    };
-    deepFreeze(stateBefore);
-    deepFreeze(action);
-    expect(reducer(stateBefore, action)).toEqual(stateAfter);
-  });
-
-  it('handles getCampaign_FETCH_START action', () => {
-    const stateBefore = {
-      ...initialState,
-      isLoading: false,
-    };
-    const stateAfter = {
-      ...initialState,
-      isLoading: true,
-    };
-    const action = {
-      type: 'getCampaign_FETCH_START',
-      args: {
-        campaignId: 'id1',
-      },
-    };
-    deepFreeze(stateBefore);
-    deepFreeze(action);
-    expect(reducer(stateBefore, action)).toEqual(stateAfter);
-  });
-
-  it('handles getCampaign_FETCH_START action when not first time loading', () => {
-    const stateBefore = {
-      ...initialState,
-      isLoading: false,
-      campaign: {
-        id: 'id1',
-      },
-    };
-    const stateAfter = {
-      ...stateBefore,
-    };
-    const action = {
-      type: 'getCampaign_FETCH_START',
-      args: {
-        campaignId: 'id1',
       },
     };
     deepFreeze(stateBefore);

--- a/packages/campaign/reducer.test.js
+++ b/packages/campaign/reducer.test.js
@@ -48,7 +48,7 @@ describe('reducer', () => {
       ...initialState,
       page: null,
       isLoading: false,
-      notLoadingHeader: false,
+      hideSkeletonHeader: false,
       campaign: {
         id: 'id1',
       },
@@ -61,7 +61,7 @@ describe('reducer', () => {
         id: 'id1',
       },
       isLoading: true,
-      notLoadingHeader: true,
+      hideSkeletonHeader: true,
     };
     const action = {
       type: LOCATION_CHANGE,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

- Add posts skeleton
- Not load header skeleton when current campaign is still the one stored in state.

<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2570
In the future we might want to make the example post just the empty state of a `<Post>`, instead of having a separated and made from scratch component, or at least move this to shared-components.
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
**Skeleton Posts:** 
https://share.buffer.com/o0uDrrAX
**How loading looks like in Publish:**
https://share.buffer.com/rRu688D6

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
