### PR TITLE
[PUB-2879] Disable Posting Groups functionality for users without any posting groups

### DIFF
--- a/packages/composer/composer/components/ProfileSection.jsx
+++ b/packages/composer/composer/components/ProfileSection.jsx
@@ -51,6 +51,7 @@ class ProfileSection extends React.Component {
       .filter(profile => profile.isSelected)
       .map(profile => profile.id);
     const hasNoProfilesSelected = selectedProfilesIds.length === 0;
+    const hasProfileGroups = profileGroups?.length > 0;
 
     const profilesTogglerClassName = [
       styles.profilesToggler,
@@ -70,13 +71,15 @@ class ProfileSection extends React.Component {
           </Button>
         )}
 
-        {shouldBeConsideredBusinessUser && hasEnoughProfiles && (
-          <ProfileGroups
-            groups={profileGroups}
-            selectedProfilesIds={selectedProfilesIds}
-            onNewPublish={onNewPublish}
-          />
-        )}
+        {shouldBeConsideredBusinessUser &&
+          hasEnoughProfiles &&
+          hasProfileGroups && (
+            <ProfileGroups
+              groups={profileGroups}
+              selectedProfilesIds={selectedProfilesIds}
+              onNewPublish={onNewPublish}
+            />
+          )}
 
         <div className={styles.profilesContainer}>
           <ul


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Disable Posting Groups functionality for users without any posting groups
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2879
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
After this PR: user with > 9 social accounts and no posting groups doesn't see the option:
<img width="937" alt="Screenshot 2020-07-01 at 14 45 09" src="https://user-images.githubusercontent.com/16758464/86251211-7b41d300-bba9-11ea-8c62-5529ca1694f4.png">
Before this PR: user with > 9 social accounts and no posting groups sees the option:
<img width="775" alt="Screenshot 2020-07-01 at 14 45 40" src="https://user-images.githubusercontent.com/16758464/86251285-9280c080-bba9-11ea-9860-090b9008071e.png">
Remains the same: user with > 9 social accounts and with posting groups sees the option. Users with <9 social accounts don't see the option.
<img width="1034" alt="Screenshot 2020-07-01 at 14 46 19" src="https://user-images.githubusercontent.com/16758464/86251350-aa584480-bba9-11ea-88a7-7dc64f3617ad.png">



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
