### PR TITLE
[PUB-2701] Add appcues for legacy awesome migrated users

### DIFF
--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -128,10 +128,10 @@ export default ({ dispatch, getState }) => next => action => {
               migratedFromAwesomeToPro_teamMember_Batch1: tags.includes(
                 'awesome-pro-forced-migration-team-member'
               ),
-              migratedFromAwesomeToPro_Batch2: tags.include(
+              migratedFromAwesomeToPro_Batch2: tags.includes(
                 'upgraded-awesome-to-pro-batch-2'
               ),
-              migratedFromAwesomeToSBP: tags.include(
+              migratedFromAwesomeToSBP: tags.includes(
                 'upgraded-awesome-to-small-business'
               ),
             });

--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -128,6 +128,12 @@ export default ({ dispatch, getState }) => next => action => {
               migratedFromAwesomeToPro_teamMember_Batch1: tags.includes(
                 'awesome-pro-forced-migration-team-member'
               ),
+              migratedFromAwesomeToPro_Batch2: tags.include(
+                'upgraded-awesome-to-pro-batch-2'
+              ),
+              migratedFromAwesomeToSBP: tags.include(
+                'upgraded-awesome-to-small-business'
+              ),
             });
 
             const dispatchAppcuesStarted = () => {

--- a/packages/thirdParty/middleware.test.js
+++ b/packages/thirdParty/middleware.test.js
@@ -128,6 +128,8 @@ describe('middleware', () => {
       upgradedFromLegacyAwesomeToProPromotion: false,
       migratedFromAwesomeToPro_Batch1: false,
       migratedFromAwesomeToPro_teamMember_Batch1: false,
+      migratedFromAwesomeToPro_Batch2: false,
+      migratedFromAwesomeToSBP: false,
     });
 
     expect(global.Appcues.on.mock.calls).toEqual([
@@ -158,6 +160,8 @@ describe('middleware', () => {
       upgradedFromLegacyAwesomeToProPromotion: true,
       migratedFromAwesomeToPro_Batch1: false,
       migratedFromAwesomeToPro_teamMember_Batch1: false,
+      migratedFromAwesomeToPro_Batch2: false,
+      migratedFromAwesomeToSBP: false,
     });
   });
 
@@ -181,6 +185,8 @@ describe('middleware', () => {
       upgradedFromLegacyAwesomeToProPromotion: false,
       migratedFromAwesomeToPro_Batch1: true,
       migratedFromAwesomeToPro_teamMember_Batch1: false,
+      migratedFromAwesomeToPro_Batch2: false,
+      migratedFromAwesomeToSBP: false,
     });
   });
 
@@ -207,6 +213,8 @@ describe('middleware', () => {
       upgradedFromLegacyAwesomeToProPromotion: false,
       migratedFromAwesomeToPro_Batch1: false,
       migratedFromAwesomeToPro_teamMember_Batch1: true,
+      migratedFromAwesomeToPro_Batch2: false,
+      migratedFromAwesomeToSBP: false,
     });
   });
 

--- a/packages/thirdParty/middleware.test.js
+++ b/packages/thirdParty/middleware.test.js
@@ -210,6 +210,62 @@ describe('middleware', () => {
     });
   });
 
+  it('tells AppCues when a user has been migrated from legacy awesome to Pro batch 2', () => {
+    const action = {
+      type: actionTypes.APPCUES,
+      result: {
+        ...mockUser,
+        tags: ['upgraded-awesome-to-pro-batch-2'],
+      },
+    };
+    middleware(store)(next)(action);
+    expect(global.Appcues.identify).toHaveBeenCalledWith(mockUser.id, {
+      name: mockUser.id,
+      modalsShowing: false,
+      createdAt: mockUser.createdAt,
+      plan: mockUser.plan,
+      planCode: mockUser.planCode,
+      onTrial: mockUser.trial.onTrial,
+      trialLength: mockUser.trial.trialLength,
+      trialTimeRemaining: mockUser.trial.trialTimeRemaining,
+      orgUserCount: mockUser.orgUserCount,
+      profileCount: mockUser.profileCount,
+      upgradedFromLegacyAwesomeToProPromotion: false,
+      migratedFromAwesomeToPro_Batch1: false,
+      migratedFromAwesomeToPro_teamMember_Batch1: false,
+      migratedFromAwesomeToPro_Batch2: true,
+      migratedFromAwesomeToSBP: false,
+    });
+  });
+
+  it('tells AppCues when a user has been migrated from legacy awesome to SBP', () => {
+    const action = {
+      type: actionTypes.APPCUES,
+      result: {
+        ...mockUser,
+        tags: ['upgraded-awesome-to-small-business'],
+      },
+    };
+    middleware(store)(next)(action);
+    expect(global.Appcues.identify).toHaveBeenCalledWith(mockUser.id, {
+      name: mockUser.id,
+      modalsShowing: false,
+      createdAt: mockUser.createdAt,
+      plan: mockUser.plan,
+      planCode: mockUser.planCode,
+      onTrial: mockUser.trial.onTrial,
+      trialLength: mockUser.trial.trialLength,
+      trialTimeRemaining: mockUser.trial.trialTimeRemaining,
+      orgUserCount: mockUser.orgUserCount,
+      profileCount: mockUser.profileCount,
+      upgradedFromLegacyAwesomeToProPromotion: false,
+      migratedFromAwesomeToPro_Batch1: false,
+      migratedFromAwesomeToPro_teamMember_Batch1: false,
+      migratedFromAwesomeToPro_Batch2: false,
+      migratedFromAwesomeToSBP: true,
+    });
+  });
+
   it('sends event to appcues when user adds a post in the composer', () => {
     const action = {
       type: 'COMPOSER_EVENT',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Add appcues for legacy awesome to pro (batch 2) and small business migrated users
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2701

@hamstu This is the first time I've added appcues logic. Let me know if I missed something!
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
