### PR TITLE
Use optional chaining to avoid undefined sent counts

### DIFF
--- a/packages/queue/middleware.js
+++ b/packages/queue/middleware.js
@@ -213,8 +213,8 @@ export default ({ dispatch, getState }) => next => action => {
       const state = getState();
       const { profileId } = action;
       const currentCounts = {
-        pending: state.queue.byProfileId[profileId].total,
-        sent: state.sent.byProfileId[profileId].total,
+        pending: state.queue.byProfileId[profileId]?.total || 0,
+        sent: state.sent.byProfileId[profileId]?.total || 0,
       };
       const changeMap = {
         [actionTypes.POST_CREATED]: { pending: 1, sent: 0 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

When post events come through Pusher we're attempting to update state that might not be defined, which is the `state.sent.byProfileId[...].total`. I added some optional chaining to default to `0` in that case.

## Context & Notes

I'm not actually sure if/where we use the total number of sent posts. 🤔  I know we use the 'pending' count in the sidebar.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`