### PR TITLE
[PUB-2668] Fix view campaign header state

### DIFF
--- a/packages/campaign/components/ViewCampaign/Header/index.jsx
+++ b/packages/campaign/components/ViewCampaign/Header/index.jsx
@@ -103,13 +103,9 @@ const Header = ({
         label={translations.createPost}
         disabled={isLoading}
         displaySkeleton={isLoading}
-        onSelectClick={selectedItem => {
-          if (typeof selectedItem.selectedItemClick !== 'undefined') {
-            // need to pass campaign directly into select methods for state to update correctly
-            selectedItem.selectedItemClick(campaignDetails);
-          }
-          return false;
-        }}
+        onSelectClick={selectedItem =>
+          selectedItem.selectedItemClick(campaignDetails)
+        }
         items={[
           {
             title: translations.createPost,

--- a/packages/campaign/components/ViewCampaign/Header/index.jsx
+++ b/packages/campaign/components/ViewCampaign/Header/index.jsx
@@ -105,7 +105,8 @@ const Header = ({
         displaySkeleton={isLoading}
         onSelectClick={selectedItem => {
           if (typeof selectedItem.selectedItemClick !== 'undefined') {
-            selectedItem.selectedItemClick();
+            // need to pass campaign directly into select methods for state to update correctly
+            selectedItem.selectedItemClick(campaignDetails);
           }
           return false;
         }}
@@ -116,13 +117,11 @@ const Header = ({
           },
           {
             title: translations.editCampaign,
-            selectedItemClick: () => onEditCampaignClick(campaignDetails.id),
+            selectedItemClick: campaign => onEditCampaignClick(campaign.id),
           },
           {
             title: translations.deleteCampaign,
-            selectedItemClick: () => {
-              onDeleteCampaignClick(campaignDetails);
-            },
+            selectedItemClick: campaign => onDeleteCampaignClick(campaign),
           },
         ]}
       />

--- a/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/ListItem/index.jsx
@@ -109,12 +109,7 @@ const ListItem = ({
               ? translations.viewCampaign
               : translations.viewReport
           }
-          onSelectClick={selectedItem => {
-            if (typeof selectedItem.selectedItemClick !== 'undefined') {
-              selectedItem.selectedItemClick();
-            }
-            return false;
-          }}
+          onSelectClick={selectedItem => selectedItem.selectedItemClick()}
           items={
             hideAnalyzeReport
               ? selectItems


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Fix view campaign header state by passing the campaign directly into the button select methods
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2668
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
It looks like the campaign state wasn't updating immediately inside the select items on getCampaign success. This caused the wrong campaign getting passed into the delete campaign modal and the wrong campaign id getting passed into the edit form (which caused the wrong campaign getting fetched in `fetchCampaign` on render.) 

The campaign state is updating immediately with the button `onClick`, so it seems to be specific to the Select component. After opening the delete modal a second time, the state is updated correctly. I took some time looking into the ui Select component, but couldn't find a simple solution. Let me know if you can think of any other solutions!


## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
