### PR TITLE
[PUB-2775] Fetch campaigns related to their current global org id

### DIFF
--- a/packages/campaigns-list/middleware.test.js
+++ b/packages/campaigns-list/middleware.test.js
@@ -6,7 +6,10 @@ import { actionTypes, initialState } from './reducer';
 
 describe('middleware', () => {
   const next = jest.fn();
-
+  const orgSelectedAction = {
+    type: orgActionTypes.ORGANIZATION_SELECTED,
+    selected: { globalOrgId: '123' },
+  };
   it('exports middleware', () => {
     expect(middleware).toBeDefined();
   });
@@ -19,12 +22,8 @@ describe('middleware', () => {
         user: { features: ['campaigns', 'org_switcher'] },
       }),
     };
-    const action = {
-      type: orgActionTypes.ORGANIZATION_SELECTED,
-      selected: { globalOrgId: '123' },
-    };
-    middleware(store)(next)(action);
-    expect(next).toBeCalledWith(action);
+    middleware(store)(next)(orgSelectedAction);
+    expect(next).toBeCalledWith(orgSelectedAction);
     expect(store.dispatch).toBeCalledWith(
       dataFetchActions.fetch({
         name: 'getCampaignsList',
@@ -41,12 +40,8 @@ describe('middleware', () => {
         user: { features: ['campaigns'] },
       }),
     };
-    const action = {
-      type: orgActionTypes.ORGANIZATION_SELECTED,
-      selected: { globalOrgId: '123' },
-    };
-    middleware(store)(next)(action);
-    expect(next).toBeCalledWith(action);
+    middleware(store)(next)(orgSelectedAction);
+    expect(next).toBeCalledWith(orgSelectedAction);
     expect(store.dispatch).not.toBeCalledWith(
       dataFetchActions.fetch({
         name: 'getCampaignsList',

--- a/packages/campaigns-list/middleware.test.js
+++ b/packages/campaigns-list/middleware.test.js
@@ -71,6 +71,26 @@ describe('middleware', () => {
       })
     );
   });
+  it('does not fetch campaigns if user has org switcher feature', () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        campaignsList: { ...initialState, campaigns: [] },
+        user: { features: ['campaigns', 'org_switcher'] },
+      }),
+    };
+    const action = {
+      type: actionTypes.FETCH_CAMPAIGNS_IF_NEEDED,
+    };
+    middleware(store)(next)(action);
+    expect(next).toBeCalledWith(action);
+    expect(store.dispatch).not.toBeCalledWith(
+      dataFetchActions.fetch({
+        name: 'getCampaignsList',
+        args: {},
+      })
+    );
+  });
   it('triggers a notification if there is an error fetching campaigns', () => {
     const store = {
       dispatch: jest.fn(),

--- a/packages/server/rpc/campaigns/getCampaignsList/index.js
+++ b/packages/server/rpc/campaigns/getCampaignsList/index.js
@@ -4,11 +4,11 @@ const { method } = require('@bufferapp/buffer-rpc');
 module.exports = method(
   'getCampaignsList',
   'gets a list of campaigns, given the global organization id',
-  (__, { session }, res, { PublishAPI, parsers }) =>
+  ({ globalOrgId }, { session }, res, { PublishAPI, parsers }) =>
     PublishAPI.get({
       uri: `/1/campaigns.json`,
       session,
-      params: {},
+      params: { global_organization_id: globalOrgId },
     })
       .then(response => response.data.map(parsers.campaignParser))
       .catch(PublishAPI.errorHandler)

--- a/packages/server/rpc/campaigns/getCampaignsList/index.test.js
+++ b/packages/server/rpc/campaigns/getCampaignsList/index.test.js
@@ -10,7 +10,7 @@ const session = {
 
 const PublishAPI = { get: jest.fn() };
 const geCampaignsList = () =>
-  RPCEndpoint.fn(null, { session }, null, {
+  RPCEndpoint.fn({ globalOrgId: 123 }, { session }, null, {
     PublishAPI,
     parsers,
   });

--- a/packages/server/rpc/campaigns/getCampaignsList/index.test.js
+++ b/packages/server/rpc/campaigns/getCampaignsList/index.test.js
@@ -10,7 +10,7 @@ const session = {
 
 const PublishAPI = { get: jest.fn() };
 const geCampaignsList = () =>
-  RPCEndpoint.fn({ globalOrgId: 123 }, { session }, null, {
+  RPCEndpoint.fn({ globalOrgId: '123' }, { session }, null, {
     PublishAPI,
     parsers,
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Only allow a user to see the campaigns related to their global org id. 
https://buffer.atlassian.net/browse/PUB-2775

<!--- Describe your changes in detail. -->

## Context & Notes
Originally, the intent was to create a new campaigns endpoint that filtered by publish org id instead of global org id. However, when working on the endpoint, I realized that since we're only storing the globalId for campaigns, it would be difficult to try to filter it by publish org id.

I instead decided to grab the global org id from the current organization in the front end, and pass it to the backend as a param. Now it should filter based on the global org id that's associated with the current publish organization selected.  
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
https://share.buffer.com/KouB1qBB
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
