### PR TITLE
Use i18n for billing upgrade banner

### DIFF
--- a/packages/cta-banner/components/BillingUpgradeCTABanner/story.jsx
+++ b/packages/cta-banner/components/BillingUpgradeCTABanner/story.jsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withA11y } from '@storybook/addon-a11y';
 import { Provider } from 'react-redux';
-import '@bufferapp/publish-web/components/i18n';
+import i18n from '@bufferapp/publish-web/components/i18n';
 
 import BillingUpgradeCTABanner from './index';
 
@@ -49,7 +49,7 @@ const fakeUser = {
   avatar: '',
   features: ['paid_users_in_new_publish'],
   trial: userOnTrial,
-  language: 'es-ES',
+  language: 'en-US',
 };
 
 function createMockStore(business, onTrial) {
@@ -72,6 +72,8 @@ function createMockStore(business, onTrial) {
 
 const storeBusiness = createMockStore(true, false);
 const storePro = createMockStore(false, true);
+
+i18n.changeLanguage(fakeUser.language);
 
 storiesOf('BillingUpgradeCTABanner', module)
   .addDecorator(withA11y)

--- a/packages/cta-banner/components/BillingUpgradeCTABanner/story.jsx
+++ b/packages/cta-banner/components/BillingUpgradeCTABanner/story.jsx
@@ -1,9 +1,9 @@
-import translations from '@bufferapp/publish-i18n/translations/en-us.json';
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withA11y } from '@storybook/addon-a11y';
 import { Provider } from 'react-redux';
+import '@bufferapp/publish-web/components/i18n';
 
 import BillingUpgradeCTABanner from './index';
 
@@ -49,6 +49,7 @@ const fakeUser = {
   avatar: '',
   features: ['paid_users_in_new_publish'],
   trial: userOnTrial,
+  language: 'es-ES',
 };
 
 function createMockStore(business, onTrial) {
@@ -56,11 +57,6 @@ function createMockStore(business, onTrial) {
     productFeatures: {
       planName: business ? 'business' : 'pro',
       features: {},
-    },
-    i18n: {
-      translations: {
-        example: {},
-      },
     },
     appSidebar: {
       user: {
@@ -82,7 +78,6 @@ storiesOf('BillingUpgradeCTABanner', module)
   .add('default', () => (
     <Provider store={storeBusiness}>
       <BillingUpgradeCTABanner
-        translations={translations['billing-upgrade-cta-banner']}
         onClickStartSubscription={action('startSubscription')}
         trial={userWithoutTrial}
         profileCount={1}
@@ -92,7 +87,6 @@ storiesOf('BillingUpgradeCTABanner', module)
   .add('free user on pro trial no billing info', () => (
     <Provider store={storePro}>
       <BillingUpgradeCTABanner
-        translations={translations['billing-upgrade-cta-banner']}
         onClickStartSubscription={action('startSubscription')}
         trial={userOnTrial}
         profileCount={1}
@@ -102,7 +96,6 @@ storiesOf('BillingUpgradeCTABanner', module)
   .add('free user on pro trial with billing info', () => (
     <Provider store={storePro}>
       <BillingUpgradeCTABanner
-        translations={translations['billing-upgrade-cta-banner']}
         onClickStartSubscription={action('startSubscription')}
         trial={userOnTrialWithBilling}
         profileCount={1}
@@ -112,7 +105,6 @@ storiesOf('BillingUpgradeCTABanner', module)
   .add('pro user on business trial no billing info', () => (
     <Provider store={storeBusiness}>
       <BillingUpgradeCTABanner
-        translations={translations['billing-upgrade-cta-banner']}
         onClickStartSubscription={action('startSubscription')}
         trial={userOnTrial}
         profileCount={1}
@@ -124,7 +116,6 @@ storiesOf('BillingUpgradeCTABanner', module)
     () => (
       <Provider store={storeBusiness}>
         <BillingUpgradeCTABanner
-          translations={translations['billing-upgrade-cta-banner']}
           onClickStartSubscription={action('startSubscription')}
           trial={userOnTrial}
           profileCount={0}
@@ -135,7 +126,6 @@ storiesOf('BillingUpgradeCTABanner', module)
   .add('pro user on business trial with billing info', () => (
     <Provider store={storeBusiness}>
       <BillingUpgradeCTABanner
-        translations={translations['billing-upgrade-cta-banner']}
         onClickStartSubscription={action('startSubscription')}
         trial={userOnTrialWithBilling}
         profileCount={1}

--- a/packages/cta-banner/index.js
+++ b/packages/cta-banner/index.js
@@ -7,7 +7,6 @@ export default connect(
   state => ({
     trial: state.appSidebar.user && state.appSidebar.user.trial,
     isPremiumBusinessPlan: state.appSidebar.user.plan === 'premium_business',
-    translations: state.i18n.translations['billing-upgrade-cta-banner'],
     profileCount: state.ctaBanner.profileCount,
   }),
   dispatch => ({

--- a/packages/cta-banner/index.test.js
+++ b/packages/cta-banner/index.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import { Button } from '@bufferapp/ui';
-import translations from '@bufferapp/publish-i18n/translations/en-us.json';
 import CTABanner, { reducer, actions, actionTypes, middleware } from './index';
 import BillingUpdateCTABanner from './components/BillingUpgradeCTABanner';
 
@@ -29,12 +28,6 @@ describe('CtaBanner', () => {
         },
         ctaBanner: {
           profileCount: 1,
-        },
-        i18n: {
-          translations: {
-            'billing-upgrade-cta-banner':
-              translations['billing-upgrade-cta-banner'],
-          },
         },
         productFeatures: {
           planName: 'business',

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -1,9 +1,9 @@
 {
   "billing-upgrade-cta-banner": {
-    "billedTrialEnd": "You'll be billed {billedAmount} at the end of your trial. ",
+    "billedTrialEnd": "You'll be billed <1>{{billedAmount}}</1> at the end of your trial. ",
     "completeBilling": "Add your billing details now to start your subscription. ",
-    "planTrial": "You're on the {plan} trial. ",
-    "remainingTrial": "You have {remaining} on your {plan} plan trial. ",
+    "planTrial": "You're on the {{plan}} trial. ",
+    "remainingTrial": "You have <1>{{remaining}} remaining</1> on your {{plan}} plan trial. ",
     "startSubscription": "Start Subscription"
   },
   "campaigns": {

--- a/packages/i18n/translations/es-es.json
+++ b/packages/i18n/translations/es-es.json
@@ -1,9 +1,9 @@
 {
   "billing-upgrade-cta-banner": {
-    "billedTrialEnd": "Se te cobrará {billedAmount} al final de la prueba. ",
+    "billedTrialEnd": "Se te cobrará <1>{{billedAmount}}</1> al final de la prueba. ",
     "completeBilling": "Añade tus datos de pago para empezar tu suscripción.",
-    "planTrial": "Estás en la prueba de {plan}. ",
-    "remainingTrial": "Te faltan {remaining} para seguir probando {plan}. ",
+    "planTrial": "Estás en la prueba de {{plan}}. ",
+    "remainingTrial": "Te faltan <1>{{remaining}}</1> para seguir probando el plan {{plan}}. ",
     "startSubscription": "Empezar suscripción"
   },
   "campaigns": {

--- a/packages/web/components/i18n/index.js
+++ b/packages/web/components/i18n/index.js
@@ -15,6 +15,7 @@ const resources = {
 };
 
 const lng = store.getState()?.user?.language || 'en-US';
+console.log('languageee', store.getState());
 
 i18n
   .use(initReactI18next) // passes i18n down to react-i18next
@@ -29,6 +30,7 @@ i18n
     },
     react: {
       wait: true,
+      transSupportBasicHtmlNodes: true, // allow <br/> and simple html elements in translations
     },
   });
 

--- a/packages/web/components/i18n/index.js
+++ b/packages/web/components/i18n/index.js
@@ -15,7 +15,6 @@ const resources = {
 };
 
 const lng = store.getState()?.user?.language || 'en-US';
-console.log('languageee', store.getState());
 
 i18n
   .use(initReactI18next) // passes i18n down to react-i18next


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Update CTA Billing upgrade banner to use react-i18n instead of translations package.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
- Removes translations and uses new react-i18n library
- Made a refactor for this component since if was a bit tricky to use and translate

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
