### PR TITLE
Fix temporary edge case

### DIFF
--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -11,7 +11,11 @@ module.exports = userData => ({
   tags: userData.tags,
   hasTwentyFourHourTimeFormat: userData.twentyfour_hour_time,
   imageDimensionsKey: userData.imagedimensions_key,
-  plan: userData.billing_plan_tier,
+  plan:
+    userData.billing_plan_tier === 'pro8' ||
+    userData.billing_plan_tier === 'pro15'
+      ? 'pro'
+      : userData.billing_plan_tier, // temporary, as we transition from userData.plan. Safe to delete the conditions once we remove the plan ==='pro' checks in the codebase .
   planBase: userData.billing_plan_base,
   planCode: userData.plan_code,
   isBusinessUser: userData.billing_plan_base === 'business',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- There was one case where userData.plan wasn't the same as userData.billing_plan_tier, which is in the pro plans.
The places where we check plan ==='pro' wouldn't work. I added this small tweak to make it work, once we are done with this tasks and proceed to move the business logic from the frontend this will be gone
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
