### PR TITLE
[PUB-2785] Sanitize composerApiProxy urls to prevent ssrf

### DIFF
--- a/packages/server/rpc/composerApiProxy/index.js
+++ b/packages/server/rpc/composerApiProxy/index.js
@@ -1,15 +1,21 @@
 const { method } = require('@bufferapp/buffer-rpc');
 const rp = require('request-promise');
+const { sanitizeApiUrl, sanitizeUrlParam } = require('./utils/sanitize');
 
 module.exports = method(
   'composerApiProxy',
   'communicate with buffer api',
-  async ({ url, args, HTTPMethod = 'POST' }, { session, connection: { remoteAddress = undefined } }) => {
+  async (
+    { url, args, HTTPMethod = 'POST' },
+    { session, connection: { remoteAddress = undefined } }
+  ) => {
     let result;
     try {
       const fieldName = HTTPMethod === 'POST' ? 'form' : 'qs';
+      const sanitizedUrl = sanitizeUrlParam(url);
+      const sanitizedApiUrl = sanitizeApiUrl(process.env.API_ADDR);
       const requestParams = {
-        uri: `${process.env.API_ADDR}${url}`,
+        uri: `${sanitizedApiUrl}${sanitizedUrl}`,
         method: HTTPMethod,
         strictSSL: process.env.NODE_ENV !== 'development',
         headers: {

--- a/packages/server/rpc/composerApiProxy/index.js
+++ b/packages/server/rpc/composerApiProxy/index.js
@@ -1,6 +1,6 @@
 const { method } = require('@bufferapp/buffer-rpc');
 const rp = require('request-promise');
-const { sanitizeApiUrl, sanitizeUrlParam } = require('./utils/sanitize');
+const { sanitizeApiUrl, sanitizePath } = require('./utils/sanitize');
 
 module.exports = method(
   'composerApiProxy',
@@ -12,10 +12,10 @@ module.exports = method(
     let result;
     try {
       const fieldName = HTTPMethod === 'POST' ? 'form' : 'qs';
-      const sanitizedUrl = sanitizeUrlParam(url);
+      const sanitizedPath = sanitizePath(url);
       const sanitizedApiUrl = sanitizeApiUrl(process.env.API_ADDR);
       const requestParams = {
-        uri: `${sanitizedApiUrl}${sanitizedUrl}`,
+        uri: `${sanitizedApiUrl}${sanitizedPath}`,
         method: HTTPMethod,
         strictSSL: process.env.NODE_ENV !== 'development',
         headers: {

--- a/packages/server/rpc/composerApiProxy/utils/sanitize.js
+++ b/packages/server/rpc/composerApiProxy/utils/sanitize.js
@@ -1,11 +1,11 @@
 // prevent ssrf attacks
 
 // ensure it doesn't start with a slash
-const sanitizeUrlParam = url => {
-  if (url && url.charAt(0) === '/') {
-    return url.substring(1);
+const sanitizePath = path => {
+  if (path && path.charAt(0) === '/') {
+    return path.substring(1);
   }
-  return url;
+  return path;
 };
 
 // ensure it ends with a slash
@@ -17,6 +17,6 @@ const sanitizeApiUrl = apiUrl => {
 };
 
 module.exports = {
-  sanitizeUrlParam,
+  sanitizePath,
   sanitizeApiUrl,
 };

--- a/packages/server/rpc/composerApiProxy/utils/sanitize.js
+++ b/packages/server/rpc/composerApiProxy/utils/sanitize.js
@@ -1,0 +1,22 @@
+// prevent ssrf attacks
+
+// ensure it doesn't start with a slash
+const sanitizeUrlParam = url => {
+  if (url && url.charAt(0) === '/') {
+    return url.substring(1);
+  }
+  return url;
+};
+
+// ensure it ends with a slash
+const sanitizeApiUrl = apiUrl => {
+  if (apiUrl && apiUrl.charAt(apiUrl.length - 1) !== '/') {
+    return `${apiUrl}/`;
+  }
+  return apiUrl;
+};
+
+module.exports = {
+  sanitizeUrlParam,
+  sanitizeApiUrl,
+};

--- a/packages/server/rpc/composerApiProxy/utils/sanitize.test.js
+++ b/packages/server/rpc/composerApiProxy/utils/sanitize.test.js
@@ -1,0 +1,27 @@
+const { sanitizeApiUrl, sanitizeUrlParam } = require('./sanitize');
+
+describe('utils/sanitize url param', () => {
+  it('should not start with a slash', () => {
+    const url = '/1/updates/create.json';
+    const sanitizedUrl = sanitizeUrlParam(url);
+    expect(sanitizedUrl).toBe('1/updates/create.json');
+  });
+  it('should return url if doesnt start with slash', () => {
+    const url = '1/updates/create.json';
+    const sanitizedUrl = sanitizeUrlParam(url);
+    expect(sanitizedUrl).toBe(url);
+  });
+});
+
+describe('utils/sanitize api url', () => {
+  it('should end with a slash', () => {
+    const url = 'https://local.api.bufferapp.com';
+    const sanitizedUrl = sanitizeApiUrl(url);
+    expect(sanitizedUrl).toBe('https://local.api.bufferapp.com/');
+  });
+  it('should return url if ends with slash', () => {
+    const url = 'https://local.api.bufferapp.com/';
+    const sanitizedUrl = sanitizeApiUrl(url);
+    expect(sanitizedUrl).toBe(url);
+  });
+});

--- a/packages/server/rpc/composerApiProxy/utils/sanitize.test.js
+++ b/packages/server/rpc/composerApiProxy/utils/sanitize.test.js
@@ -1,15 +1,15 @@
-const { sanitizeApiUrl, sanitizeUrlParam } = require('./sanitize');
+const { sanitizeApiUrl, sanitizePath } = require('./sanitize');
 
-describe('utils/sanitize url param', () => {
+describe('utils/sanitize param path', () => {
   it('should not start with a slash', () => {
-    const url = '/1/updates/create.json';
-    const sanitizedUrl = sanitizeUrlParam(url);
-    expect(sanitizedUrl).toBe('1/updates/create.json');
+    const path = '/1/updates/create.json';
+    const sanitizedPath = sanitizePath(path);
+    expect(sanitizedPath).toBe('1/updates/create.json');
   });
-  it('should return url if doesnt start with slash', () => {
-    const url = '1/updates/create.json';
-    const sanitizedUrl = sanitizeUrlParam(url);
-    expect(sanitizedUrl).toBe(url);
+  it('should return path if doesnt start with slash', () => {
+    const path = '1/updates/create.json';
+    const sanitizedPath = sanitizePath(path);
+    expect(sanitizedPath).toBe(path);
   });
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
https://buffer.atlassian.net/browse/PUB-2785
Sanitize the api url to end with a slash and the url param to start without a slash
<!--- Describe your changes in detail. -->

## Context & Notes
Hey @karelm let me know if there's anything I misunderstood, as there were several comments in the jira.  😄 
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
