### PR TITLE
Check account is present when fetching product name

### DIFF
--- a/packages/server/rpc/globalAccount/index.js
+++ b/packages/server/rpc/globalAccount/index.js
@@ -19,6 +19,7 @@ module.exports = method(
       });
       if (organization) {
         account.productSolutionName =
+          organization.metadata.account &&
           organization.metadata.account.productSolutionName;
       }
     } catch (e) {


### PR DESCRIPTION
## Description
Fix issue where account is not present to get the product name.

## Context & Notes
This issue is part of #PUB-2697 and has been observed in the logs: 

![image](https://user-images.githubusercontent.com/567695/80470623-904c7c80-8942-11ea-9a1e-ebc4bfa0ae85.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
