### PR TITLE
[PUB-2824] Display retiring social login banner if user pw has not been set

### DIFF
--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -122,4 +122,5 @@ module.exports = userData => ({
   isAnalyzeCustomer: userData.is_analyze_customer,
   canSeePaydayPage: userData.features.includes('awesome_user_can_visit_payday'),
   isUsingPublishAsTeamMember: userData.is_using_publish_as_team_member,
+  hasPasswordSet: userData.has_password,
 });

--- a/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
+++ b/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
@@ -28,6 +28,7 @@ const TemporaryDashboardBanner = ({
   awesomeToProUpgradeDetails,
   awesomeToProMessageKey,
   userReadMessage,
+  displayRetiringSocialLoginBanner,
 }) => {
   const [hidden, hideBanner] = useState(false);
 
@@ -64,6 +65,20 @@ const TemporaryDashboardBanner = ({
     return TopBanner({
       status: hidden,
       content: awesomeToProUpgradeDetails,
+      onCloseBanner: onCloseBannerClick,
+    });
+  }
+
+  // Displays Temporary Banner with retiring social login message. We will want to remove after June 30th
+  if (displayRetiringSocialLoginBanner) {
+    const retiringSocialLoginMessage = `We are retiring social login on June 30, 2020. Please 
+    <a href="https://login.buffer.com/forgot-password" style="color: rgb(44, 75, 255); text-decoration: none;">
+      set up a password to ensure continued access.
+    </a>
+  `;
+    return TopBanner({
+      status: hidden,
+      content: retiringSocialLoginMessage,
       onCloseBanner: onCloseBannerClick,
     });
   }

--- a/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
+++ b/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
@@ -50,6 +50,20 @@ const TemporaryDashboardBanner = ({
     return null;
   }
 
+  // Displays Temporary Banner with retiring social login message. We will want to remove after June 30th
+  if (displayRetiringSocialLoginBanner) {
+    const retiringSocialLoginMessage = `We are retiring social login on June 30, 2020. Please 
+      <a href="https://login.buffer.com/forgot-password" style="color: rgb(44, 75, 255); text-decoration: none;">
+        set up a password to ensure continued access.
+      </a>
+    `;
+    return TopBanner({
+      status: hidden,
+      content: retiringSocialLoginMessage,
+      onCloseBanner: onCloseBannerClick,
+    });
+  }
+
   // Displays Temporary Banner With Admin Message.
   if (enabledApplicationModes && getEnabledApplicationMode(dashboardBanner)) {
     const { content } = getEnabledApplicationMode(dashboardBanner);
@@ -65,20 +79,6 @@ const TemporaryDashboardBanner = ({
     return TopBanner({
       status: hidden,
       content: awesomeToProUpgradeDetails,
-      onCloseBanner: onCloseBannerClick,
-    });
-  }
-
-  // Displays Temporary Banner with retiring social login message. We will want to remove after June 30th
-  if (displayRetiringSocialLoginBanner) {
-    const retiringSocialLoginMessage = `We are retiring social login on June 30, 2020. Please 
-    <a href="https://login.buffer.com/forgot-password" style="color: rgb(44, 75, 255); text-decoration: none;">
-      set up a password to ensure continued access.
-    </a>
-  `;
-    return TopBanner({
-      status: hidden,
-      content: retiringSocialLoginMessage,
       onCloseBanner: onCloseBannerClick,
     });
   }

--- a/packages/temporary-banner/index.js
+++ b/packages/temporary-banner/index.js
@@ -30,6 +30,7 @@ export default connect(
       awesomeToProUpgradeDetails:
         state.temporaryBanner.awesomeToProUpgradeDetails,
       awesomeToProMessageKey: state.temporaryBanner.awesomeToProMessageKey,
+      displayRetiringSocialLoginBanner: state.user.hasPasswordSet === false,
     };
   },
   dispatch => ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Add an in-app alert to let customers know we're retiring social login on June 30th. 
https://buffer.atlassian.net/browse/PUB-2824
<!--- Describe your changes in detail. -->

## Context & Notes
Currently using the `has_password` field on the user model to understand whether a user has set a password. 

@philippemiguet do you know if this is the best way to tell whether a user is solely using social login and hasn't set a pw yet?  
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
https://share.getcloudapp.com/bLujpPoy
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
