### PR TITLE
[PUB-2881] Change date and color to social login retirement banner

### DIFF
--- a/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
+++ b/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
@@ -10,15 +10,21 @@ const getContainerStyle = hidden => ({
 });
 
 /* eslint-disable react/prop-types */
-const TopBanner = ({ status, content, onCloseBanner }) => (
+const TopBanner = ({
+  status,
+  content,
+  onCloseBanner,
+  themeColor = 'orange',
+}) => (
   <div style={getContainerStyle(status)}>
     <Banner
-      themeColor="orange"
+      themeColor={themeColor}
       customHTML={{ __html: content }}
       onCloseBanner={onCloseBanner}
     />
   </div>
 );
+
 /* eslint-enable react/prop-types */
 
 const TemporaryDashboardBanner = ({
@@ -50,11 +56,11 @@ const TemporaryDashboardBanner = ({
     return null;
   }
 
-  // Displays Temporary Banner with retiring social login message. We will want to remove after June 30th
+  // Displays Temporary Banner with retiring social login message. We will want to remove after July 7
 
   if (displayRetiringSocialLoginBanner) {
-    const retiringSocialLoginMessage = `We are retiring social login on June 30, 2020. Please 
-      <a href="https://login.buffer.com/forgot-password" style="color: rgb(44, 75, 255); text-decoration: none;">
+    const retiringSocialLoginMessage = `We are retiring social login on July 7, 2020. Please
+      <a href="https://login.buffer.com/forgot-password">
         set up a password to ensure continued access.
       </a>
     `;
@@ -62,6 +68,7 @@ const TemporaryDashboardBanner = ({
       status: hidden,
       content: retiringSocialLoginMessage,
       onCloseBanner: onCloseBannerClick,
+      themeColor: 'blue',
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Change the social login retirement banner date to July 7 (it's recently been pushed back)
- Change the color theme to blue

https://buffer.atlassian.net/browse/PUB-2881
<!--- Describe your changes in detail. -->

## Context & Notes
Screenshot: https://share.buffer.com/rRul1GEB
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
