### PR TITLE
PUB-2691  | Prevent showing direct scheduling modal when completing appcues flow

### DIFF
--- a/packages/modals/middleware.js
+++ b/packages/modals/middleware.js
@@ -1,8 +1,4 @@
-import {
-  actionTypes as dataFetchActionTypes,
-  actions as dataFetchActions,
-} from '@bufferapp/async-data-fetch';
-import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
+import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import { actionTypes as lockedProfileActionTypes } from '@bufferapp/publish-locked-profile-notification/reducer';
 import { actionTypes as thirdPartyActionTypes } from '@bufferapp/publish-thirdparty/reducer';
 import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
@@ -16,19 +12,19 @@ import {
   shouldShowWelcomeModal,
   getSourceFromKey,
   shouldShowStealProfileModal,
-  shouldShowInstagramDirectPostingModal,
   shouldShowWelcomeModalPaidUsers,
   getShowModalValue,
-  resetShowModalKey,
   shouldShowInstagramFirstCommentModal,
 } from './util/showModal';
 
-export default ({ dispatch, getState }) => next => (action) => {
+export default ({ dispatch, getState }) => next => action => {
   next(action);
   switch (action.type) {
     case lockedProfileActionTypes.UPGRADE:
       if (action.plan === 'free') {
-        dispatch(actions.showSwitchPlanModal({ source: 'locked_profile', plan: 'pro' }));
+        dispatch(
+          actions.showSwitchPlanModal({ source: 'locked_profile', plan: 'pro' })
+        );
       }
       break;
     case 'APP_INIT': {
@@ -45,7 +41,11 @@ export default ({ dispatch, getState }) => next => (action) => {
         );
       }
       if (shouldShowStealProfileModal()) {
-        dispatch(actions.showStealProfileModal({ stealProfileUsername: getShowModalValue() }));
+        dispatch(
+          actions.showStealProfileModal({
+            stealProfileUsername: getShowModalValue(),
+          })
+        );
       }
       if (shouldShowWelcomeModalPaidUsers()) {
         dispatch(actions.showWelcomePaidModal());
@@ -66,7 +66,10 @@ export default ({ dispatch, getState }) => next => (action) => {
         // Context: https://buffer.atlassian.net/browse/PUB-2004
         return;
       }
-      if (action.result && action.result.some(profile => profile.isDisconnected)) {
+      if (
+        action.result &&
+        action.result.some(profile => profile.isDisconnected)
+      ) {
         dispatch(actions.showProfilesDisconnectedModal());
       }
       break;
@@ -95,7 +98,10 @@ export default ({ dispatch, getState }) => next => (action) => {
         // Context: https://buffer.atlassian.net/browse/PUB-2004
         return;
       }
-      if (shouldShowProTrialExpiredModal || shouldShowBusinessTrialExpiredModal) {
+      if (
+        shouldShowProTrialExpiredModal ||
+        shouldShowBusinessTrialExpiredModal
+      ) {
         dispatch(actions.showTrialCompleteModal());
       }
       break;
@@ -108,25 +114,13 @@ export default ({ dispatch, getState }) => next => (action) => {
       }
 
       if (modalToShow.id === actionTypes.SHOW_IG_DIRECT_POSTING_MODAL) {
-        dispatch(actions.showInstagramDirectPostingModal({
-          profileId: modalToShow.params.profileId,
-        }));
+        dispatch(
+          actions.showInstagramDirectPostingModal({
+            profileId: modalToShow.params.profileId,
+          })
+        );
       }
 
-      break;
-    }
-
-    case thirdPartyActionTypes.APPCUES_STARTED: {
-      const tourInProgress = getState().thirdparty.appCues.inProgress;
-      const selectedProfileId = getState().profileSidebar.selectedProfileId;
-
-      if (tourInProgress) {
-        dispatch(actions.hideInstagramDirectPostingModal());
-        dispatch(actions.saveModalToShowLater({
-          modalId: actionTypes.SHOW_IG_DIRECT_POSTING_MODAL,
-          selectedProfileId,
-        }));
-      }
       break;
     }
 
@@ -140,7 +134,9 @@ export default ({ dispatch, getState }) => next => (action) => {
     }
     case 'COMPOSER_EVENT':
       if (action.eventType === 'show-switch-plan-modal') {
-        dispatch(actions.showSwitchPlanModal({ source: 'queue_limit', plan: 'pro' }));
+        dispatch(
+          actions.showSwitchPlanModal({ source: 'queue_limit', plan: 'pro' })
+        );
       }
       break;
 

--- a/packages/modals/middleware.js
+++ b/packages/modals/middleware.js
@@ -1,6 +1,5 @@
 import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import { actionTypes as lockedProfileActionTypes } from '@bufferapp/publish-locked-profile-notification/reducer';
-import { actionTypes as thirdPartyActionTypes } from '@bufferapp/publish-thirdparty/reducer';
 import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
 import { actionTypes as storiesActionTypes } from '@bufferapp/publish-stories/reducer';
 import getCtaProperties from '@bufferapp/publish-analytics-middleware/utils/CtaStrings';
@@ -104,23 +103,6 @@ export default ({ dispatch, getState }) => next => action => {
       ) {
         dispatch(actions.showTrialCompleteModal());
       }
-      break;
-    }
-
-    case thirdPartyActionTypes.APPCUES_FINISHED: {
-      const modalToShow = getState().modals.modalToShowLater;
-      if (!modalToShow) {
-        return;
-      }
-
-      if (modalToShow.id === actionTypes.SHOW_IG_DIRECT_POSTING_MODAL) {
-        dispatch(
-          actions.showInstagramDirectPostingModal({
-            profileId: modalToShow.params.profileId,
-          })
-        );
-      }
-
       break;
     }
 

--- a/packages/modals/middleware.test.js
+++ b/packages/modals/middleware.test.js
@@ -1,19 +1,8 @@
-import {
-  actionTypes as dataFetchActionTypes,
-  actions as dataFetchActions,
-} from '@bufferapp/async-data-fetch';
-
-import {
-  actionTypes as thirdPartyActionTypes,
-} from '@bufferapp/publish-thirdparty';
-import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
+import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware';
 
 import middleware from './middleware';
-import {
-  actions,
-  actionTypes as modalsActionTypes,
-} from './reducer';
+import { actions, actionTypes as modalsActionTypes } from './reducer';
 
 describe('middleware', () => {
   it('should show welcome modal when key is present', () => {
@@ -33,10 +22,8 @@ describe('middleware', () => {
       type: 'APP_INIT',
     };
     middleware({ dispatch, getState })(next)(action);
-    expect(next)
-      .toBeCalledWith(action);
-    expect(dispatch)
-      .toBeCalledWith(actions.showWelcomeModal());
+    expect(next).toBeCalledWith(action);
+    expect(dispatch).toBeCalledWith(actions.showWelcomeModal());
   });
   it('should show and track modal when key with source is present', () => {
     window._showModal = {
@@ -55,12 +42,12 @@ describe('middleware', () => {
       type: 'APP_INIT',
     };
     middleware({ dispatch, getState })(next)(action);
-    expect(next)
-      .toBeCalledWith(action);
-    expect(dispatch)
-      .toBeCalledWith(actions.showSwitchPlanModal({ source: 'profile_limit', plan: 'pro' }));
+    expect(next).toBeCalledWith(action);
+    expect(dispatch).toBeCalledWith(
+      actions.showSwitchPlanModal({ source: 'profile_limit', plan: 'pro' })
+    );
   });
-  it('should send \'unknown\' for key without source', () => {
+  it("should send 'unknown' for key without source", () => {
     window._showModal = {
       key: 'upgrade-to-pro',
     };
@@ -77,10 +64,10 @@ describe('middleware', () => {
       type: 'APP_INIT',
     };
     middleware({ dispatch, getState })(next)(action);
-    expect(next)
-      .toBeCalledWith(action);
-    expect(dispatch)
-      .toBeCalledWith(actions.showSwitchPlanModal({ source: 'unknown', plan: 'pro' }));
+    expect(next).toBeCalledWith(action);
+    expect(dispatch).toBeCalledWith(
+      actions.showSwitchPlanModal({ source: 'unknown', plan: 'pro' })
+    );
   });
   it('should show and track upgrade modal when triggered from composer', () => {
     const next = jest.fn();
@@ -90,10 +77,10 @@ describe('middleware', () => {
       eventType: 'show-switch-plan-modal',
     };
     middleware({ dispatch })(next)(action);
-    expect(next)
-      .toBeCalledWith(action);
-    expect(dispatch)
-      .toBeCalledWith(actions.showSwitchPlanModal({ source: 'queue_limit', plan: 'pro' }));
+    expect(next).toBeCalledWith(action);
+    expect(dispatch).toBeCalledWith(
+      actions.showSwitchPlanModal({ source: 'queue_limit', plan: 'pro' })
+    );
   });
   it('should show steal profile modal when key is present', () => {
     window._showModal = {
@@ -113,10 +100,10 @@ describe('middleware', () => {
       type: 'APP_INIT',
     };
     middleware({ dispatch, getState })(next)(action);
-    expect(next)
-      .toBeCalledWith(action);
-    expect(dispatch)
-      .toBeCalledWith(actions.showStealProfileModal({ stealProfileUsername: 'Test Profile' }));
+    expect(next).toBeCalledWith(action);
+    expect(dispatch).toBeCalledWith(
+      actions.showStealProfileModal({ stealProfileUsername: 'Test Profile' })
+    );
   });
   it('should show welcome modal to paid users', () => {
     window._showModal = {
@@ -135,10 +122,8 @@ describe('middleware', () => {
       type: 'APP_INIT',
     };
     middleware({ dispatch, getState })(next)(action);
-    expect(next)
-      .toBeCalledWith(action);
-    expect(dispatch)
-      .toBeCalledWith(actions.showWelcomePaidModal());
+    expect(next).toBeCalledWith(action);
+    expect(dispatch).toBeCalledWith(actions.showWelcomePaidModal());
   });
 
   it('should show profiles disconnected modal when one or more is disconnected', () => {
@@ -153,13 +138,15 @@ describe('middleware', () => {
     });
     const action = {
       type: `profiles_${dataFetchActionTypes.FETCH_SUCCESS}`,
-      result: [{ isDisconnected: false }, { isDisconnected: false }, { isDisconnected: true }],
+      result: [
+        { isDisconnected: false },
+        { isDisconnected: false },
+        { isDisconnected: true },
+      ],
     };
     middleware({ dispatch, getState })(next)(action);
-    expect(next)
-      .toBeCalledWith(action);
-    expect(dispatch)
-      .toBeCalledWith(actions.showProfilesDisconnectedModal());
+    expect(next).toBeCalledWith(action);
+    expect(dispatch).toBeCalledWith(actions.showProfilesDisconnectedModal());
   });
 
   it('should show trial upgrade modal', () => {
@@ -170,44 +157,8 @@ describe('middleware', () => {
       result: { shouldShowProTrialExpiredModal: true },
     };
     middleware({ dispatch })(next)(action);
-    expect(next)
-      .toBeCalledWith(action);
-    expect(dispatch)
-      .toBeCalledWith(actions.showTrialCompleteModal());
-  });
-
-  it('should hide instagram direct posting modal if AppCues tour starts', () => {
-    window._showModal = {
-      key: 'ig-direct-post-modal',
-    };
-    const next = jest.fn();
-    const dispatch = jest.fn();
-    const getState = () => ({
-      profileSidebar: {
-        selectedProfileId: 'id1',
-        selectedProfile: {
-          service_type: 'profile',
-        },
-      },
-      thirdparty: {
-        appCues: {
-          inProgress: true,
-        },
-      },
-    });
-
-    const action = {
-      type: thirdPartyActionTypes.APPCUES_STARTED,
-    };
-
-    const nextAction = {
-      type: modalsActionTypes.HIDE_IG_DIRECT_POSTING_MODAL,
-    };
-    middleware({ dispatch, getState })(next)(action);
-    expect(next)
-      .toBeCalledWith(action);
-    expect(dispatch)
-      .toBeCalledWith(nextAction);
+    expect(next).toBeCalledWith(action);
+    expect(dispatch).toBeCalledWith(actions.showTrialCompleteModal());
   });
 
   it('tracks a Modal Payment Opened event when the payment modal opens', () => {
@@ -233,11 +184,12 @@ describe('middleware', () => {
     };
     middleware({ dispatch })(next)(action);
 
-    expect(next)
-      .toBeCalledWith(action);
+    expect(next).toBeCalledWith(action);
 
-    expect(analyticsActions.trackEvent)
-      .toBeCalledWith('Modal Payment Opened', expectedMetadata);
+    expect(analyticsActions.trackEvent).toBeCalledWith(
+      'Modal Payment Opened',
+      expectedMetadata
+    );
   });
 
   it('should ignore other actions', () => {
@@ -247,7 +199,6 @@ describe('middleware', () => {
       type: 'SOME_OTHER_ACTION',
     };
     middleware({ dispatch })(next)(action);
-    expect(next)
-      .toBeCalledWith(action);
+    expect(next).toBeCalledWith(action);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Prevent showing direct scheduling modal when completing appcues flow.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
