### PR TITLE
[PUB-2816] Remove gray overloading when switching profiles

### DIFF
--- a/packages/modals/components/AppModals/index.jsx
+++ b/packages/modals/components/AppModals/index.jsx
@@ -7,7 +7,6 @@ import StealProfileModal from '@bufferapp/publish-steal-profile-modal';
 import ProfilesDisconnectedModal from '@bufferapp/publish-profiles-disconnected-modal';
 import WelcomePaidModal from '@bufferapp/publish-welcome-paid-modal';
 import InstagramFirstCommentModal from '@bufferapp/publish-ig-first-comment-modal';
-import InstagramDirectPostingModal from '@bufferapp/publish-ig-direct-posting-modal';
 import TrialCompleteModal from '@bufferapp/publish-trial-complete-modal';
 import InstagramFirstCommentProTrialModal from '@bufferapp/publish-ig-first-comment-pro-trial-modal';
 import CloseComposerConfirmationModal from '@bufferapp/publish-close-composer-confirmation-modal';
@@ -47,7 +46,6 @@ AppModals.propTypes = {
   showWelcomePaidModal: PropTypes.bool.isRequired,
   showProfilesDisconnectedModal: PropTypes.bool.isRequired,
   showStealProfileModal: PropTypes.bool.isRequired,
-  showInstagramDirectPostingModal: PropTypes.bool.isRequired,
   showInstagramFirstCommentModal: PropTypes.bool.isRequired,
   showTrialCompleteModal: PropTypes.bool.isRequired,
   showInstagramFirstCommentProTrialModal: PropTypes.bool.isRequired,

--- a/packages/queue/middleware.js
+++ b/packages/queue/middleware.js
@@ -23,22 +23,6 @@ export default ({ dispatch, getState }) => next => action => {
           },
         })
       );
-
-      if (getState().user.plan !== 'awesome') {
-        const sidebar = getState().profileSidebar;
-        const profileId = sidebar.selectedProfileId;
-        const isIGBusiness = sidebar.selectedProfile.service_type === 'business';
-        if (!isIGBusiness) {
-          dispatch(
-            dataFetchActions.fetch({
-              name: 'checkInstagramBusiness',
-              args: {
-                profileId,
-              },
-            })
-          );
-        }
-      }
       break;
     }
     case `updateSchedule_${dataFetchActionTypes.FETCH_SUCCESS}`:

--- a/packages/queue/middleware.js
+++ b/packages/queue/middleware.js
@@ -4,7 +4,7 @@ import {
   actions as dataFetchActions,
   actionTypes as dataFetchActionTypes,
 } from '@bufferapp/async-data-fetch';
-import { actions as generalSettingsActions } from '@bufferapp/publish-general-settings/reducer';
+import { actions as igDirectPostingActions } from '@bufferapp/publish-ig-direct-posting-modal/reducer';
 import { actions as notificationActions } from '@bufferapp/notifications';
 import { campaignScheduled, campaignSent } from '@bufferapp/publish-routes';
 import { actionTypes, actions } from './reducer';
@@ -76,7 +76,7 @@ export default ({ dispatch, getState }) => next => action => {
       if (action.args.recheck) {
         if (action.result.is_business) {
           dispatch(
-            generalSettingsActions.handleSetUpDirectPostingClick({
+            igDirectPostingActions.handleSetUpDirectPostingClick({
               profileId: action.args.profileId,
             })
           );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Currently, when switching profiles, a brief dark gray overlay shows in the queue. This was happening because we were making a request to `checkInstagramBusiness` for every profile switch that wasn't IG business. While we were waiting for success, the overlay would display. 

Since we are no longer auto-opening the modal [[PR](https://github.com/bufferapp/buffer-publish/pull/1366/files)], we should only call this request in the direct modal flow when we check whether a user has [converted to business](https://share.getcloudapp.com/v1ue6R7n) and when we first open the direct modal from the banner.

Also, it looks like [an error was displaying](https://share.getcloudapp.com/yAuYPvO5) in the flow once a user converted their profile to business. Added a fix for it.
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2816
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
