### PR TITLE
Removing leftovers from removal of segment metadata event work

### DIFF
--- a/packages/composer/composer/utils/TrackingUtils.js
+++ b/packages/composer/composer/utils/TrackingUtils.js
@@ -42,29 +42,6 @@ const formatShareDate = shareDate => {
   return null;
 };
 
-const getSegmentMetadata = ({
-  post = {},
-  profile = {},
-  formattedData = {},
-  composerSource,
-  queueingType,
-}) => ({
-  channel: post.profile_service || null,
-  channelId: post.profile_id || null,
-  channelServiceId: profile.serviceId || null,
-  channelType: profile.serviceType || null,
-  client: post.client ? post.client.name : null,
-  composerSource: composerSource || null,
-  hasFirstComment: !!formattedData.comment_text,
-  hasLocation: !!formattedData.service_geolocation_id,
-  hasShopGridLink: !!formattedData.link,
-  isDraft: !!post.draft,
-  mediaType: post.type || null,
-  postId: post.id || null,
-  shareDate: formatShareDate(post.due_at),
-  shareType: trackingShareTypeMap.get(queueingType) || null,
-});
-
 const getSegmentCampaignMetadata = ({
   post = {},
   profile = {},
@@ -83,7 +60,6 @@ const getSegmentCampaignMetadata = ({
 
 export {
   getComposerSource,
-  getSegmentMetadata,
   formatShareDate,
   getSegmentCampaignMetadata,
 };

--- a/packages/composer/composer/utils/WebAPIUtils.js
+++ b/packages/composer/composer/utils/WebAPIUtils.js
@@ -9,7 +9,7 @@ import AppStore from '../stores/AppStore';
 import API from './API';
 import { observeStore } from '../utils/StoreUtils';
 import { extractSavedUpdatesIdsFromResponses } from '../utils/APIDataTransforms';
-import { getComposerSource, getSegmentMetadata, getSegmentCampaignMetadata } from '../utils/TrackingUtils';
+import { getComposerSource, getSegmentCampaignMetadata } from '../utils/TrackingUtils';
 
 import getFacebookAutocompleteEntities from '../utils/draft-js-custom-plugins/autocomplete/utils/getFacebookAutocompleteEntities';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Cleanup files left from segment event tracking removal when updates are created

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
