### PR TITLE
Fix payday and upgrade button regressions

### DIFF
--- a/packages/credit-card-form/components/CreditCardForm/form.jsx
+++ b/packages/credit-card-form/components/CreditCardForm/form.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { CardElement, injectStripe } from 'react-stripe-elements';
 import { Button } from '@bufferapp/ui';
-import { ButtonWrapper, InputWrapper } from './styles';
+import { ButtonWrapper, InputWrapper, StyledButton } from './styles';
 
 class CreditCardForm extends Component {
   constructor() {
@@ -55,7 +55,7 @@ class CreditCardForm extends Component {
             label={closeButtonLabel}
             onClick={closeAction}
           />
-          <Button
+          <StyledButton
             type="primary"
             onClick={this.handleSubmit}
             label={buttonLabel}

--- a/packages/credit-card-form/components/CreditCardForm/styles.js
+++ b/packages/credit-card-form/components/CreditCardForm/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { grayLight } from '@bufferapp/ui/style/colors';
 import { borderRadius } from '@bufferapp/ui/style/borders';
+import { Button } from '@bufferapp/ui';
 
 export const InputWrapper = styled.div`
   border: 1px solid ${grayLight};
@@ -12,8 +13,8 @@ export const ButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
   margin-top: 1.5rem;
+`;
 
-  button:last-of-type {
-    margin-left: 1rem;
-  }
+export const StyledButton = styled(Button)`
+  margin-left: 1rem;
 `;

--- a/packages/plans/components/PlanColumnWithPremiumSolo/index.jsx
+++ b/packages/plans/components/PlanColumnWithPremiumSolo/index.jsx
@@ -56,8 +56,8 @@ const RightPlanButton = ({
 const RightButton = styled(Button)`
   button {
     height: unset;
+    padding: ${props => (props.isNonprofit ? '4% 3%' : '20px 30px 15px 30px')};
   }
-  padding: ${props => (props.isNonprofit ? '4% 3%' : '20px 15px 15px 15px')};
   border-radius: 0 25px 25px 0;
   background-color: ${props =>
     props.type === 'primary' ? '#EEF1FF' : 'white'};

--- a/packages/plans/components/PlanColumnWithPremiumSolo/index.jsx
+++ b/packages/plans/components/PlanColumnWithPremiumSolo/index.jsx
@@ -54,8 +54,10 @@ const RightPlanButton = ({
 );
 
 const RightButton = styled(Button)`
-  height: unset;
-  padding: ${props => (props.isNonprofit ? '4% 3%' : '20px 30px 15px 30px')};
+  button {
+    height: unset;
+  }
+  padding: ${props => (props.isNonprofit ? '4% 3%' : '20px 15px 15px 15px')};
   border-radius: 0 25px 25px 0;
   background-color: ${props =>
     props.type === 'primary' ? '#EEF1FF' : 'white'};
@@ -123,7 +125,7 @@ const PlanColumnWithPremiumSolo = ({
           <Image src={imageSrc} width="auto" height="130px" />
         </ImageWrapperStyle>
         {!isPremium && (
-          <React.Fragment>
+          <>
             <UserIcon Icon={<Person />} text="1 user" isSelected />
             <PriceStyle>
               <TextStyle type="h1">
@@ -132,10 +134,10 @@ const PlanColumnWithPremiumSolo = ({
               </TextStyle>
             </PriceStyle>
             <LeftBillingText type="p">{billingText}</LeftBillingText>
-          </React.Fragment>
+          </>
         )}
         {isPremium && (
-          <React.Fragment>
+          <>
             <PlanStyle>
               <LeftButton
                 type={isSelected() ? 'primary' : 'secondary'}
@@ -173,7 +175,7 @@ const PlanColumnWithPremiumSolo = ({
               />
             </PlanStyle>
             <EmptySpan />
-          </React.Fragment>
+          </>
         )}
       </TopContentStyle>
       <FeatureListStyle>

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -9,19 +9,14 @@ import { withTranslation } from 'react-i18next';
 import { getValidTab } from '../../utils';
 import TabTag from '../TabTag';
 
-const UpgradeCtaStyle = styled.div`
+const UpgradeButton = styled(Button)`
   transform: translate(0, 1px);
-  margin: 12px 0;
+  margin: 10px;
   display: inline-block;
   text-align: center;
   position: absolute;
   top: 0;
   right: 0;
-`;
-
-const ButtonWrapper = styled.div`
-  margin-left: 8px;
-  display: inline-block;
 `;
 
 const tabsStyle = {
@@ -124,19 +119,15 @@ class TabNavigation extends React.Component {
           <Tab tabId="settings">{t('tabs.settings')}</Tab>
         </Tabs>
         {shouldShowUpgradeButton && (
-          <UpgradeCtaStyle>
-            <ButtonWrapper>
-              <Button
-                label={t('tabs.upgrade')}
-                type="secondary"
-                size="small"
-                onClick={e => {
-                  e.preventDefault();
-                  onUpgradeButtonClick();
-                }}
-              />
-            </ButtonWrapper>
-          </UpgradeCtaStyle>
+          <UpgradeButton
+            label={t('tabs.upgrade')}
+            type="secondary"
+            size="small"
+            onClick={e => {
+              e.preventDefault();
+              onUpgradeButtonClick();
+            }}
+          />
         )}
         {shouldShowNestedAnalyticsTab && !isLockedProfile && (
           <Tabs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
I noticed today that there were some button style regressions with the upgrade & payday page buttons. It looks like they were caused a few weeks ago by a change to the ui library button (it added a div wrapper to the button component). This change caused certain styles to no longer work. 

**Before** https://share.getcloudapp.com/d5uWrKNB
**After**: https://share.getcloudapp.com/DOuAXOrx
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
