### PR TITLE
PUB-2677 | Fixing campaigns empty sent post state message issue

### DIFF
--- a/packages/campaign/components/ViewCampaign/EmptyState/index.jsx
+++ b/packages/campaign/components/ViewCampaign/EmptyState/index.jsx
@@ -20,7 +20,8 @@ const EmptyStateCampaign = ({
   const displayEmptyCampaign =
     !sentView && campaign?.scheduled === 0 && campaign?.sent === 0;
   const displayEmptySentPosts = sentView && campaign?.sent === 0;
-  const displayAllPostsSent = campaign?.scheduled === 0 && campaign?.sent > 0;
+  const displayAllPostsSent =
+    !sentView && campaign?.scheduled === 0 && campaign?.sent > 0;
 
   const teamMemberPrimaryAction = {
     label: translations.allPostsSent.createCampaign,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

Fixing campaigns empty sent post state message issue

## Context & Notes

All posts sent message was appearing in the sent tab, as it was missing a check for which tab it was presently in.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
