### PR TITLE
[PUB-2644] Move posts pusher events

### DIFF
--- a/packages/pusher-sync/middleware.js
+++ b/packages/pusher-sync/middleware.js
@@ -144,17 +144,16 @@ const bindOrganizationEvents = (orgChannel, dispatch) => {
   });
   // Posts and Drafts
   orgChannel.bind('added_update', data => {
-    debugger;
     if (data.update.draft) {
       dispatch({
         type: draftActionTypes.DRAFT_CREATED,
-        profileId: data.update.profileId,
+        profileId: data.profile_id,
         draft: postParser(data.update),
       });
     } else {
       dispatch({
         type: queueActionTypes.POST_CREATED,
-        profileId: data.update.profileId,
+        profileId: data.profile_id,
         post: postParser(data.update),
       });
     }
@@ -163,13 +162,13 @@ const bindOrganizationEvents = (orgChannel, dispatch) => {
     if (data.update.draft) {
       dispatch({
         type: draftActionTypes.DRAFT_DELETED,
-        profileId: data.update.profileId,
+        profileId: data.profile_id,
         draft: postParser(data.update),
       });
     } else {
       dispatch({
         type: queueActionTypes.POST_DELETED,
-        profileId: data.update.profileId,
+        profileId: data.profile_id,
         post: postParser(data.update),
       });
     }
@@ -177,7 +176,7 @@ const bindOrganizationEvents = (orgChannel, dispatch) => {
   orgChannel.bind('collaboration_draft_approved', data => {
     dispatch({
       type: draftActionTypes.DRAFT_APPROVED,
-      profileId: data.update.profileId,
+      profileId: data.profile_id,
       draft: postParser(data.draft),
     });
   });
@@ -185,7 +184,7 @@ const bindOrganizationEvents = (orgChannel, dispatch) => {
     orgChannel.bind(pusherEvent, data => {
       dispatch({
         type: actionType,
-        profileId: data.update.profileId,
+        profileId: data.profile_id,
         post: postParser(data.update),
       });
     });

--- a/packages/pusher-sync/middleware.js
+++ b/packages/pusher-sync/middleware.js
@@ -144,6 +144,7 @@ const bindOrganizationEvents = (orgChannel, dispatch) => {
   });
   // Posts and Drafts
   orgChannel.bind('added_update', data => {
+    debugger;
     if (data.update.draft) {
       dispatch({
         type: draftActionTypes.DRAFT_CREATED,

--- a/packages/pusher-sync/middleware.test.js
+++ b/packages/pusher-sync/middleware.test.js
@@ -1,7 +1,5 @@
 import Pusher from 'pusher-js';
 import { actionTypes as profileSidebarActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
-import { actionTypes as queueActionTypes } from '@bufferapp/publish-queue/reducer';
-import { postParser } from '@bufferapp/publish-server/parsers/src';
 
 import middleware from './middleware';
 
@@ -60,44 +58,31 @@ describe('middleware', () => {
   it('should subscribe to update events', () => {
     middleware(store)(next)(selectProfileAction);
     expect(Pusher.bind.mock.calls[0][0]).toEqual('private-updates-12345');
-    expect(Pusher.bind.mock.calls[0][1]).toEqual('sent_update');
+    expect(Pusher.bind.mock.calls[0][1]).toEqual('collaboration_draft_updated');
     expect(Pusher.bind.mock.calls[1][0]).toEqual('private-updates-12345');
-    expect(Pusher.bind.mock.calls[1][1]).toEqual('updated_update');
+    expect(Pusher.bind.mock.calls[1][1]).toEqual('collaboration_draft_moved');
     expect(Pusher.bind.mock.calls[2][0]).toEqual('private-updates-12345');
-    expect(Pusher.bind.mock.calls[2][1]).toEqual('added_update');
+    expect(Pusher.bind.mock.calls[2][1]).toEqual('reordered_updates');
     expect(Pusher.bind.mock.calls[3][0]).toEqual('private-updates-12345');
-    expect(Pusher.bind.mock.calls[3][1]).toEqual('deleted_update');
-    expect(Pusher.bind.mock.calls[4][0]).toEqual('private-updates-12345');
-    expect(Pusher.bind.mock.calls[4][1]).toEqual(
-      'collaboration_draft_approved'
-    );
-    expect(Pusher.bind.mock.calls[5][0]).toEqual('private-updates-12345');
-    expect(Pusher.bind.mock.calls[5][1]).toEqual('collaboration_draft_updated');
-    expect(Pusher.bind.mock.calls[6][0]).toEqual('private-updates-12345');
-    expect(Pusher.bind.mock.calls[6][1]).toEqual('collaboration_draft_moved');
-    expect(Pusher.bind.mock.calls[7][0]).toEqual('private-updates-12345');
-    expect(Pusher.bind.mock.calls[7][1]).toEqual('reordered_updates');
-    expect(Pusher.bind.mock.calls[8][0]).toEqual('private-updates-12345');
-    expect(Pusher.bind.mock.calls[8][1]).toEqual('queue_paused');
-    expect(Pusher.bind.mock.calls[9][0]).toEqual('private-story-groups-12345');
-    expect(Pusher.bind.mock.calls[9][1]).toEqual('sent_story_group');
-    expect(Pusher.bind.mock.calls[10][0]).toEqual('private-story-groups-12345');
-    expect(Pusher.bind.mock.calls[10][1]).toEqual('story_group_created');
-    expect(Pusher.bind.mock.calls[11][0]).toEqual('private-story-groups-12345');
-    expect(Pusher.bind.mock.calls[11][1]).toEqual('story_group_updated');
-    expect(Pusher.bind.mock.calls[12][0]).toEqual('private-story-groups-12345');
-    expect(Pusher.bind.mock.calls[12][1]).toEqual('story_group_deleted');
-    expect(Pusher.bind).toHaveBeenCalledTimes(13);
+    expect(Pusher.bind.mock.calls[3][1]).toEqual('queue_paused');
+    expect(Pusher.bind.mock.calls[4][0]).toEqual('private-story-groups-12345');
+    expect(Pusher.bind.mock.calls[4][1]).toEqual('sent_story_group');
+    expect(Pusher.bind.mock.calls[5][0]).toEqual('private-story-groups-12345');
+    expect(Pusher.bind.mock.calls[5][1]).toEqual('story_group_created');
+    expect(Pusher.bind.mock.calls[6][0]).toEqual('private-story-groups-12345');
+    expect(Pusher.bind.mock.calls[6][1]).toEqual('story_group_updated');
+    expect(Pusher.bind.mock.calls[7][0]).toEqual('private-story-groups-12345');
+    expect(Pusher.bind.mock.calls[7][1]).toEqual('story_group_deleted');
+    expect(Pusher.bind).toHaveBeenCalledTimes(8);
   });
 
   it('should dispatch when a subscribed pusher event happens', () => {
     middleware(store)(next)(selectProfileAction);
-    const update = { id: '00012345', text: 'Hello, world.' };
-    Pusher.simulate('private-updates-12345', 'added_update', { update });
+    Pusher.simulate('private-updates-12345', 'queue_paused', true);
     expect(store.dispatch).toHaveBeenCalledWith({
-      type: queueActionTypes.POST_CREATED,
+      type: profileSidebarActionTypes.PUSHER_PROFILE_PAUSED_STATE,
       profileId: '12345',
-      post: postParser(update),
+      paused: true,
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Move post pusher events to bindOrganizationEvents.
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2644
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [x] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
