### PR TITLE
[PUB-1179] Error for campaign tracking with no link shortener

### DIFF
--- a/packages/general-settings/components/GeneralSettings/index.jsx
+++ b/packages/general-settings/components/GeneralSettings/index.jsx
@@ -46,6 +46,8 @@ const GeneralSettings = ({
   isDisconnectedProfile,
   isBusinessAccount,
   linkShortening,
+  linkShorteningEnabled,
+  showLinkShortenerErrorMessage,
 }) => {
   if (isLockedProfile) {
     return <LockedProfileNotification />;
@@ -92,6 +94,8 @@ const GeneralSettings = ({
           utmMedium={utmMedium}
           onChangeUtmMedium={onChangeUtmMedium}
           onSaveGATrackingSettingsClick={onSaveGATrackingSettingsClick}
+          linkShorteningEnabled={linkShorteningEnabled}
+          showLinkShortenerErrorMessage={showLinkShortenerErrorMessage}
         />
         {isManager && (
           <ShuffleQueue
@@ -116,10 +120,7 @@ GeneralSettings.defaultProps = {
   profileService: null,
   profileName: null,
   avatarUrl: null,
-  linkShorteners: null,
-  loadingLinkShorteners: true,
   onLinkShortenerOptionSelect: null,
-  selectedShortener: null,
   isManager: true,
   showGACustomizationForm: false,
   googleAnalyticsIsEnabled: false,
@@ -130,7 +131,9 @@ GeneralSettings.defaultProps = {
   isLockedProfile: false,
   isDisconnectedProfile: false,
   loadingShuffle: false,
+  linkShorteningEnabled: false,
   linkShortening: {},
+  showLinkShortenerErrorMessage: false,
 };
 
 GeneralSettings.propTypes = {
@@ -140,6 +143,8 @@ GeneralSettings.propTypes = {
   isInstagramBusiness: PropTypes.bool,
   onConnectBitlyURLClick: PropTypes.func.isRequired,
   onDisconnectBitlyURLClick: PropTypes.func.isRequired,
+  showLinkShortenerErrorMessage: PropTypes.bool,
+  linkShorteningEnabled: PropTypes.bool,
   linkShortening: PropTypes.shape({
     isBitlyConnected: PropTypes.bool,
     isManager: PropTypes.bool,

--- a/packages/general-settings/components/GeneralSettings/index.jsx
+++ b/packages/general-settings/components/GeneralSettings/index.jsx
@@ -47,7 +47,6 @@ const GeneralSettings = ({
   isBusinessAccount,
   linkShortening,
   linkShorteningEnabled,
-  showLinkShortenerErrorMessage,
 }) => {
   if (isLockedProfile) {
     return <LockedProfileNotification />;
@@ -95,7 +94,6 @@ const GeneralSettings = ({
           onChangeUtmMedium={onChangeUtmMedium}
           onSaveGATrackingSettingsClick={onSaveGATrackingSettingsClick}
           linkShorteningEnabled={linkShorteningEnabled}
-          showLinkShortenerErrorMessage={showLinkShortenerErrorMessage}
         />
         {isManager && (
           <ShuffleQueue
@@ -133,7 +131,6 @@ GeneralSettings.defaultProps = {
   loadingShuffle: false,
   linkShorteningEnabled: false,
   linkShortening: {},
-  showLinkShortenerErrorMessage: false,
 };
 
 GeneralSettings.propTypes = {
@@ -143,7 +140,6 @@ GeneralSettings.propTypes = {
   isInstagramBusiness: PropTypes.bool,
   onConnectBitlyURLClick: PropTypes.func.isRequired,
   onDisconnectBitlyURLClick: PropTypes.func.isRequired,
-  showLinkShortenerErrorMessage: PropTypes.bool,
   linkShorteningEnabled: PropTypes.bool,
   linkShortening: PropTypes.shape({
     isBitlyConnected: PropTypes.bool,

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -65,7 +65,7 @@ const CampaignWrapper = styled.div`
   align-items: center;
   flex: 1 1 0%;
   margin-top: 2px;
-  transition: 800ms all linear;
+  transition: all 200ms linear 0s;
   ${props => {
     if (props.enabled) {
       return `
@@ -84,7 +84,7 @@ const CampaignWrapper = styled.div`
 const InfoText = styled(Text)`
   margin-top: 0px;
   color: ${grayDark};
-  transition: 800ms all linear;
+  transition: all 200ms linear 0s;
   ${props => {
     if (props.enabled) {
       return `
@@ -158,10 +158,10 @@ const GoogleAnalytics = ({
       </div>
       <div style={switchStyle}>
         <Toggle
-          disabled={!isManager}
+          disabled={!isManager || !linkShorteningEnabled}
           onText={'Enabled'}
           offText={'Disabled'}
-          on={googleAnalyticsIsEnabled}
+          on={googleAnalyticsIsEnabled && linkShorteningEnabled}
           size={'small'}
           onClick={() =>
             onToggleGoogleAnalyticsClick(
@@ -211,6 +211,7 @@ const GoogleAnalytics = ({
                 }}
                 name={'utmMedium'}
                 placeholder={'social'}
+                disabled={!googleAnalyticsIsEnabled}
               />
             </div>
             <div style={saveChangesStyle}>
@@ -236,6 +237,7 @@ const GoogleAnalytics = ({
       (!features.isFreeUser() || (isBusinessAccount && isManager)) && (
         <div style={customizeButtonStyle}>
           <Button
+            disabled={!linkShorteningEnabled}
             type="secondary"
             label="Customize Campaign Tracking"
             onClick={onShowGACustomizationFormClick}

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import { redDark } from '@bufferapp/ui/style/colors';
+import styled, { keyframes } from 'styled-components';
+import { grayDark } from '@bufferapp/ui/style/colors';
 import { Toggle, Input, Card } from '@bufferapp/components';
 import { Text, Button } from '@bufferapp/ui';
 import { Field, reduxForm } from 'redux-form';
@@ -19,13 +20,6 @@ const enableGoogleAnalyticsStyle = {
 const generalWrapperStyle = {
   display: 'flex',
   marginBottom: '0.5rem',
-};
-
-const enableCampaignWrapperStyle = {
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  flex: '1 1 0%',
 };
 
 const formWrapperStyle = {
@@ -66,13 +60,35 @@ const customizeButtonStyle = {
   flexBasis: '170px',
 };
 
-const EnableCampaignText = styled(Text)`
-  margin-bottom: 2px;
+const fadeIn = keyframes`
+  from: {
+    opacity: 0;
+  }
+  to: {
+    opacity: 1;
+  }
 `;
 
-const ErrorText = styled(Text)`
+const fadeOut = keyframes`
+  from: {
+    opacity: 1;
+  }
+  to: {
+    opacity: 0;
+  }
+`;
+
+const enableCampaignWrapperStyle = {
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  flex: '1 1 0%',
+};
+
+const InfoText = styled(Text)`
   margin-top: 0px;
-  color: ${redDark};
+  color: ${grayDark};
+  animation: ${props => (props.shouldShow ? fadeIn : fadeOut)} 10000ms;
 `;
 
 const GoogleAnalytics = ({
@@ -107,49 +123,51 @@ const GoogleAnalytics = ({
       </div>
       <div style={rightContainerStyle} />
     </div>
-    <div style={enableCampaignWrapperStyle}>
-      <div style={textStyle}>
-        <div style={headerTextWrapperStyle}>
-          <EnableCampaignText type="p">
-            <strong>Enable Campaign Tracking</strong>
-          </EnableCampaignText>
-        </div>
-        {!linkShorteningEnabled && (
-          <ErrorText type="p">
-            <strong>
-              Please choose a link shortener above if you&apos;d like to enable
-              campaign tracking.
-            </strong>
-          </ErrorText>
-        )}
-        <div style={enableGoogleAnalyticsStyle}>
-          <Text type="p">
-            This enables Google Analytics Tracking via UTM parameters added to
-            links you share.
-          </Text>
-          <div>
+    {!linkShorteningEnabled && (
+      <InfoText type="p" shouldShow={!linkShorteningEnabled}>
+        <em>
+          Please choose a link shortener above if you&apos;d like to enable
+          campaign tracking.
+        </em>
+      </InfoText>
+    )}
+    {linkShorteningEnabled && (
+      <div style={enableCampaignWrapperStyle}>
+        <div style={textStyle}>
+          <div style={headerTextWrapperStyle}>
             <Text type="p">
-              (This will override any existing UTM parameters)
+              <strong>Enable Campaign Tracking</strong>
             </Text>
           </div>
+          <div style={enableGoogleAnalyticsStyle}>
+            <Text type="p">
+              This enables Google Analytics Tracking via UTM parameters added to
+              links you share.
+            </Text>
+            <div>
+              <Text type="p">
+                (This will override any existing UTM parameters)
+              </Text>
+            </div>
+          </div>
+        </div>
+        <div style={switchStyle}>
+          <Toggle
+            disabled={!isManager}
+            onText={'Enabled'}
+            offText={'Disabled'}
+            on={googleAnalyticsIsEnabled}
+            size={'small'}
+            onClick={() =>
+              onToggleGoogleAnalyticsClick(
+                !googleAnalyticsIsEnabled,
+                linkShorteningEnabled
+              )
+            }
+          />
         </div>
       </div>
-      <div style={switchStyle}>
-        <Toggle
-          disabled={!isManager}
-          onText={'Enabled'}
-          offText={'Disabled'}
-          on={googleAnalyticsIsEnabled}
-          size={'small'}
-          onClick={() =>
-            onToggleGoogleAnalyticsClick(
-              !googleAnalyticsIsEnabled,
-              linkShorteningEnabled
-            )
-          }
-        />
-      </div>
-    </div>
+    )}
     {showGACustomizationForm && googleAnalyticsIsEnabled && (
       <div>
         <Card noBorder noPadding>

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -64,6 +64,12 @@ const customizeButtonStyle = {
   flexBasis: '170px',
 };
 
+const onHoverGoogleAnalytics = linkShorteningEnabled => {
+  if (!linkShorteningEnabled) {
+    console.log('here i am!');
+  }
+};
+
 const GoogleAnalytics = ({
   googleAnalyticsIsEnabled,
   showGACustomizationForm,
@@ -79,6 +85,8 @@ const GoogleAnalytics = ({
   isManager,
   isBusinessAccount,
   features,
+  linkShorteningEnabled,
+  showLinkShortenerErrorMessage,
 }) => (
   <div style={googleAnalyticsWrapperStyle}>
     <div style={headerTextWrapperStyle}>
@@ -102,6 +110,14 @@ const GoogleAnalytics = ({
             <strong>Enable Campaign Tracking</strong>
           </Text>
         </div>
+        {showLinkShortenerErrorMessage && (
+          <Text type="p" color="darkRed">
+            <strong>
+              Please choose a link shortener above if you&apos;d like to enable
+              campaign tracking.
+            </strong>
+          </Text>
+        )}
         <div style={enableGoogleAnalyticsStyle}>
           <Text type="p">
             This enables Google Analytics Tracking via UTM parameters added to
@@ -122,8 +138,12 @@ const GoogleAnalytics = ({
           on={googleAnalyticsIsEnabled}
           size={'small'}
           onClick={() =>
-            onToggleGoogleAnalyticsClick(!googleAnalyticsIsEnabled)
+            onToggleGoogleAnalyticsClick(
+              !googleAnalyticsIsEnabled,
+              linkShorteningEnabled
+            )
           }
+          onHover={() => onHoverGoogleAnalytics(linkShorteningEnabled)}
         />
       </div>
     </div>
@@ -201,10 +221,11 @@ const GoogleAnalytics = ({
 );
 
 GoogleAnalytics.defaultProps = {
-  trackingSettings: null,
   utmCampaign: null,
   utmSource: null,
   utmMedium: null,
+  linkShorteningEnabled: false,
+  showLinkShortenerErrorMessage: false,
 };
 
 GoogleAnalytics.propTypes = {
@@ -222,6 +243,8 @@ GoogleAnalytics.propTypes = {
   isManager: PropTypes.bool.isRequired,
   isBusinessAccount: PropTypes.bool.isRequired,
   features: PropTypes.any.isRequired, // eslint-disable-line
+  linkShorteningEnabled: PropTypes.bool,
+  showLinkShortenerErrorMessage: PropTypes.bool,
 };
 
 export default reduxForm({

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { redDark } from '@bufferapp/ui/style/colors';
 import { Toggle, Input, Card } from '@bufferapp/components';
 import { Text, Button } from '@bufferapp/ui';
 import { Field, reduxForm } from 'redux-form';
@@ -64,11 +66,14 @@ const customizeButtonStyle = {
   flexBasis: '170px',
 };
 
-const onHoverGoogleAnalytics = linkShorteningEnabled => {
-  if (!linkShorteningEnabled) {
-    console.log('here i am!');
-  }
-};
+const EnableCampaignText = styled(Text)`
+  margin-bottom: 2px;
+`;
+
+const ErrorText = styled(Text)`
+  margin-top: 0px;
+  color: ${redDark};
+`;
 
 const GoogleAnalytics = ({
   googleAnalyticsIsEnabled,
@@ -86,7 +91,6 @@ const GoogleAnalytics = ({
   isBusinessAccount,
   features,
   linkShorteningEnabled,
-  showLinkShortenerErrorMessage,
 }) => (
   <div style={googleAnalyticsWrapperStyle}>
     <div style={headerTextWrapperStyle}>
@@ -106,17 +110,17 @@ const GoogleAnalytics = ({
     <div style={enableCampaignWrapperStyle}>
       <div style={textStyle}>
         <div style={headerTextWrapperStyle}>
-          <Text type="p">
+          <EnableCampaignText type="p">
             <strong>Enable Campaign Tracking</strong>
-          </Text>
+          </EnableCampaignText>
         </div>
-        {showLinkShortenerErrorMessage && (
-          <Text type="p" color="darkRed">
+        {!linkShorteningEnabled && (
+          <ErrorText type="p">
             <strong>
               Please choose a link shortener above if you&apos;d like to enable
               campaign tracking.
             </strong>
-          </Text>
+          </ErrorText>
         )}
         <div style={enableGoogleAnalyticsStyle}>
           <Text type="p">
@@ -143,7 +147,6 @@ const GoogleAnalytics = ({
               linkShorteningEnabled
             )
           }
-          onHover={() => onHoverGoogleAnalytics(linkShorteningEnabled)}
         />
       </div>
     </div>
@@ -225,7 +228,6 @@ GoogleAnalytics.defaultProps = {
   utmSource: null,
   utmMedium: null,
   linkShorteningEnabled: false,
-  showLinkShortenerErrorMessage: false,
 };
 
 GoogleAnalytics.propTypes = {
@@ -244,7 +246,6 @@ GoogleAnalytics.propTypes = {
   isBusinessAccount: PropTypes.bool.isRequired,
   features: PropTypes.any.isRequired, // eslint-disable-line
   linkShorteningEnabled: PropTypes.bool,
-  showLinkShortenerErrorMessage: PropTypes.bool,
 };
 
 export default reduxForm({

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import PropTypes from 'prop-types';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 import { grayDark } from '@bufferapp/ui/style/colors';
 import { Toggle, Input, Card } from '@bufferapp/components';
 import { Text, Button } from '@bufferapp/ui';
@@ -60,35 +59,16 @@ const customizeButtonStyle = {
   flexBasis: '170px',
 };
 
-const fadeIn = keyframes`
-  from: {
-    opacity: 0;
-  }
-  to: {
-    opacity: 1;
-  }
+const CampaignWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex: 1 1 0%;
 `;
-
-const fadeOut = keyframes`
-  from: {
-    opacity: 1;
-  }
-  to: {
-    opacity: 0;
-  }
-`;
-
-const enableCampaignWrapperStyle = {
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  flex: '1 1 0%',
-};
 
 const InfoText = styled(Text)`
   margin-top: 0px;
   color: ${grayDark};
-  animation: ${props => (props.shouldShow ? fadeIn : fadeOut)} 10000ms;
 `;
 
 const GoogleAnalytics = ({
@@ -124,7 +104,7 @@ const GoogleAnalytics = ({
       <div style={rightContainerStyle} />
     </div>
     {!linkShorteningEnabled && (
-      <InfoText type="p" shouldShow={!linkShorteningEnabled}>
+      <InfoText type="p" enabled={!linkShorteningEnabled}>
         <em>
           Please choose a link shortener above if you&apos;d like to enable
           campaign tracking.
@@ -132,7 +112,7 @@ const GoogleAnalytics = ({
       </InfoText>
     )}
     {linkShorteningEnabled && (
-      <div style={enableCampaignWrapperStyle}>
+      <CampaignWrapper enabled={linkShorteningEnabled}>
         <div style={textStyle}>
           <div style={headerTextWrapperStyle}>
             <Text type="p">
@@ -166,7 +146,7 @@ const GoogleAnalytics = ({
             }
           />
         </div>
-      </div>
+      </CampaignWrapper>
     )}
     {showGACustomizationForm && googleAnalyticsIsEnabled && (
       <div>

--- a/packages/general-settings/components/GoogleAnalytics/index.jsx
+++ b/packages/general-settings/components/GoogleAnalytics/index.jsx
@@ -64,11 +64,39 @@ const CampaignWrapper = styled.div`
   flex-direction: row;
   align-items: center;
   flex: 1 1 0%;
+  margin-top: 2px;
+  transition: 800ms all linear;
+  ${props => {
+    if (props.enabled) {
+      return `
+        height: auto;
+        opacity: 1;
+        `;
+    }
+    return `
+      height: 0;
+      opacity: 0;
+      flex: unset;
+      `;
+  }}
 `;
 
 const InfoText = styled(Text)`
   margin-top: 0px;
   color: ${grayDark};
+  transition: 800ms all linear;
+  ${props => {
+    if (props.enabled) {
+      return `
+        height: auto;
+        opacity: 1;
+        `;
+    }
+    return `
+      height: 0;
+      opacity: 0;
+      `;
+  }}
 `;
 
 const GoogleAnalytics = ({
@@ -103,51 +131,47 @@ const GoogleAnalytics = ({
       </div>
       <div style={rightContainerStyle} />
     </div>
-    {!linkShorteningEnabled && (
-      <InfoText type="p" enabled={!linkShorteningEnabled}>
-        <em>
-          Please choose a link shortener above if you&apos;d like to enable
-          campaign tracking.
-        </em>
-      </InfoText>
-    )}
-    {linkShorteningEnabled && (
-      <CampaignWrapper enabled={linkShorteningEnabled}>
-        <div style={textStyle}>
-          <div style={headerTextWrapperStyle}>
+    <InfoText type="p" enabled={!linkShorteningEnabled}>
+      <em>
+        Please choose a link shortener above if you&apos;d like to enable
+        campaign tracking.
+      </em>
+    </InfoText>
+    <CampaignWrapper enabled={linkShorteningEnabled}>
+      <div style={textStyle}>
+        <div style={headerTextWrapperStyle}>
+          <Text type="p">
+            <strong>Enable Campaign Tracking</strong>
+          </Text>
+        </div>
+        <div style={enableGoogleAnalyticsStyle}>
+          <Text type="p">
+            This enables Google Analytics Tracking via UTM parameters added to
+            links you share.
+          </Text>
+          <div>
             <Text type="p">
-              <strong>Enable Campaign Tracking</strong>
+              (This will override any existing UTM parameters)
             </Text>
           </div>
-          <div style={enableGoogleAnalyticsStyle}>
-            <Text type="p">
-              This enables Google Analytics Tracking via UTM parameters added to
-              links you share.
-            </Text>
-            <div>
-              <Text type="p">
-                (This will override any existing UTM parameters)
-              </Text>
-            </div>
-          </div>
         </div>
-        <div style={switchStyle}>
-          <Toggle
-            disabled={!isManager}
-            onText={'Enabled'}
-            offText={'Disabled'}
-            on={googleAnalyticsIsEnabled}
-            size={'small'}
-            onClick={() =>
-              onToggleGoogleAnalyticsClick(
-                !googleAnalyticsIsEnabled,
-                linkShorteningEnabled
-              )
-            }
-          />
-        </div>
-      </CampaignWrapper>
-    )}
+      </div>
+      <div style={switchStyle}>
+        <Toggle
+          disabled={!isManager}
+          onText={'Enabled'}
+          offText={'Disabled'}
+          on={googleAnalyticsIsEnabled}
+          size={'small'}
+          onClick={() =>
+            onToggleGoogleAnalyticsClick(
+              !googleAnalyticsIsEnabled,
+              linkShorteningEnabled
+            )
+          }
+        />
+      </div>
+    </CampaignWrapper>
     {showGACustomizationForm && googleAnalyticsIsEnabled && (
       <div>
         <Card noBorder noPadding>

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -33,9 +33,7 @@ export default connect(
     showModal: state.generalSettings.showModal,
     loadingShuffle: state.generalSettings.loadingShuffle,
     linkShortening: state.generalSettings.linkShortening,
-    linkShorteningEnabled:
-      state.generalSettings.linkShortening?.linkShorteners &&
-      state.generalSettings.linkShortening?.linkShorteners[0].selected !== true,
+    linkShorteningEnabled: state.generalSettings.linkShorteningEnabled,
   }),
   (dispatch, ownProps) => ({
     onDirectPostingClick: () => {

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -101,8 +101,6 @@ export default connect(
               : 'disabled',
           })
         );
-      } else {
-        dispatch(actions.showLinkShortenerError());
       }
     },
     onSaveGATrackingSettingsClick: (utmCampaign, utmSource, utmMedium) => {

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -36,6 +36,8 @@ export default connect(
     linkShorteningEnabled:
       state.generalSettings.linkShortening?.linkShorteners &&
       state.generalSettings.linkShortening?.linkShorteners[0].selected !== true,
+    showLinkShortenerErrorMessage:
+      state.generalSettings.showLinkShortenerErrorMessage,
   }),
   (dispatch, ownProps) => ({
     onDirectPostingClick: () => {
@@ -88,13 +90,22 @@ export default connect(
         })
       );
     },
-    onToggleGoogleAnalyticsClick: googleAnalyticsIsEnabled => {
-      dispatch(
-        actions.handleGoogleAnalyticsToggle({
-          profileId: ownProps.profileId,
-          utmTrackingChoice: googleAnalyticsIsEnabled ? 'enabled' : 'disabled',
-        })
-      );
+    onToggleGoogleAnalyticsClick: (
+      googleAnalyticsIsEnabled,
+      linkShorteningEnabled
+    ) => {
+      if (linkShorteningEnabled) {
+        dispatch(
+          actions.handleGoogleAnalyticsToggle({
+            profileId: ownProps.profileId,
+            utmTrackingChoice: googleAnalyticsIsEnabled
+              ? 'enabled'
+              : 'disabled',
+          })
+        );
+      } else {
+        dispatch(actions.showLinkShortenerError());
+      }
     },
     onSaveGATrackingSettingsClick: (utmCampaign, utmSource, utmMedium) => {
       dispatch(

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -33,6 +33,9 @@ export default connect(
     showModal: state.generalSettings.showModal,
     loadingShuffle: state.generalSettings.loadingShuffle,
     linkShortening: state.generalSettings.linkShortening,
+    linkShorteningEnabled:
+      state.generalSettings.linkShortening?.linkShorteners &&
+      state.generalSettings.linkShortening?.linkShorteners[0].selected !== true,
   }),
   (dispatch, ownProps) => ({
     onDirectPostingClick: () => {

--- a/packages/general-settings/index.js
+++ b/packages/general-settings/index.js
@@ -36,8 +36,6 @@ export default connect(
     linkShorteningEnabled:
       state.generalSettings.linkShortening?.linkShorteners &&
       state.generalSettings.linkShortening?.linkShorteners[0].selected !== true,
-    showLinkShortenerErrorMessage:
-      state.generalSettings.showLinkShortenerErrorMessage,
   }),
   (dispatch, ownProps) => ({
     onDirectPostingClick: () => {

--- a/packages/general-settings/reducer.js
+++ b/packages/general-settings/reducer.js
@@ -16,7 +16,6 @@ export const actionTypes = keyWrapper('GENERAL_SETTINGS', {
   SHUFFLE_QUEUE: 0,
   CONFIRM_SHUFFLE_QUEUE: 0,
   CLOSE_MODAL: 0,
-  SHOW_LINK_SHORTENER_ERROR: 0,
 });
 
 const initialState = {
@@ -27,7 +26,6 @@ const initialState = {
   googleAnalyticsIsEnabled: false,
   remindersAreEnabled: false,
   showModal: false,
-  showLinkShortenerErrorMessage: false,
 };
 
 export default (state = initialState, action) => {
@@ -96,18 +94,12 @@ export default (state = initialState, action) => {
           linkShorteners,
           isBitlyConnected,
         },
-        showLinkShortenerErrorMessage: false,
         linkShorteningEnabled: !noLinkShorteningDomain.selected,
       };
     }
     case actionTypes.SHOW_GA_CUSTOMIZATION_FORM:
       return {
         ...state,
-      };
-    case actionTypes.SHOW_LINK_SHORTENER_ERROR:
-      return {
-        ...state,
-        showLinkShortenerErrorMessage: true,
       };
     case `getGATrackingSettings_${dataFetchActionTypes.FETCH_START}`:
       return {
@@ -261,8 +253,5 @@ export const actions = {
   }),
   handleCloseModal: () => ({
     type: actionTypes.CLOSE_MODAL,
-  }),
-  showLinkShortenerError: () => ({
-    type: actionTypes.SHOW_LINK_SHORTENER_ERROR,
   }),
 };

--- a/packages/general-settings/reducer.js
+++ b/packages/general-settings/reducer.js
@@ -16,6 +16,7 @@ export const actionTypes = keyWrapper('GENERAL_SETTINGS', {
   SHUFFLE_QUEUE: 0,
   CONFIRM_SHUFFLE_QUEUE: 0,
   CLOSE_MODAL: 0,
+  SHOW_LINK_SHORTENER_ERROR: 0,
 });
 
 const initialState = {
@@ -26,6 +27,7 @@ const initialState = {
   googleAnalyticsIsEnabled: false,
   remindersAreEnabled: false,
   showModal: false,
+  showLinkShortenerErrorMessage: false,
 };
 
 export default (state = initialState, action) => {
@@ -94,12 +96,18 @@ export default (state = initialState, action) => {
           linkShorteners,
           isBitlyConnected,
         },
+        showLinkShortenerErrorMessage: false,
         linkShorteningEnabled: !noLinkShorteningDomain.selected,
       };
     }
     case actionTypes.SHOW_GA_CUSTOMIZATION_FORM:
       return {
         ...state,
+      };
+    case actionTypes.SHOW_LINK_SHORTENER_ERROR:
+      return {
+        ...state,
+        showLinkShortenerErrorMessage: true,
       };
     case `getGATrackingSettings_${dataFetchActionTypes.FETCH_START}`:
       return {
@@ -253,5 +261,8 @@ export const actions = {
   }),
   handleCloseModal: () => ({
     type: actionTypes.CLOSE_MODAL,
+  }),
+  showLinkShortenerError: () => ({
+    type: actionTypes.SHOW_LINK_SHORTENER_ERROR,
   }),
 };

--- a/packages/general-settings/reducer.js
+++ b/packages/general-settings/reducer.js
@@ -50,6 +50,7 @@ export default (state = initialState, action) => {
         },
         trackingSettings: action.trackingSettings,
         remindersAreEnabled: !action.profile.directPostingEnabled,
+        linkShorteningEnabled: false,
       };
     case `changeLinkShortener_${dataFetchActionTypes.FETCH_START}`:
       return {
@@ -74,9 +75,14 @@ export default (state = initialState, action) => {
     case `changeLinkShortener_${dataFetchActionTypes.FETCH_SUCCESS}`: {
       const { linkShorteners } = action.result;
       const hasShortenersWithLogins =
-        (linkShorteners && linkShorteners.filter(shortener => shortener.login)) ||
+        (linkShorteners &&
+          linkShorteners.filter(shortener => shortener.login)) ||
         [];
       const isBitlyConnected = hasShortenersWithLogins.length > 0;
+
+      const noLinkShorteningDomain = linkShorteners.find(
+        ls => ls.domain === 'No Shortening'
+      );
 
       return {
         ...state,
@@ -88,6 +94,7 @@ export default (state = initialState, action) => {
           linkShorteners,
           isBitlyConnected,
         },
+        linkShorteningEnabled: !noLinkShorteningDomain.selected,
       };
     }
     case actionTypes.SHOW_GA_CUSTOMIZATION_FORM:
@@ -100,7 +107,7 @@ export default (state = initialState, action) => {
         showGACustomizationForm: false,
       };
     case `getGATrackingSettings_${dataFetchActionTypes.FETCH_SUCCESS}`: {
-      const trackingSettings = action.result.trackingSettings;
+      const { trackingSettings } = action.result;
       return {
         ...state,
         showGACustomizationForm: true,

--- a/packages/general-settings/reducer.js
+++ b/packages/general-settings/reducer.js
@@ -84,9 +84,12 @@ export default (state = initialState, action) => {
         ls => ls.domain === 'No Shortening'
       );
 
+      const linkShorteningEnabled = !noLinkShorteningDomain.selected;
+
       return {
         ...state,
         isBitlyConnected,
+        linkShorteningEnabled,
         linkShortening: {
           loading: false,
           selectedShortener: null,
@@ -94,7 +97,9 @@ export default (state = initialState, action) => {
           linkShorteners,
           isBitlyConnected,
         },
-        linkShorteningEnabled: !noLinkShorteningDomain.selected,
+        googleAnalyticsEnabled: linkShorteningEnabled
+          ? state.googleAnalyticsEnabled
+          : false,
       };
     }
     case actionTypes.SHOW_GA_CUSTOMIZATION_FORM:

--- a/packages/general-settings/reducer.test.js
+++ b/packages/general-settings/reducer.test.js
@@ -35,6 +35,7 @@ describe('reducer', () => {
         profileService: 'twitter',
         selectedShortener: null,
       },
+      linkShorteningEnabled: false,
       googleAnalyticsIsEnabled: false,
       showGACustomizationForm: false,
       remindersAreEnabled: false,


### PR DESCRIPTION
## Description

This change adds a note to the Campaign Tracking section notifying users that they must enable a link shortener before they enable Campaign tracking.

## Context & Notes
PUB-1179

## Screenshots (if appropriate)
[https://share.buffer.com/JruLDPpB](https://share.buffer.com/JruLDPpB)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
