### PR TITLE
[PUB-2878] Fix queue overlap when post is larger than 100vh

### DIFF
--- a/packages/shared-components/QueueItems/styles.js
+++ b/packages/shared-components/QueueItems/styles.js
@@ -8,7 +8,6 @@ export const PostWrapper = styled.div`
   display: flex;
   align-items: flex-start;
   margin-bottom: 8px;
-  max-height: 100vh;
   width: 100%;
   transition: all ${transitionAnimationTime} ${transitionAnimationType};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Fix long update in the queue of being overlapped by the time slots.
<!--- Describe your changes in detail. -->
https://buffer.atlassian.net/browse/PUB-2878
## Context & Notes
Issue: https://share.buffer.com/12uNgeoR
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
