### PR TITLE
[PUB-2685] Pass campaign into view report method in scheduled empty state

### DIFF
--- a/packages/campaign/components/ViewCampaign/EmptyState/index.jsx
+++ b/packages/campaign/components/ViewCampaign/EmptyState/index.jsx
@@ -29,7 +29,7 @@ const EmptyStateCampaign = ({
   };
   const ownerPrimaryAction = {
     label: translations.allPostsSent.viewReport,
-    onClick: actions.goToAnalyzeReport,
+    onClick: () => actions.goToAnalyzeReport(campaign),
     icon: <ArrowRightIcon />,
     iconEnd: true,
   };

--- a/packages/server/formatters/src/getURL.js
+++ b/packages/server/formatters/src/getURL.js
@@ -98,6 +98,10 @@ module.exports = {
     return 'https://publish.buffer.com';
   },
   getAnalyzeReportUrl: campaignId => {
+    if (!campaignId) {
+      // Send user to reports route if campaignId isn't valid
+      return 'https://analyze.buffer.com/reports';
+    }
     if (window.location.hostname === 'publish.local.buffer.com') {
       return `https://analyze.local.buffer.com/campaigns/${campaignId}`;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Pass campaign into view report method in the scheduled empty state
https://buffer.atlassian.net/browse/PUB-2685
(we weren't passing the campaign previously, which was causing a redirect to a blank page)
<!--- Describe your changes in detail. -->

## Context & Notes
Hey @hamstu I'm having trouble getting set up with analyze in production (and I've already used my free trial 😂 ). Do you mind checking if analyze.buffer.com/campaigns is a valid route?

Slack thread: https://buffer.slack.com/archives/C151RRDL1/p1587503321198300
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
