### PR TITLE
Remove Edit button from RTs without comments

### DIFF
--- a/packages/queue/components/QueueItems/index.jsx
+++ b/packages/queue/components/QueueItems/index.jsx
@@ -99,7 +99,9 @@ const renderPost = ({
     hasPushNotifications,
     onSetRemindersClick,
     hasCampaignsFeature,
+    shouldShowEditButton: post.retweet && !!post.retweetComment,
   };
+
   const PostComponent = Post;
 
   const defaultStyle = {

--- a/packages/shared-components/CardFooter/index.jsx
+++ b/packages/shared-components/CardFooter/index.jsx
@@ -116,6 +116,7 @@ const CardFooter = ({
   isDragging,
   disableBorder,
   hasUserTags,
+  shouldShowEditButton,
 }) => {
   const hideAllButtons = hideButtons || isPerformingAction || messageLink;
   const [isConfirmingDelete, setConfirmingDelete] = useState(false);
@@ -196,7 +197,7 @@ const CardFooter = ({
               <VerticalDivider />
             </Fragment>
           )}
-          {onEditClick && (
+          {shouldShowEditButton && onEditClick && (
             <EditButton
               type="secondary"
               label="Edit"
@@ -271,6 +272,7 @@ CardFooter.propTypes = {
   isDragging: PropTypes.bool,
   disableBorder: PropTypes.bool,
   hasUserTags: PropTypes.bool,
+  shouldShowEditButton: PropTypes.bool,
 };
 
 CardFooter.defaultProps = {
@@ -294,6 +296,7 @@ CardFooter.defaultProps = {
   isDragging: false,
   disableBorder: false,
   hasUserTags: false,
+  shouldShowEditButton: true,
 };
 
 export default CardFooter;

--- a/packages/shared-components/Post/index.jsx
+++ b/packages/shared-components/Post/index.jsx
@@ -68,6 +68,7 @@ const Post = ({
   hasCampaignsFeature,
   headerDetails,
   postContent,
+  shouldShowEditButton,
 }) => {
   const hasError =
     postDetails && postDetails.error && postDetails.error.length > 0;
@@ -148,6 +149,7 @@ const Post = ({
             hasCommentEnabled={hasCommentEnabled}
             hasFirstCommentFlip={hasFirstCommentFlip}
             hasUserTags={hasUserTags}
+            shouldShowEditButton={shouldShowEditButton}
           />
           {(isBusinessAccount || !features.isFreeUser()) &&
             isSent &&
@@ -195,6 +197,7 @@ Post.commonPropTypes = {
     email: PropTypes.string,
   }),
   basic: PropTypes.bool,
+  shouldShowEditButton: PropTypes.bool,
 };
 
 Post.propTypes = {
@@ -213,6 +216,7 @@ Post.defaultProps = {
   dueTime: null,
   sharedBy: null,
   basic: false,
+  shouldShowEditButton: true,
 };
 
 export default WithFeatureLoader(Post);

--- a/packages/shared-components/PostFooter/index.jsx
+++ b/packages/shared-components/PostFooter/index.jsx
@@ -49,6 +49,7 @@ const PostFooter = ({
   commentText,
   hasCommentEnabled,
   hasUserTags,
+  shouldShowEditButton,
 }) => {
   const hasError = postDetails.error && postDetails.error.length > 0;
   const { isCustomScheduled, isInstagramReminder } = postDetails;
@@ -84,6 +85,7 @@ const PostFooter = ({
       isDragging={dragging}
       disableBorder={isSent}
       hasUserTags={hasUserTags}
+      shouldShowEditButton={shouldShowEditButton}
     />
   );
 };
@@ -113,6 +115,7 @@ PostFooter.propTypes = {
   commentEnabled: PropTypes.bool,
   commentText: PropTypes.string,
   hasUserTags: PropTypes.bool,
+  shouldShowEditButton: PropTypes.bool,
 };
 
 PostFooter.defaultProps = {
@@ -123,6 +126,7 @@ PostFooter.defaultProps = {
   isSent: false,
   isPastReminder: false,
   hasCommentEnabled: false,
+  shouldShowEditButton: true,
 };
 
 export default PostFooter;


### PR DESCRIPTION
## Description
Since the behavior of editing a native retweet without a custom comment is to copy the content of the RT to the composer, this change disables that action to fix the issue.



## Context & Notes
Fix https://buffer.atlassian.net/browse/PUB-1217

## Screenshots

![image](https://user-images.githubusercontent.com/567695/82891441-08ac5a80-9f4e-11ea-98f4-2e7cf5b23c13.png)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
