### PR TITLE
e2e | Add an await for auth in e2e test

### DIFF
--- a/cypress/e2e/publish.js
+++ b/cypress/e2e/publish.js
@@ -9,18 +9,20 @@ describe('Publish', () => {
     cy.server();
     cy.route({
       method: 'POST',
-      url: '/pusher/auth',
+      url: '/rpc/queuedPosts',
       status: 200,
-    }).as('auth');
+    }).as('getQueuedPosts');
 
     cy.login();
     cy.visit('/');
-    cy.wait('@auth');
+    cy.wait('@getQueuedPosts');
     cy.get('[data-cy=open-composer-button]').click();
 
     const randomPostText = getRandomPostText();
     cy.get('[data-cy=composer-text-zone]').type(`${randomPostText}`);
     cy.findByText(/add to queue/i).click();
+    cy.wait('@getQueuedPosts');
+
     cy.findByText(randomPostText).should('exist');
   });
 });

--- a/cypress/e2e/publish.js
+++ b/cypress/e2e/publish.js
@@ -6,13 +6,21 @@ const getRandomPostText = () => {
 
 describe('Publish', () => {
   it('creates a new post', () => {
+    cy.server();
+    cy.route({
+      method: 'POST',
+      url: '/pusher/auth',
+      status: 200,
+    }).as('auth');
+
     cy.login();
     cy.visit('/');
+    cy.wait('@auth');
     cy.get('[data-cy=open-composer-button]').click();
+
     const randomPostText = getRandomPostText();
-    cy.get('[data-cy=composer-text-zone]').type(
-      `${randomPostText}{cmd}{enter}`
-    );
-    cy.get('[data-cy=post]').should('contain', randomPostText);
+    cy.get('[data-cy=composer-text-zone]').type(`${randomPostText}`);
+    cy.findByText(/add to queue/i).click();
+    cy.findByText(randomPostText).should('exist');
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,7 @@
+/* Temporary workaround:
+ * Issue: Cypress doesn't currently suppport window.fetch
+ * More info: https://github.com/cypress-io/cypress/issues/95#issuecomment-347607198
+ */
+Cypress.on('window:before:load', win => {
+  win.fetch = null;
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,3 +1,5 @@
+import '@testing-library/cypress/add-commands';
+
 /**
  * Import our custom Cypress commands
  */

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -4,6 +4,7 @@ import '@testing-library/cypress/add-commands';
  * Import our custom Cypress commands
  */
 import './login';
+import './commands';
 
 /**
  * Install package that adds console messages to the Cypress output

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -70,7 +70,7 @@ Cypress.Commands.add('createTestUser', () => {
       })
         .its('body')
         .then(body => {
-          // Write the standalone-session.json file so that Publish is logged in 
+          // Write the standalone-session.json file so that Publish is logged in
           // as our newly created test user.
           cy.task('writeStandaloneSession', body.standalone_session);
         });

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "@testing-library/jest-dom": "^5.5.0",
     "@testing-library/react": "^10.0.3",
     "@testing-library/user-event": "^10.1.0",
+    "@testing-library/cypress": "6.0.0",
     "@types/jest": "25.2.1",
     "axe-core": "2.2.0",
     "babel-eslint": "10.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,6 +992,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.8.7":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
+  integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.0", "@babel/template@^7.4.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.10.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.0.tgz#f15d852ce16cd5fb3e219097a75f662710b249b1"
@@ -2785,6 +2792,25 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testing-library/cypress@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-6.0.0.tgz#935f7716e0e495f02fd753a42621e4d350097dce"
+  integrity sha512-vWPQtPsIDk5STOH2XdJbJoYq9gxOSAItP0ail+MlylK230zNkf3ODKd6eqWnDdruuqrhTF3CyqvPNMA8Xks/UQ==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    "@testing-library/dom" "^7.0.2"
+    "@types/testing-library__cypress" "^5.0.3"
+
+"@testing-library/dom@^7.0.2":
+  version "7.16.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.16.2.tgz#f7a20b5548817e5c7ed26077913372d977be90af"
+  integrity sha512-4fT5l5L+5gfNhUZVCg0wnSszbRJ7A1ZHEz32v7OzH3mcY5lUsK++brI3IB2L9F5zO4kSDc2TRGEVa8v2hgl9vA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    aria-query "^4.0.2"
+    dom-accessibility-api "^0.4.5"
+    pretty-format "^25.5.0"
+
 "@testing-library/dom@^7.2.2":
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.5.9.tgz#25bab5872ee2c446e21bceb209c8d0003cac5d40"
@@ -3067,6 +3093,14 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
   integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
+"@types/testing-library__cypress@^5.0.3":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__cypress/-/testing-library__cypress-5.0.5.tgz#ca2a23eb03c48ecb50f411b3d5e62a218ac6b03b"
+  integrity sha512-FXRE98G+jkru7Dag6dFWs3M90BGMzDEBzox8Uro+7M70UcB1YVUetNVRyqYShFDLIDv+z3ZjV4ZeUmdgPuuyNw==
+  dependencies:
+    "@types/testing-library__dom" "*"
+    cypress "*"
 
 "@types/testing-library__dom@*":
   version "7.0.2"
@@ -7410,6 +7444,49 @@ cypress-terminal-report@1.3.1:
     chalk "^3.0.0"
     methods "^1.1.2"
 
+cypress@*:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.8.0.tgz#8fe731db77f39310511d83e81439d06ae3388554"
+  integrity sha512-Lsff8lF8pq6k/ioNua783tCsxGSLp6gqGXecdIfqCkqjYiOA53XKuEf1CaQJLUVs1dHSf49eDUp/sb620oJjVQ==
+  dependencies:
+    "@cypress/listr-verbose-renderer" "0.4.1"
+    "@cypress/request" "2.88.5"
+    "@cypress/xvfb" "1.2.4"
+    "@types/sinonjs__fake-timers" "6.0.1"
+    "@types/sizzle" "2.3.2"
+    arch "2.1.1"
+    bluebird "3.7.2"
+    cachedir "2.3.0"
+    chalk "2.4.2"
+    check-more-types "2.24.0"
+    cli-table3 "0.5.1"
+    commander "4.1.0"
+    common-tags "1.8.0"
+    debug "4.1.1"
+    eventemitter2 "4.1.2"
+    execa "1.0.0"
+    executable "4.1.1"
+    extract-zip "1.7.0"
+    fs-extra "8.1.0"
+    getos "3.1.4"
+    is-ci "2.0.0"
+    is-installed-globally "0.1.0"
+    lazy-ass "1.6.0"
+    listr "0.14.3"
+    lodash "4.17.15"
+    log-symbols "3.0.0"
+    minimist "1.2.5"
+    moment "2.24.0"
+    ospath "1.2.2"
+    pretty-bytes "5.3.0"
+    ramda "0.26.1"
+    request-progress "3.0.0"
+    supports-color "7.1.0"
+    tmp "0.1.0"
+    untildify "4.0.0"
+    url "0.11.0"
+    yauzl "2.10.0"
+
 cypress@4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.7.0.tgz#3ea29bddaf9a1faeaa5b8d54b60a84ed1cafa83d"
@@ -7904,6 +7981,11 @@ dom-accessibility-api@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.4.tgz#c2f9fb8b591bc19581e7ef3e6fe35baf1967c498"
   integrity sha512-XBM62jdDc06IXSujkqw6BugEWiDkp6jphtzVJf1kgPQGvfzaU7/jRtRSF/mxc8DBCIm2LS3bN1dCa5Sfxx982A==
+
+dom-accessibility-api@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.5.tgz#d9c1cefa89f509d8cf132ab5d250004d755e76e3"
+  integrity sha512-HcPDilI95nKztbVikaN2vzwvmv0sE8Y2ZJFODy/m15n7mGXLeOKGiys9qWVbFbh+aq/KYj2lqMLybBOkYAEXqg==
 
 dom-converter@^0.2:
   version "0.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Add an await for auth in e2e test before clicking in the composer button.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
- Added Testing Library Cypress plugin
- Included a `wait` for `/pusher/auth` to make sure the page is loaded before clicking on the composer button

## Additional comments
The main reason why I added the Testing Library Cypress plugin, is because it makes it a lot easier to query elements in the DOM without the need to add additional tags in the elements we need to test (`data-cy`), and as we get more familiar with the queries from React Testing Library, we'll be able to easily use the same queries for our e2e tests without having to switch too much context.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
