### PR TITLE
Temporarily remove social deprecation banner

### DIFF
--- a/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
+++ b/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
@@ -51,18 +51,20 @@ const TemporaryDashboardBanner = ({
   }
 
   // Displays Temporary Banner with retiring social login message. We will want to remove after June 30th
-  if (displayRetiringSocialLoginBanner) {
-    const retiringSocialLoginMessage = `We are retiring social login on June 30, 2020. Please 
-      <a href="https://login.buffer.com/forgot-password" style="color: rgb(44, 75, 255); text-decoration: none;">
-        set up a password to ensure continued access.
-      </a>
-    `;
-    return TopBanner({
-      status: hidden,
-      content: retiringSocialLoginMessage,
-      onCloseBanner: onCloseBannerClick,
-    });
-  }
+  
+  // Commenting out this method for now until we find the most accurate way to tell whether a user has a password set. 
+  // if (displayRetiringSocialLoginBanner) {
+  //   const retiringSocialLoginMessage = `We are retiring social login on June 30, 2020. Please 
+  //     <a href="https://login.buffer.com/forgot-password" style="color: rgb(44, 75, 255); text-decoration: none;">
+  //       set up a password to ensure continued access.
+  //     </a>
+  //   `;
+  //   return TopBanner({
+  //     status: hidden,
+  //     content: retiringSocialLoginMessage,
+  //     onCloseBanner: onCloseBannerClick,
+  //   });
+  // }
 
   // Displays Temporary Banner With Admin Message.
   if (enabledApplicationModes && getEnabledApplicationMode(dashboardBanner)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
After chatting with Colleen on Core, I don't think the `has_password` field is always accurate as the core and publish db are not in sync. Commenting this out for now while I look more into it.  

Slack thread for context: https://buffer.slack.com/archives/C151RRDL1/p1591980767408700
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
