### PR TITLE
[PUB-2805] Hide social shortcuts for non admin users

### DIFF
--- a/packages/profile-sidebar/components/ProfileSidebar/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/index.jsx
@@ -96,6 +96,7 @@ const ProfileSidebar = ({
   onSearchProfileChange,
   isSearchPopupVisible,
   // Flags for showing connection shortcut buttons
+  hideSocialShortcuts,
   hasInstagram,
   hasFacebook,
   hasTwitter,
@@ -147,54 +148,56 @@ const ProfileSidebar = ({
         </ProfileListStyle>
       )}
       <ManageSocialAccountsStyle>
-        <SocialButtonsWrapperStyle>
-          {!hasInstagram && (
-            <ProfileConnectShortcut
-              label={t('profile-sidebar.connectInstagram')}
-              network="instagram"
-              url="https://buffer.com/oauth/instagram?cta=publish-app-sidebar-addProfile-1"
-              profileLimit={profileLimit}
-              profiles={profiles}
-              showSwitchPlanModal={showSwitchPlanModal}
-              goToConnectSocialAccount={goToConnectSocialAccount}
-            />
-          )}
-          {!hasFacebook && (
-            <ProfileConnectShortcut
-              label={t('profile-sidebar.connectFacebook')}
-              network="facebook"
-              url="https://buffer.com/oauth/facebook/choose?cta=publish-app-sidebar-addProfile-1"
-              profileLimit={profileLimit}
-              profiles={profiles}
-              showSwitchPlanModal={showSwitchPlanModal}
-              goToConnectSocialAccount={goToConnectSocialAccount}
-            />
-          )}
-          {!hasTwitter && (
-            <ProfileConnectShortcut
-              label={t('profile-sidebar.connectTwitter')}
-              network="twitter"
-              url="https://buffer.com/oauth/twitter?cta=publish-app-sidebar-addProfile-1"
-              profileLimit={profileLimit}
-              profiles={profiles}
-              showSwitchPlanModal={showSwitchPlanModal}
-              goToConnectSocialAccount={goToConnectSocialAccount}
-            />
-          )}
-          <BottomSectionStyle>
-            <ButtonDividerStyle>
-              <Divider marginTop="1rem" />
-            </ButtonDividerStyle>
-            <Button
-              label={t('profile-sidebar.connectButton')}
-              type="secondary"
-              fullWidth
-              onClick={() => {
-                onManageSocialAccountClick();
-              }}
-            />
-          </BottomSectionStyle>
-        </SocialButtonsWrapperStyle>
+        {!hideSocialShortcuts && (
+          <SocialButtonsWrapperStyle>
+            {!hasInstagram && (
+              <ProfileConnectShortcut
+                label={t('profile-sidebar.connectInstagram')}
+                network="instagram"
+                url="https://buffer.com/oauth/instagram?cta=publish-app-sidebar-addProfile-1"
+                profileLimit={profileLimit}
+                profiles={profiles}
+                showSwitchPlanModal={showSwitchPlanModal}
+                goToConnectSocialAccount={goToConnectSocialAccount}
+              />
+            )}
+            {!hasFacebook && (
+              <ProfileConnectShortcut
+                label={t('profile-sidebar.connectFacebook')}
+                network="facebook"
+                url="https://buffer.com/oauth/facebook/choose?cta=publish-app-sidebar-addProfile-1"
+                profileLimit={profileLimit}
+                profiles={profiles}
+                showSwitchPlanModal={showSwitchPlanModal}
+                goToConnectSocialAccount={goToConnectSocialAccount}
+              />
+            )}
+            {!hasTwitter && (
+              <ProfileConnectShortcut
+                label={t('profile-sidebar.connectTwitter')}
+                network="twitter"
+                url="https://buffer.com/oauth/twitter?cta=publish-app-sidebar-addProfile-1"
+                profileLimit={profileLimit}
+                profiles={profiles}
+                showSwitchPlanModal={showSwitchPlanModal}
+                goToConnectSocialAccount={goToConnectSocialAccount}
+              />
+            )}
+            <BottomSectionStyle>
+              <ButtonDividerStyle>
+                <Divider marginTop="1rem" />
+              </ButtonDividerStyle>
+              <Button
+                label={t('profile-sidebar.connectButton')}
+                type="secondary"
+                fullWidth
+                onClick={() => {
+                  onManageSocialAccountClick();
+                }}
+              />
+            </BottomSectionStyle>
+          </SocialButtonsWrapperStyle>
+        )}
       </ManageSocialAccountsStyle>
     </ProfileSidebarStyle>
   );
@@ -214,6 +217,7 @@ ProfileSidebar.propTypes = {
   hasFacebook: PropTypes.bool.isRequired,
   hasTwitter: PropTypes.bool.isRequired,
   onSearchProfileChange: () => {},
+  hideSocialShortcuts: PropTypes.bool,
   isSearchPopupVisible: PropTypes.bool,
   hasCampaignsFlip: PropTypes.bool,
   isCampaignsSelected: PropTypes.bool,
@@ -230,6 +234,7 @@ ProfileSidebar.defaultProps = {
   onDropProfile: () => {},
   onCampaignsButtonClick: () => {},
   profileLimit: 0,
+  hideSocialShortcuts: false,
   hasCampaignsFlip: false,
   isCampaignsSelected: false,
 };

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -26,6 +26,9 @@ export default hot(
         hasTwitter: state.profileSidebar.hasTwitter,
         isSearchPopupVisible: state.profileSidebar.isSearchPopupVisible,
         hasCampaignsFlip: state.user.features?.includes('campaigns') ?? false,
+        hideSocialShortcuts:
+          state.user.features?.includes('orgSwitcher') &&
+          !state.organizations?.selected?.isAdmin,
         isCampaignsSelected: !!getMatch({
           pathname: state.router?.location?.pathname,
           route: campaignsPage.route,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Hide Profile Sidebar Social Account Shortcuts for users who are not org admin.
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2805
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
