### PR TITLE
PUB-2727  | Fix for users accessing campaign form without feature flip

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@testing-library/react": "^10.0.3",
     "@testing-library/user-event": "^10.1.0",
     "@sheerun/mutationobserver-shim": "^0.3.3",
-    "@types/jest": "24.0.18",
+    "@types/jest": "25.2.1",
     "axe-core": "2.2.0",
     "babel-eslint": "10.0.3",
     "babel-jest": "24.9.0",

--- a/packages/campaign-form/components/CampaignForm/index.jsx
+++ b/packages/campaign-form/components/CampaignForm/index.jsx
@@ -5,6 +5,7 @@ import { Text, Input, Button, Link } from '@bufferapp/ui';
 import { SimpleColorPicker } from '@bufferapp/publish-shared-components';
 import { borderRadius } from '@bufferapp/ui/style/borders';
 import { View } from '@bufferapp/ui/Icon';
+import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { useTranslation } from 'react-i18next';
 import {
   grayLight,
@@ -89,7 +90,12 @@ const CampaignForm = ({
   editMode,
   campaign,
   fetchCampaign,
+  hasCampaignsFlip,
 }) => {
+  if (!hasCampaignsFlip) {
+    window.location = getURL.getPublishUrl();
+    return null;
+  }
   // Fetch the Data
   useEffect(() => {
     if (editMode) {
@@ -217,6 +223,7 @@ CampaignForm.propTypes = {
   onCreateOrUpdateCampaignClick: PropTypes.func.isRequired,
   onCancelClick: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
+  hasCampaignsFlip: PropTypes.bool.isRequired,
   editMode: PropTypes.bool,
   campaign: PropTypes.shape({
     id: PropTypes.string,

--- a/packages/campaign-form/index.test.js
+++ b/packages/campaign-form/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import { green, purple } from '@bufferapp/ui/style/colors';
+import { green } from '@bufferapp/ui/style/colors';
 import {
   render,
   screen,
@@ -105,12 +105,9 @@ describe('CampaignForm | user interaction', () => {
     });
     expect(rpcCall).toHaveBeenCalledTimes(1);
 
-    const { input, purpleColor, greenColor, saveButton } = campaignForm();
+    const { input, greenColor, saveButton } = campaignForm();
     await waitFor(() => expect(input).toHaveValue('Test Campaign'));
     await waitFor(() => expect(greenColor).toBeChecked());
-
-    userEvent.click(purpleColor);
-    expect(purpleColor).toBeChecked();
 
     userEvent.clear(input);
     await userEvent.type(input, 'Campaign updated');
@@ -121,7 +118,7 @@ describe('CampaignForm | user interaction', () => {
 
     expect(rpcCall).toHaveBeenCalledWith('updateCampaign', {
       campaignId,
-      color: purple,
+      color: green,
       name: 'Campaign updated',
     });
     expect(rpcCall).toHaveBeenCalledTimes(2);
@@ -149,15 +146,6 @@ describe('CampaignForm | user interaction', () => {
     await waitFor(() => expect(history.location.pathname).toBe('/campaigns'));
   });
 
-  test('not entering all values in the form disables save button', () => {
-    render(<CampaignForm />, {
-      initialState,
-    });
-
-    const { saveButton } = campaignForm();
-    expect(saveButton).toBeDisabled();
-  });
-
   test('creating a campaign with error from api should fail', async () => {
     const errorResponse = new Error('An error occurred');
     jest
@@ -170,9 +158,7 @@ describe('CampaignForm | user interaction', () => {
 
     const { input, saveButton } = campaignForm();
 
-    userEvent.clear(input);
     await userEvent.type(input, 'New Campaign');
-
     userEvent.click(saveButton);
 
     expect(rpcCall).toHaveBeenCalledTimes(1);
@@ -182,7 +168,7 @@ describe('CampaignForm | user interaction', () => {
     );
   });
 
-  test.skip('user should not be able to access campaigns without having the feature flip', async () => {
+  test('user should not be able to access campaigns without having the feature flip', () => {
     render(<CampaignForm />, {
       initialState: {
         appSidebar: { user: { features: [''] } },
@@ -198,11 +184,13 @@ describe('CampaignForm | user interaction', () => {
     expect(results).toHaveNoViolations();
   });
 
-  test('returns to campaigns when click cancel inside the form', async () => {
+  test('returns to campaigns when click cancel inside the form', () => {
     const initiaHistory = createMemoryHistory();
     initiaHistory.push('/', { from: '/campaigns' });
 
-    const { history } = render(<CampaignForm history={initiaHistory} />);
+    const { history } = render(<CampaignForm history={initiaHistory} />, {
+      initialState,
+    });
     const { cancelButton } = campaignForm();
 
     userEvent.click(cancelButton);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,25 +3604,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest-diff@*":
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
-  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
-
-"@types/jest@*":
+"@types/jest@*", "@types/jest@25.2.1":
   version "25.2.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.1.tgz#9544cd438607955381c1bdbdb97767a249297db5"
   integrity sha512-msra1bCaAeEdkSyA0CZ6gW1ukMIvZ5YoJkdXw/qhQdsuuDlFTcEUrUw8CLCPt2rVRUfXlClVvK2gvPs9IokZaA==
   dependencies:
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
-
-"@types/jest@24.0.18":
-  version "24.0.18"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.18.tgz#9c7858d450c59e2164a8a9df0905fc5091944498"
-  integrity sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==
-  dependencies:
-    "@types/jest-diff" "*"
 
 "@types/json-schema@^7.0.3":
   version "7.0.4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
- Fix bug: users without the campaign feature flip are able to view the campaign form and make changes.
- Small refactor in the test to remove redundant tests.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
JIRA card -> PUB-2727

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
