### PR TITLE
[PUB-2905] Use user data in product features

### DIFF
--- a/packages/app-shell/index.js
+++ b/packages/app-shell/index.js
@@ -20,8 +20,8 @@ export default connect(
     bannerOptions: state.appShell.bannerOptions,
     bannerKey: state.appShell.bannerKey,
     showReturnToClassic: state.user.showReturnToClassic,
-    showSwitchPlan: state.user.is_free_user && !state.user.isBusinessTeamMember,
-    showManageTeam: !state.user.is_free_user,
+    showSwitchPlan: state.user.isFreeUser && !state.user.isBusinessTeamMember,
+    showManageTeam: !state.user.isFreeUser,
     showStartProTrial:
       state.user.canStartProTrial && !state.user.isBusinessTeamMember,
     hideAppShell:

--- a/packages/composer/composer/utils/DataImportUtils.js
+++ b/packages/composer/composer/utils/DataImportUtils.js
@@ -180,7 +180,7 @@ const DataImportUtils = {
           },
           uses24hTime: userData.hasTwentyFourHourTimeFormat,
           weekStartsMonday: userData.week_starts_monday,
-          isFreeUser: userData.is_free_user,
+          isFreeUser: userData.isFreeUser,
           isBusinessUser: userData.is_business_user,
           canStartProTrial: userData.canStartProTrial,
           shouldAlwaysSkipEmptyTextAlert: userData.skip_empty_text_alert,

--- a/packages/composer/composer/utils/DataImportUtils.js
+++ b/packages/composer/composer/utils/DataImportUtils.js
@@ -181,7 +181,7 @@ const DataImportUtils = {
           uses24hTime: userData.hasTwentyFourHourTimeFormat,
           weekStartsMonday: userData.week_starts_monday,
           isFreeUser: userData.isFreeUser,
-          isBusinessUser: userData.is_business_user,
+          isBusinessUser: userData.isBusinessUser,
           canStartProTrial: userData.canStartProTrial,
           shouldAlwaysSkipEmptyTextAlert: userData.skip_empty_text_alert,
           hasSimplifiedFreePlanUX: userData.has_simplified_free_plan_ux,

--- a/packages/composer/interfaces/buffer-publish.jsx
+++ b/packages/composer/interfaces/buffer-publish.jsx
@@ -157,7 +157,7 @@ ComposerWrapper.propTypes = {
     profile_groups: PropTypes.PropTypes.array,
     isFreeUser: PropTypes.bool.isRequired,
     skip_empty_text_alert: PropTypes.bool.isRequired,
-    is_business_user: PropTypes.bool.isRequired,
+    isBusinessUser: PropTypes.bool.isRequired,
     imageDimensionsKey: PropTypes.string.isRequired,
     has_simplified_free_plan_ux: PropTypes.bool.isRequired,
   }).isRequired,

--- a/packages/composer/interfaces/buffer-publish.jsx
+++ b/packages/composer/interfaces/buffer-publish.jsx
@@ -46,7 +46,7 @@ const ComposerWrapper = ({
   const saveButtons = getSaveButtons();
 
   // Add Share Next feature to all users except free.
-  const freeUser = userData.is_free_user && !userData.isBusinessTeamMember;
+  const freeUser = userData.isFreeUser && !userData.isBusinessTeamMember;
   if (!freeUser && !editMode && !draftMode && !emptySlotMode) {
     saveButtons.splice(2, 2, 'SHARE_NEXT', 'SCHEDULE_POST');
   }
@@ -155,7 +155,7 @@ ComposerWrapper.propTypes = {
     hasTwentyFourHourTimeFormat: PropTypes.bool.isRequired,
     week_starts_monday: PropTypes.bool.isRequired,
     profile_groups: PropTypes.PropTypes.array,
-    is_free_user: PropTypes.bool.isRequired,
+    isFreeUser: PropTypes.bool.isRequired,
     skip_empty_text_alert: PropTypes.bool.isRequired,
     is_business_user: PropTypes.bool.isRequired,
     imageDimensionsKey: PropTypes.string.isRequired,

--- a/packages/cta-banner/middleware.js
+++ b/packages/cta-banner/middleware.js
@@ -23,7 +23,7 @@ export default ({ getState, dispatch }) => next => action => {
             plan: 'small',
           })
         );
-      } else if (user && user.is_business_user) {
+      } else if (user && user.isBusinessUser) {
         openBillingWindow();
       } else {
         dispatch(

--- a/packages/grid/index.test.jsx
+++ b/packages/grid/index.test.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
-import Grid, {
-  reducer,
-  actions,
-  actionTypes,
-  middleware,
-} from './index';
+import Grid, { reducer, actions, actionTypes, middleware } from './index';
 import GridPosts from './components/GridPosts';
 
 const storeFake = state => ({
@@ -29,7 +24,7 @@ describe('Grid', () => {
         },
       },
       user: {
-        is_business_user: false,
+        isBusinessUser: false,
       },
       profileSidebar: {
         selectedProfile: {
@@ -40,32 +35,25 @@ describe('Grid', () => {
     });
     const wrapper = mount(
       <Provider store={store}>
-        <Grid
-          profileId="abc"
-        />
-      </Provider>,
+        <Grid profileId="abc" />
+      </Provider>
     );
-    expect(wrapper.find(GridPosts).length)
-      .toBe(1);
+    expect(wrapper.find(GridPosts).length).toBe(1);
   });
 
   it('should export reducer', () => {
-    expect(reducer)
-      .toBeDefined();
+    expect(reducer).toBeDefined();
   });
 
   it('should export actions', () => {
-    expect(actions)
-      .toBeDefined();
+    expect(actions).toBeDefined();
   });
 
   it('should export actionTypes', () => {
-    expect(actionTypes)
-      .toBeDefined();
+    expect(actionTypes).toBeDefined();
   });
 
   it('should export middleware', () => {
-    expect(middleware)
-      .toBeDefined();
+    expect(middleware).toBeDefined();
   });
 });

--- a/packages/product-features/reducer.js
+++ b/packages/product-features/reducer.js
@@ -1,5 +1,4 @@
 import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
-import { isSupportedPlan } from './utils';
 
 export const actionTypes = {};
 
@@ -7,7 +6,6 @@ const initialState = {
   loading: true,
   features: [],
   planName: 'free',
-  defaultPlan: 'free',
 };
 
 export default (state = initialState, action) => {
@@ -22,10 +20,14 @@ export default (state = initialState, action) => {
         ...state,
         loading: false,
         features: action.result.features,
-        planName: action.result.planName,
-        isFreeUser: isSupportedPlan('free', action.result.planName),
-        isProUser: isSupportedPlan('pro', action.result.planName),
-        isBusinessUser: isSupportedPlan('business', action.result.planName),
+      };
+    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
+      return {
+        ...state,
+        planName: action.result.planBase,
+        isFreeUser: action.result.isFreeUser,
+        isProUser: action.result.isProUser,
+        isBusinessUser: action.result.isBusinessUser,
       };
     default:
       return state;

--- a/packages/product-features/reducer.test.js
+++ b/packages/product-features/reducer.test.js
@@ -8,7 +8,6 @@ describe('reducer', () => {
       loading: true,
       features: [],
       planName: 'free',
-      defaultPlan: 'free',
     };
     const action = {
       type: 'INIT',
@@ -22,8 +21,6 @@ describe('reducer', () => {
         show_stuff: true,
         not_here: false,
       },
-      planName: 'pro',
-      defaultPlan: 'free',
     };
     const action = {
       type: `features_${dataFetchActionTypes.FETCH_SUCCESS}`,
@@ -32,11 +29,33 @@ describe('reducer', () => {
     const stateAfter = {
       ...features,
       loading: false,
-      isBusinessUser: false,
-      isFreeUser: false,
-      isProUser: true,
+      planName: 'free',
     };
     deepFreeze(action);
     expect(reducer(undefined, action)).toEqual(stateAfter);
+  });
+  it('saves user plan into state', () => {
+    const stateBefore = {
+      features: ['feature1'],
+    };
+    const userData = {
+      isFreeUser: false,
+      isProUser: true,
+      isBusinessUser: false,
+      planBase: 'pro',
+    };
+    const action = {
+      type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
+      result: userData,
+    };
+    const stateAfter = {
+      isFreeUser: false,
+      isProUser: true,
+      isBusinessUser: false,
+      planName: 'pro',
+      features: ['feature1'],
+    };
+    deepFreeze(action);
+    expect(reducer(stateBefore, action)).toEqual(stateAfter);
   });
 });

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -263,7 +263,7 @@ export default (state = initialState, action) => {
       return {
         ...state,
         userId: action.result.id,
-        isFreeUser: action.result.is_free_user,
+        isFreeUser: action.result.isFreeUser,
         isOrganizationSwitcherEnabled:
           action.result.features?.includes('org_switcher') ?? false,
       };

--- a/packages/profile-sidebar/reducer.test.js
+++ b/packages/profile-sidebar/reducer.test.js
@@ -183,7 +183,7 @@ describe('reducer', () => {
         type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
         result: {
           id: stateAfter.userId,
-          is_free_user: stateAfter.isFreeUser,
+          isFreeUser: stateAfter.isFreeUser,
           features: [],
         },
       };
@@ -206,7 +206,7 @@ describe('reducer', () => {
         type: `user_${dataFetchActionTypes.FETCH_SUCCESS}`,
         result: {
           id: stateAfter.userId,
-          is_free_user: stateAfter.isFreeUser,
+          isFreeUser: stateAfter.isFreeUser,
           features: ['org_switcher'],
         },
       };

--- a/packages/queue/middleware.test.js
+++ b/packages/queue/middleware.test.js
@@ -9,7 +9,7 @@ import middleware from './middleware';
 
 const getStateWithPaidUser = () => ({
   user: {
-    is_free_user: false,
+    isFreeUser: false,
   },
   profileSidebar: {
     selectedProfileId: 'id1',

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -14,7 +14,8 @@ module.exports = userData => ({
   plan: userData.plan,
   planCode: userData.plan_code,
   is_business_user: userData.plan_code >= 8 && userData.plan_code <= 19,
-  is_free_user: userData.plan === 'free',
+  is_free_user: userData.plan_code === 1,
+  isProUser: userData.plan_code === 5 || userData.plan_code === 6,
   messages: userData.messages || [],
   skip_empty_text_alert: userData.messages.includes(
     'remember_confirm_saving_modal'

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -12,6 +12,7 @@ module.exports = userData => ({
   hasTwentyFourHourTimeFormat: userData.twentyfour_hour_time,
   imageDimensionsKey: userData.imagedimensions_key,
   plan: userData.billing_plan_tier,
+  planBase: userData.billing_plan_base,
   planCode: userData.plan_code,
   isBusinessUser: userData.billing_plan_base === 'business',
   isFreeUser: userData.billing_plan_base === 'free',

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -11,11 +11,11 @@ module.exports = userData => ({
   tags: userData.tags,
   hasTwentyFourHourTimeFormat: userData.twentyfour_hour_time,
   imageDimensionsKey: userData.imagedimensions_key,
-  plan: userData.plan,
+  plan: userData.billing_plan_tier,
   planCode: userData.plan_code,
-  isBusinessUser: userData.plan_code >= 8 && userData.plan_code <= 19,
-  isFreeUser: userData.plan_code === 1,
-  isProUser: userData.plan_code === 5 || userData.plan_code === 6,
+  isBusinessUser: userData.billing_plan_base === 'business',
+  isFreeUser: userData.billing_plan_base === 'free',
+  isProUser: userData.billing_plan_base === 'pro',
   messages: userData.messages || [],
   skip_empty_text_alert: userData.messages.includes(
     'remember_confirm_saving_modal'
@@ -52,13 +52,12 @@ module.exports = userData => ({
   canStartProTrial: userData.can_start_pro_trial,
   shouldShowProTrialExpiredModal:
     hasProTrialExpired(userData.feature_trials) &&
-    userData.plan === 'free' &&
+    userData.billing_plan_base === 'free' &&
     !userData.has_cancelled,
   isOnBusinessTrial:
-    userData.plan_code >= 8 && userData.plan_code <= 19 && userData.on_trial,
+    userData.billing_plan_base === 'business' && userData.on_trial,
   shouldShowBusinessTrialExpiredModal:
-    userData.plan_code >= 8 &&
-    userData.plan_code <= 19 &&
+    userData.billing_plan_base === 'business' &&
     userData.on_trial &&
     userData.trial_expired &&
     !userData.trial_done,

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -13,7 +13,7 @@ module.exports = userData => ({
   imageDimensionsKey: userData.imagedimensions_key,
   plan: userData.plan,
   planCode: userData.plan_code,
-  is_business_user: userData.plan_code >= 8 && userData.plan_code <= 19,
+  isBusinessUser: userData.plan_code >= 8 && userData.plan_code <= 19,
   isFreeUser: userData.plan_code === 1,
   isProUser: userData.plan_code === 5 || userData.plan_code === 6,
   messages: userData.messages || [],

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -14,7 +14,7 @@ module.exports = userData => ({
   plan: userData.plan,
   planCode: userData.plan_code,
   is_business_user: userData.plan_code >= 8 && userData.plan_code <= 19,
-  is_free_user: userData.plan_code === 1,
+  isFreeUser: userData.plan_code === 1,
   isProUser: userData.plan_code === 5 || userData.plan_code === 6,
   messages: userData.messages || [],
   skip_empty_text_alert: userData.messages.includes(

--- a/packages/server/rpc/preferences/changeDateTimePreferences/test.js
+++ b/packages/server/rpc/preferences/changeDateTimePreferences/test.js
@@ -14,7 +14,7 @@ const mockUser = {
   features: [],
   experiments: [],
   messages: [],
-  plan: 'free',
+  billing_plan_base: 'free',
   email_notifications: [],
   feature_trials: [],
   tags: [],

--- a/packages/server/rpc/preferences/changeDateTimePreferences/test.js
+++ b/packages/server/rpc/preferences/changeDateTimePreferences/test.js
@@ -54,6 +54,6 @@ describe('rpc/changeDateTimePreferences', () => {
       },
       { session }
     );
-    expect(response.is_free_user).toBeTruthy();
+    expect(response.isFreeUser).toBeTruthy();
   });
 });

--- a/packages/stories/middleware.test.js
+++ b/packages/stories/middleware.test.js
@@ -4,7 +4,7 @@ import middleware from './middleware';
 
 const getStateWithPaidUser = () => ({
   user: {
-    is_free_user: false,
+    isFreeUser: false,
   },
 });
 

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -15,7 +15,7 @@ export default connect(
       state.user.trial?.onTrial &&
       !state.profileSidebar.selectedProfile.business,
     shouldShowUpgradeCta:
-      state.user.is_free_user && !state.user.isBusinessTeamMember,
+      state.user.isFreeUser && !state.user.isBusinessTeamMember,
     shouldShowUpgradeButton:
       state.user.plan === 'free' ||
       state.user.plan === 'pro' ||

--- a/packages/test/generate-data/index.js
+++ b/packages/test/generate-data/index.js
@@ -39,7 +39,7 @@ const buildUser = build('User', {
     plan: 'business',
     planCode: 11,
     is_business_user: true,
-    is_free_user: false,
+    isFreeUser: false,
     features: [
       'campaigns',
       'instagram',

--- a/packages/test/generate-data/index.js
+++ b/packages/test/generate-data/index.js
@@ -38,7 +38,7 @@ const buildUser = build('User', {
     email: fake(f => f.internet.email()),
     plan: 'business',
     planCode: 11,
-    is_business_user: true,
+    isBusinessUser: true,
     isFreeUser: false,
     features: [
       'campaigns',

--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -1,7 +1,4 @@
-import {
-  actionTypes as dataFetchActionTypes,
-  actions as dataFetchActions,
-} from '@bufferapp/async-data-fetch';
+import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import { actions as analyticsActions } from '@bufferapp/publish-analytics-middleware/actions';
 import {
   getPageNameFromPath,
@@ -62,7 +59,7 @@ export default ({ dispatch, getState }) => next => action => {
       break;
 
     case actionTypes.FULLSTORY:
-      if (!action.result.is_free_user) {
+      if (!action.result.isFreeUser) {
         if (window) {
           if (window.FS && window.FS.identify) {
             const { id } = action.result;

--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -95,7 +95,7 @@ export default ({ dispatch, getState }) => next => action => {
             trial,
             orgUserCount,
             profileCount,
-            is_business_user: isBusinessUser,
+            isBusinessUser,
             tags,
           } = action.result; // user
           if (shouldIdentifyWithAppcues({ isBusinessUser, plan, tags })) {

--- a/packages/thirdParty/middleware.test.js
+++ b/packages/thirdParty/middleware.test.js
@@ -22,7 +22,7 @@ const mockUser = {
   trial: {},
   orgUserCount: 2,
   profileCount: 3,
-  is_business_user: true,
+  isBusinessUser: true,
   tags: [],
 };
 

--- a/packages/thirdParty/middleware.test.js
+++ b/packages/thirdParty/middleware.test.js
@@ -34,7 +34,7 @@ const mockFreeUser = {
   trial: {},
   orgUserCount: 2,
   profileCount: 3,
-  is_free_user: true,
+  isFreeUser: true,
   tags: [],
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Use user data in product-features package
- Get user plan with userData.billing_plan_tier
- Get user planBase with userData.billing_plan_base

Extra:
- Replace `is_free_user` references by `isFreeUser`
- Replace `is_business_user` references by `isBusinessUser`

<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2905
The goal is to deprecate the features endpoint in a future task and get all the plans data from the same place.
After the org switcher rollout we plan on moving features to the backend, so we no longer need business logic props related to plans like isFreeUser, isProUser and isBusinessUser
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
