### PR TITLE
[PUB-2895] Replace user data

### DIFF
--- a/packages/analytics/index.js
+++ b/packages/analytics/index.js
@@ -1,7 +1,4 @@
 import { connect } from 'react-redux';
-import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
-
-import { actions as settingsAction } from '@bufferapp/publish-general-settings';
 import Analytics from './components/Analytics';
 
 const mapStateToProps = state => ({
@@ -11,15 +8,14 @@ const mapStateToProps = state => ({
   isInstagramBusiness: state.profileSidebar.selectedProfile.isInstagramBusiness,
   isAnalyticsSupported:
     state.profileSidebar.selectedProfile.isAnalyticsSupported,
-  //  TODO: Refactor so we're not pulling this state from drafts
-  canStartBusinessTrial: state.drafts.canStartBusinessTrial,
+  canStartBusinessTrial: state.user.canStartBusinessTrial,
   linkShortening: state.generalSettings.linkShortening,
   hasBitlyPosts: !!state.sent.byProfileId[
     state.profileSidebar.selectedProfile.id
   ]?.hasBitlyPosts,
 });
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   /**
    * We pass down these methods so that when the lazy-loaded `AnalyticsList`
    * is mounted it can setup its stores / trigger fetches / etc.

--- a/packages/app-shell/index.js
+++ b/packages/app-shell/index.js
@@ -12,24 +12,28 @@ import AppShell from './components/AppShell';
 
 export default connect(
   state => ({
-    user: state.appShell.user,
+    user: {
+      email: state.user.email,
+      name: state.user.name,
+    },
     bannerOptions: state.appShell.bannerOptions,
     bannerKey: state.appShell.bannerKey,
-    showReturnToClassic: state.appShell.showReturnToClassic,
-    showSwitchPlan: state.appShell.showSwitchPlan,
-    showManageTeam: state.appShell.showManageTeam,
-    showStartProTrial: state.appShell.showStartProTrial,
+    showReturnToClassic: state.user.showReturnToClassic,
+    showSwitchPlan: state.user.is_free_user && !state.user.isBusinessTeamMember,
+    showManageTeam: state.user.is_free_user,
+    showStartProTrial:
+      state.user.canStartProTrial && !state.user.isBusinessTeamMember,
     hideAppShell:
       state.onboarding.canSeeOnboardingPage &&
       state.router.location.pathname === newBusinessTrialists.route,
-    hideMenuItems: state.appShell.hideMenuItems,
+    hideMenuItems: state.user.canSeePaydayPage && state.user.isOnAwesomePlan,
     enabledProducts: state.appShell.enabledProducts,
     featureFlips: state.appShell.featureFlips,
     /**
      * Org Switcher
      * Needs organizations and profiles.
      */
-    hasOrgSwitcherFeature: state.appShell.hasOrgSwitcherFeature,
+    hasOrgSwitcherFeature: state.user.hasOrgSwitcherFeature,
     organizations: state.organizations.list,
     selectedOrganizationId: state.organizations.selected?.id,
     profiles: state.publishProfiles,

--- a/packages/app-shell/index.js
+++ b/packages/app-shell/index.js
@@ -20,7 +20,7 @@ export default connect(
     bannerKey: state.appShell.bannerKey,
     showReturnToClassic: state.user.showReturnToClassic,
     showSwitchPlan: state.user.is_free_user && !state.user.isBusinessTeamMember,
-    showManageTeam: state.user.is_free_user,
+    showManageTeam: !state.user.is_free_user,
     showStartProTrial:
       state.user.canStartProTrial && !state.user.isBusinessTeamMember,
     hideAppShell:

--- a/packages/app-shell/reducer.js
+++ b/packages/app-shell/reducer.js
@@ -7,14 +7,6 @@ export const actionTypes = keyWrapper('APP_SHELL', {
 });
 
 export const initialState = {
-  showReturnToClassic: false,
-  showSwitchPlanModal: false,
-  hasOrgSwitcherFeature: false,
-  user: {
-    name: '...',
-    email: '',
-    avatar: null,
-  },
   bannerKey: null,
   bannerOptions: undefined,
   enabledProducts: [],
@@ -24,23 +16,6 @@ export const initialState = {
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
-      return {
-        ...state,
-        user: {
-          email: action.result.email,
-          name: action.result.name,
-        },
-        hideMenuItems:
-          action.result.canSeePaydayPage && action.result.isOnAwesomePlan,
-        showReturnToClassic: action.result.showReturnToClassic,
-        showSwitchPlanModal:
-          action.result.is_free_user && !action.result.isBusinessTeamMember,
-        showManageTeam: !action.result.is_free_user,
-        showStartProTrial:
-          action.result.canStartProTrial && !action.result.isBusinessTeamMember,
-        hasOrgSwitcherFeature: action.result.hasOrgSwitcherFeature,
-      };
     case `globalAccount_${dataFetchActionTypes.FETCH_SUCCESS}`: {
       const productLinks = action.result.productlinks || [];
       const enabledProducts = productLinks.map(product => product.productName);

--- a/packages/app-shell/reducer.test.js
+++ b/packages/app-shell/reducer.test.js
@@ -8,57 +8,6 @@ describe('reducer', () => {
     expect(reducer(undefined, action)).toEqual(initialState);
   });
 
-  it('should set showReturnToClassic when the user is loaded', () => {
-    const action = {
-      type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
-      result: { showReturnToClassic: true },
-    };
-    expect(reducer(undefined, action).showReturnToClassic).toBe(true);
-  });
-
-  it('should set showStartProTrial to true for users with canStartProTrial set to true that are not team members', () => {
-    const action = {
-      type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
-      result: { canStartProTrial: true, isBusinessTeamMember: false },
-    };
-    expect(reducer(undefined, action).showStartProTrial).toBe(true);
-  });
-
-  it('should set showStartProTrial to false for users with canStartProTrial set to true that are team members', () => {
-    const action = {
-      type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
-      result: { canStartProTrial: true, isBusinessTeamMember: true },
-    };
-    expect(reducer(undefined, action).showStartProTrial).toBe(false);
-  });
-
-  it('should set showSwitchPlanModal to true for free users', () => {
-    const action = {
-      type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
-      result: { is_free_user: true, isBusinessTeamMember: false },
-    };
-    expect(reducer(undefined, action).showSwitchPlanModal).toBe(true);
-  });
-
-  it('should set showSwitchPlanModal to false for free users that are business team members', () => {
-    const action = {
-      type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
-      result: { is_free_user: true, isBusinessTeamMember: true },
-    };
-    expect(reducer(undefined, action).showSwitchPlanModal).toBe(false);
-  });
-
-  it('should collect the user data when the user is loaded', () => {
-    const action = {
-      type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
-      result: { email: 'foo@wow.com', name: 'Carlton', ignoredData: 'foobar' },
-    };
-    expect(reducer(undefined, action).user).toEqual({
-      email: 'foo@wow.com',
-      name: 'Carlton',
-    });
-  });
-
   it('should set isImpersonation to true during an impersonation session', () => {
     const action = {
       type: `globalAccount_${dataFetchActionTypes.FETCH_SUCCESS}`,

--- a/packages/cta-banner/index.js
+++ b/packages/cta-banner/index.js
@@ -7,7 +7,7 @@ export default connect(
   state => ({
     trial: state.user?.trial,
     isPremiumBusinessPlan: state.user.plan === 'premium_business',
-    profileCount: state.ctaBanner.profileCount,
+    profileCount: state.user.profileCount,
   }),
   dispatch => ({
     onClickStartSubscription: () => {

--- a/packages/cta-banner/index.test.js
+++ b/packages/cta-banner/index.test.js
@@ -23,9 +23,7 @@ describe('CtaBanner', () => {
             onTrial: true, // user has to be on a trial for the Banner to be displayed
           },
           plan: 'premium_business',
-        },
-        ctaBanner: {
-          profileCount: 1,
+          profileCount: 3,
         },
         productFeatures: {
           planName: 'business',

--- a/packages/cta-banner/reducer.js
+++ b/packages/cta-banner/reducer.js
@@ -1,22 +1,13 @@
 import keyWrapper from '@bufferapp/keywrapper';
 
-import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
-
 export const actionTypes = keyWrapper('CTA_BANNER', {
   START_SUBSCRIPTION: 0,
 });
 
-export const initialState = {
-  profileCount: 0,
-};
+export const initialState = {};
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
-      return {
-        ...state,
-        profileCount: action.result.profileCount,
-      };
     default:
       return state;
   }

--- a/packages/cta-banner/reducer.test.js
+++ b/packages/cta-banner/reducer.test.js
@@ -15,28 +15,6 @@ describe('reducer', () => {
     expect(reducer(undefined, action)).toEqual(initialState);
   });
 
-  it('handles user_FETCH_SUCCESS action type and updates profileCount', () => {
-    const stateBefore = {
-      ...initialState,
-      profileCount: 0,
-    };
-    const stateAfter = {
-      ...initialState,
-      profileCount: 2,
-    };
-    const action = {
-      type: 'user_FETCH_SUCCESS',
-      result: {
-        profileCount: 2,
-      },
-    };
-
-    deepFreeze(stateBefore);
-    deepFreeze(action);
-
-    expect(reducer(stateBefore, action)).toEqual(stateAfter);
-  });
-
   // Test action creators:
   describe('action creators', () => {
     it('creates a START_SUBSCRIPTION action', () => {

--- a/packages/drafts/index.js
+++ b/packages/drafts/index.js
@@ -142,8 +142,9 @@ export default connect(
         isLockedProfile: state.profileSidebar.isLockedProfile,
         isDisconnectedProfile:
           state.profileSidebar.selectedProfile.isDisconnected,
-        canStartBusinessTrial: state.drafts.canStartBusinessTrial,
-        hasFirstCommentFlip: state.user.features?.includes('first_comment') ?? false,
+        canStartBusinessTrial: state.user.canStartBusinessTrial ?? true,
+        hasFirstCommentFlip:
+          state.user.features?.includes('first_comment') ?? false,
       };
     }
     return {};

--- a/packages/drafts/reducer.js
+++ b/packages/drafts/reducer.js
@@ -22,7 +22,6 @@ export const initialState = {
   editMode: false,
   editingPostId: '',
   draftMode: true,
-  canStartBusinessTrial: true,
 };
 
 const profileInitialState = {
@@ -182,12 +181,6 @@ const profileReducer = (state = profileInitialState, action) => {
 export default (state = initialState, action) => {
   let profileId;
   switch (action.type) {
-    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`: {
-      return {
-        ...state,
-        canStartBusinessTrial: action.result.canStartBusinessTrial,
-      };
-    }
     case profileSidebarActionTypes.SELECT_PROFILE:
     case `draftPosts_${dataFetchActionTypes.FETCH_START}`:
     case `draftPosts_${dataFetchActionTypes.FETCH_SUCCESS}`:

--- a/packages/ig-first-comment-pro-trial-modal/middleware.js
+++ b/packages/ig-first-comment-pro-trial-modal/middleware.js
@@ -3,7 +3,7 @@ import { actions as modalActions } from '@bufferapp/publish-modals/reducer';
 import { actions as trialActions } from '@bufferapp/publish-trial/reducer';
 import { actionTypes } from './reducer';
 
-export default ({ dispatch, getState }) => next => action => {
+export default ({ dispatch }) => next => action => {
   // eslint-disable-line
   next(action);
   switch (action.type) {
@@ -16,16 +16,11 @@ export default ({ dispatch, getState }) => next => action => {
       break;
     case `startTrial_${dataFetchActionTypes.FETCH_SUCCESS}`: {
       dispatch(modalActions.hideInstagramFirstCommentProTrialModal());
-      break;
-    }
-    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`: {
-      if (getState().trial.startedTrial) {
-        // focus instagram first comment text area after starting trial
-        const textareaElement = document.querySelector(
-          "[class^='Composer__expandedFirstComment']"
-        );
-        if (textareaElement) textareaElement.focus();
-      }
+      // focus instagram first comment text area after starting trial
+      const textareaElement = document.querySelector(
+        "[class^='Composer__expandedFirstComment']"
+      );
+      if (textareaElement) textareaElement.focus();
       break;
     }
     default:

--- a/packages/posting-schedule/index.js
+++ b/packages/posting-schedule/index.js
@@ -17,7 +17,7 @@ export default connect(
     items: state.postingSchedule.items,
     profileTimezoneCity: state.postingSchedule.profileTimezoneCity,
     hasTwentyFourHourTimeFormat:
-      state.postingSchedule.hasTwentyFourHourTimeFormat,
+      state.user.hasTwentyFourHourTimeFormat,
     clearTimezoneInput: state.postingSchedule.clearTimezoneInput,
     paused: state.postingSchedule.paused,
     showClearAllModal: state.postingSchedule.showClearAllModal,

--- a/packages/posting-schedule/index.js
+++ b/packages/posting-schedule/index.js
@@ -16,8 +16,7 @@ export default connect(
     mergedSchedules: state.postingSchedule.mergedSchedules,
     items: state.postingSchedule.items,
     profileTimezoneCity: state.postingSchedule.profileTimezoneCity,
-    hasTwentyFourHourTimeFormat:
-      state.user.hasTwentyFourHourTimeFormat,
+    hasTwentyFourHourTimeFormat: state.user.hasTwentyFourHourTimeFormat,
     clearTimezoneInput: state.postingSchedule.clearTimezoneInput,
     paused: state.postingSchedule.paused,
     showClearAllModal: state.postingSchedule.showClearAllModal,

--- a/packages/posting-schedule/index.test.jsx
+++ b/packages/posting-schedule/index.test.jsx
@@ -28,7 +28,6 @@ describe('PostingSchedule', () => {
         settingsHeader,
         days,
         profileTimezone: 'Europe/London',
-        hasTwentyFourHourTimeFormat: false,
         items: timezones,
       },
       i18n: {
@@ -38,6 +37,9 @@ describe('PostingSchedule', () => {
             loggedOut: 'Logged Out...',
           },
         },
+      },
+      user: {
+        hasTwentyFourHourTimeFormat: false,
       },
     });
     const wrapper = mount(

--- a/packages/posting-schedule/reducer.js
+++ b/packages/posting-schedule/reducer.js
@@ -45,7 +45,6 @@ const initialState = {
   mergedSchedules: [],
   items: [],
   profileTimezoneCity: '',
-  hasTwentyFourHourTimeFormat: false,
   clearTimezoneInput: false,
   paused: false,
   profileId: null,
@@ -113,11 +112,6 @@ export default (state = initialState, action) => {
         };
       }
       return state;
-    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
-      return {
-        ...state,
-        hasTwentyFourHourTimeFormat: action.result.hasTwentyFourHourTimeFormat,
-      };
     case `updateSchedule_${dataFetchActionTypes.FETCH_SUCCESS}`:
       mergedSchedules = mergeSchedules(
         action.result.schedules,

--- a/packages/user/reducer.js
+++ b/packages/user/reducer.js
@@ -1,4 +1,6 @@
-let userData =
+import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
+
+const userData =
   typeof window !== 'undefined' &&
   typeof window.bufferData !== 'undefined' &&
   typeof window.bufferData.user !== 'undefined' &&
@@ -6,6 +8,8 @@ let userData =
 
 module.exports = (state = userData || {}, action) => {
   switch (action.type) {
+    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      return action.result;
     default:
       return state;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
When the user data is only used in the UI component, I've stopped storing it in the component state and used state.user instead.

- Replace user data in app-shell
- Replace user data in cta-banner
- Replace user data in drafts
- Replace user data in ig-first-comment-pro-modal
- Add case to user reducer, to update user state when `user_${dataFetchActionTypes.FETCH_SUCCESS}` 
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2895
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
