### PR TITLE
Add feature flip to filter profiles by organization

### DIFF
--- a/packages/bootstrap/middleware.js
+++ b/packages/bootstrap/middleware.js
@@ -13,6 +13,8 @@ export default ({ dispatch }) => next => action => {
       dispatch({ type: 'INIT_STRIPE_DETAILS' });
       break;
     case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      // temporary, will be dispatched on APP_INIT once we've deleted the org_switcher flip
+      // or we extract the features from the organization instead.
       dispatch({ type: 'INIT_ORGANIZATIONS' });
       break;
     case 'ORGANIZATIONS_INITIALIZED': {

--- a/packages/bootstrap/middleware.js
+++ b/packages/bootstrap/middleware.js
@@ -1,4 +1,4 @@
-import { actionTypes as dataFetchActions } from '@bufferapp/async-data-fetch';
+import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 
 export default ({ dispatch }) => next => action => {
   next(action);
@@ -6,12 +6,14 @@ export default ({ dispatch }) => next => action => {
     case 'APP_INIT':
       dispatch({ type: 'INIT_MODALS' });
       dispatch({ type: 'INIT_USER' });
-      dispatch({ type: 'INIT_ORGANIZATIONS' });
       dispatch({ type: 'INIT_APPSHELL' });
       dispatch({ type: 'INIT_FEATURES' });
       dispatch({ type: 'INIT_PUSHER' });
       dispatch({ type: 'INIT_CHECK_BOOKMARKLET' });
       dispatch({ type: 'INIT_STRIPE_DETAILS' });
+      break;
+    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      dispatch({ type: 'INIT_ORGANIZATIONS' });
       break;
     case 'ORGANIZATIONS_INITIALIZED': {
       dispatch({ type: 'INIT_PROFILES' });

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -50,7 +50,7 @@ const moveProfileInArray = (arr, from, to) => {
 };
 
 const isOrgSwitcherFeatureEnabled = state =>
-  state.user.features?.includes('org_switcher');
+  state.user?.features?.includes('org_switcher');
 
 const handleProfileDropped = (profiles, action, userId, isFreeUser) => {
   const { profileLimit, hoverIndex, dragIndex } = action;

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -2,7 +2,6 @@ import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch
 import { actionTypes as queueActionTypes } from '@bufferapp/publish-queue/reducer';
 
 import keyWrapper from '@bufferapp/keywrapper';
-import { getSelectedOrganization } from '@bufferapp/publish-data-organizations/utils';
 import { filterProfilesByOrg } from './utils';
 
 export const actionTypes = keyWrapper('PROFILE_SIDEBAR', {
@@ -49,6 +48,9 @@ const moveProfileInArray = (arr, from, to) => {
   );
   return clone;
 };
+
+const isOrgSwitcherFeatureEnabled = state =>
+  state.user.features?.includes('org_switcher');
 
 const handleProfileDropped = (profiles, action, userId, isFreeUser) => {
   const { profileLimit, hoverIndex, dragIndex } = action;
@@ -151,7 +153,11 @@ export default (state = initialState, action) => {
 
       if (profiles) {
         const { profileList } = state;
-        profiles = filterProfilesByOrg(profileList, selectedOrganization);
+        profiles = filterProfilesByOrg(
+          profileList,
+          selectedOrganization,
+          isOrgSwitcherFeatureEnabled(state)
+        );
       }
 
       return {
@@ -166,7 +172,11 @@ export default (state = initialState, action) => {
 
       if (profiles) {
         const { profileList } = state;
-        profiles = filterProfilesByOrg(profileList, selectedOrganization);
+        profiles = filterProfilesByOrg(
+          profileList,
+          selectedOrganization,
+          isOrgSwitcherFeatureEnabled(state)
+        );
       }
 
       return {
@@ -189,7 +199,11 @@ export default (state = initialState, action) => {
         ...state,
         loading: false,
         profileList: action.result,
-        profiles: filterProfilesByOrg(action.result, state.organization),
+        profiles: filterProfilesByOrg(
+          action.result,
+          state.organization,
+          isOrgSwitcherFeatureEnabled(state)
+        ),
         hasInstagram: action.result.some(p => p.service === 'instagram'),
         hasFacebook: action.result.some(p => p.service === 'facebook'),
         hasTwitter: action.result.some(p => p.service === 'twitter'),

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -30,7 +30,11 @@ export const initialState = {
   isSearchPopupVisible: false,
   searchText: null,
   userId: null,
+  isOrganizationSwitcherEnabled: false,
 };
+
+const isOrgSwitcherFeatureEnabled = user =>
+  user.features?.includes('org_switcher') ?? false;
 
 const moveProfileInArray = (arr, from, to) => {
   const clone = [...arr];
@@ -48,9 +52,6 @@ const moveProfileInArray = (arr, from, to) => {
   );
   return clone;
 };
-
-const isOrgSwitcherFeatureEnabled = state =>
-  state.user?.features?.includes('org_switcher');
 
 const handleProfileDropped = (profiles, action, userId, isFreeUser) => {
   const { profileLimit, hoverIndex, dragIndex } = action;
@@ -156,7 +157,7 @@ export default (state = initialState, action) => {
         profiles = filterProfilesByOrg(
           profileList,
           selectedOrganization,
-          isOrgSwitcherFeatureEnabled(state)
+          state.isOrganizationSwitcherEnabled
         );
       }
 
@@ -175,7 +176,7 @@ export default (state = initialState, action) => {
         profiles = filterProfilesByOrg(
           profileList,
           selectedOrganization,
-          isOrgSwitcherFeatureEnabled(state)
+          state.isOrganizationSwitcherEnabled
         );
       }
 
@@ -202,7 +203,7 @@ export default (state = initialState, action) => {
         profiles: filterProfilesByOrg(
           action.result,
           state.organization,
-          isOrgSwitcherFeatureEnabled(state)
+          state.isOrganizationSwitcherEnabled
         ),
         hasInstagram: action.result.some(p => p.service === 'instagram'),
         hasFacebook: action.result.some(p => p.service === 'facebook'),
@@ -281,6 +282,9 @@ export default (state = initialState, action) => {
         isOnBusinessTrial: action.result.isOnBusinessTrial,
         userId: action.result.id,
         isFreeUser: action.result.is_free_user,
+        isOrganizationSwitcherEnabled: isOrgSwitcherFeatureEnabled(
+          action.result
+        ),
       };
     }
     default:

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -33,9 +33,6 @@ export const initialState = {
   isOrganizationSwitcherEnabled: false,
 };
 
-const isOrgSwitcherFeatureEnabled = user =>
-  user.features?.includes('org_switcher') ?? false;
-
 const moveProfileInArray = (arr, from, to) => {
   const clone = [...arr];
 
@@ -282,9 +279,8 @@ export default (state = initialState, action) => {
         isOnBusinessTrial: action.result.isOnBusinessTrial,
         userId: action.result.id,
         isFreeUser: action.result.is_free_user,
-        isOrganizationSwitcherEnabled: isOrgSwitcherFeatureEnabled(
-          action.result
-        ),
+        isOrganizationSwitcherEnabled:
+          action.result.features?.includes('org_switcher') ?? false,
       };
     }
     default:

--- a/packages/profile-sidebar/reducer.test.js
+++ b/packages/profile-sidebar/reducer.test.js
@@ -24,6 +24,7 @@ describe('reducer', () => {
       hasTwitter: true,
       isSearchPopupVisible: false,
       searchText: null,
+      isOrganizationSwitcherEnabled: false,
     };
     const action = {
       type: 'INIT',

--- a/packages/profile-sidebar/reducer.test.js
+++ b/packages/profile-sidebar/reducer.test.js
@@ -168,5 +168,55 @@ describe('reducer', () => {
       expect(profilesWithUpdatedPostCounts[0].pendingCount).toBe(5);
       expect(profilesWithUpdatedPostCounts[0].sentCount).toBe(2);
     });
+
+    it("should extract properties from user when it's fetched", () => {
+      const stateBefore = profileInitialState;
+
+      const stateAfter = {
+        ...profileInitialState,
+        isOnBusinessTrial: true,
+        userId: '1234',
+        isFreeUser: false,
+        isOrganizationSwitcherEnabled: false,
+      };
+
+      const action = {
+        type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
+        result: {
+          isOnBusinessTrial: stateAfter.isOnBusinessTrial,
+          id: stateAfter.userId,
+          is_free_user: stateAfter.isFreeUser,
+          features: [],
+        },
+      };
+
+      deepFreeze(action);
+      expect(reducer(stateBefore, action)).toEqual(stateAfter);
+    });
+
+    it('should change isOrganizationSwitcherEnabled to true when feature is enabled and user fetched', () => {
+      const stateBefore = profileInitialState;
+
+      const stateAfter = {
+        ...profileInitialState,
+        isOnBusinessTrial: true,
+        userId: '1234',
+        isFreeUser: false,
+        isOrganizationSwitcherEnabled: true,
+      };
+
+      const action = {
+        type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
+        result: {
+          isOnBusinessTrial: stateAfter.isOnBusinessTrial,
+          id: stateAfter.userId,
+          is_free_user: stateAfter.isFreeUser,
+          features: ['org_switcher'],
+        },
+      };
+
+      deepFreeze(action);
+      expect(reducer(stateBefore, action)).toEqual(stateAfter);
+    });
   });
 });

--- a/packages/profile-sidebar/utils/index.js
+++ b/packages/profile-sidebar/utils/index.js
@@ -9,9 +9,15 @@ export const shouldGoToProfile = (profile, prevProps) => {
   );
 };
 
-export const filterProfilesByOrg = (profiles, organization) => {
-  return profiles;
-  // return profiles?.filter(
-  //   profile => profile.organizationId === organization.id
-  // );
+export const filterProfilesByOrg = (
+  profiles,
+  organization,
+  isFeatureEnabled
+) => {
+  if (!isFeatureEnabled) {
+    return profiles;
+  }
+  return profiles?.filter(
+    profile => profile.organizationId === organization.id
+  );
 };

--- a/packages/profile-sidebar/utils/index.test.js
+++ b/packages/profile-sidebar/utils/index.test.js
@@ -29,7 +29,7 @@ describe('profile-sidebar utils', () => {
       expect(filteredProfiles).toEqual(profiles);
     });
 
-    it("returns only the organization's profiles if feature is enabled", () => {
+    it('returns only the profiles in the organization if feature is enabled', () => {
       const filteredProfiles = filterProfilesByOrg(
         profiles,
         organization,

--- a/packages/profile-sidebar/utils/index.test.js
+++ b/packages/profile-sidebar/utils/index.test.js
@@ -1,0 +1,81 @@
+import { filterProfilesByOrg, shouldGoToProfile } from './index';
+
+describe('profile-sidebar utils', () => {
+  describe('filterProfilesByOrg', () => {
+    const organization1Id = '876956785678';
+    const profiles = [
+      {
+        id: '123123123',
+        name: 'Profile 1',
+        organizationId: '524343123',
+      },
+      {
+        id: '6786785678',
+        name: 'Profile 2',
+        organizationId: organization1Id,
+      },
+    ];
+
+    const organization = {
+      id: organization1Id,
+    };
+
+    it('returns all profiles if feature not enabled', () => {
+      const filteredProfiles = filterProfilesByOrg(
+        profiles,
+        organization,
+        false
+      );
+      expect(filteredProfiles).toEqual(profiles);
+    });
+
+    it("returns only the organization's profiles if feature is enabled", () => {
+      const filteredProfiles = filterProfilesByOrg(
+        profiles,
+        organization,
+        true
+      );
+      expect(filteredProfiles).toEqual([profiles[1]]);
+    });
+  });
+
+  describe('shouldGoToProfile', () => {
+    it('returns false if profile is null', () => {
+      expect(shouldGoToProfile(null, {})).toBeFalsy();
+    });
+
+    it('returns false if profile is false', () => {
+      expect(shouldGoToProfile(false, {})).toBeFalsy();
+    });
+
+    it('returns false if profile is the same that prevProps.profileId', () => {
+      const profile1 = {
+        id: '1234',
+      };
+      const prevProps = {
+        profileId: '1234',
+      };
+      expect(shouldGoToProfile(profile1, prevProps)).toBeFalsy();
+    });
+
+    it('returns true if profile is different than prevProps.profileId', () => {
+      const profile1 = {
+        id: '1234',
+      };
+      const prevProps = {
+        profileId: '5678',
+      };
+      expect(shouldGoToProfile(profile1, prevProps)).toEqual(true);
+    });
+
+    it("returns true if we don't have a profile in prevProps", () => {
+      const profile1 = {
+        id: '1234',
+      };
+      const prevProps = {
+        profileId: null,
+      };
+      expect(shouldGoToProfile(profile1, prevProps)).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
## Description
Add feature flip to filter profiles so we can later test this in production without changing the code.

## Context & Notes
Part of the org. switcher project.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [x] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
