### PR TITLE
PUB-2672  | Add is past reminder in post parser

### DIFF
--- a/packages/server/parsers/src/postParser.js
+++ b/packages/server/parsers/src/postParser.js
@@ -197,6 +197,7 @@ module.exports = post => {
     retweetCommentLinks,
     retweetProfile: getRetweetProfileInfo(post),
     isSent: post.status === 'sent',
+    isPastReminder: post.status === 'notified',
     source_url: post.source_url,
     text,
     type: getPostType({ post }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Add is past reminder in post parser

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
When a post in sent tab is a past reminder is displaying the footer as if it were in the queue, by setting the post in the parser when is a reminder we ensure displaying the footer properly.

## Screenshots
This is the way it's being displayed on Sent tab
<img width="880" alt="Image 2020-04-21 at 11 20 29 AM" src="https://user-images.githubusercontent.com/988972/79849005-2c660900-83c2-11ea-82d9-657ea5b3a9f3.png">

This is how it looks like with isPastReminder in post parser
<img width="884" alt="Image 2020-04-21 at 11 21 14 AM" src="https://user-images.githubusercontent.com/988972/79849178-6c2cf080-83c2-11ea-94fb-2e0cd6563079.png">

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
