### PR TITLE
Move user features to parser

### DIFF
--- a/packages/app-pages/index.js
+++ b/packages/app-pages/index.js
@@ -15,7 +15,7 @@ export default connect(
     const selectedOrgId = state.organizations?.selected?.id;
     const currentPath = state.router.location?.pathname;
     const profiles = state.publishProfiles;
-    const hasOrgSwitcherFeature = state.user.features?.includes('org_switcher');
+    const { hasOrgSwitcherFeature } = state.user;
 
     // Verify if it is an org route and get id param
     const orgRouteParams = getParams({

--- a/packages/campaign-form/index.js
+++ b/packages/campaign-form/index.js
@@ -12,7 +12,7 @@ export default connect(
       editMode: ownProps.editMode,
       campaignId:
         ownProps?.match?.params?.id || state?.campaignForm?.campaignId,
-      hasCampaignsFlip: state.user.features?.includes('campaigns') ?? false,
+      hasCampaignsFlip: state.user.hasCampaignsFeature,
     };
   },
   (dispatch, ownProps) => ({

--- a/packages/campaign-form/index.test.js
+++ b/packages/campaign-form/index.test.js
@@ -31,7 +31,7 @@ const campaignForm = () => {
 };
 
 const initialState = {
-  user: { features: ['campaigns'] },
+  user: { hasCampaignsFeature: true },
 };
 
 describe('CampaignForm | user interaction', () => {

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -34,7 +34,7 @@ export default connect(
       hideSkeletonHeader: state.campaign.hideSkeletonHeader,
       campaignId: ownProps.match?.params?.id || state.campaign?.campaignId,
       page: state.campaign.page,
-      hasCampaignsFlip: state.user.features?.includes('campaigns') ?? false,
+      hasCampaignsFlip: state.user.hasCampaignsFeature,
     };
   },
 

--- a/packages/campaigns-list/index.js
+++ b/packages/campaigns-list/index.js
@@ -15,7 +15,7 @@ export default connect(
       campaigns: state.campaignsList.campaigns,
       showCampaignActions: !state.user.isUsingPublishAsTeamMember,
       isLoading: state.campaignsList.isLoading,
-      hasCampaignsFlip: state.user.features?.includes('campaigns') ?? false,
+      hasCampaignsFlip: state.user.hasCampaignsFeature,
     };
   },
   (dispatch, ownProps) => ({

--- a/packages/campaigns-list/middleware.js
+++ b/packages/campaigns-list/middleware.js
@@ -27,8 +27,7 @@ export default ({ dispatch, getState }) => next => action => {
     case actionTypes.FETCH_CAMPAIGNS_IF_NEEDED: {
       /* if a user enters a url directly, the campaign list will need to be fetched.
        campaign list should only be fetched once while in publish */
-      const { hasCampaignsFeature } = state.user;
-      const { hasOrgSwitcherFeature } = state.user;
+      const { hasCampaignsFeature, hasOrgSwitcherFeature } = state.user;
       const shouldFetchCampaigns =
         !hasOrgSwitcherFeature &&
         hasCampaignsFeature &&

--- a/packages/campaigns-list/middleware.js
+++ b/packages/campaigns-list/middleware.js
@@ -11,10 +11,7 @@ export default ({ dispatch, getState }) => next => action => {
   const state = getState();
   switch (action.type) {
     case orgActionTypes.ORGANIZATION_SELECTED: {
-      const hasCampaignsFeature = state.user.features?.includes('campaigns');
-      const hasOrgSwitcherFeature = state.user.features?.includes(
-        'org_switcher'
-      );
+      const { hasCampaignsFeature, hasOrgSwitcherFeature } = state.user;
       if (hasOrgSwitcherFeature && hasCampaignsFeature) {
         const { globalOrgId } = action.selected;
         dispatch(
@@ -30,10 +27,8 @@ export default ({ dispatch, getState }) => next => action => {
     case actionTypes.FETCH_CAMPAIGNS_IF_NEEDED: {
       /* if a user enters a url directly, the campaign list will need to be fetched.
        campaign list should only be fetched once while in publish */
-      const hasCampaignsFeature = state.user.features?.includes('campaigns');
-      const hasOrgSwitcherFeature = state.user.features?.includes(
-        'org_switcher'
-      );
+      const { hasCampaignsFeature } = state.user;
+      const { hasOrgSwitcherFeature } = state.user;
       const shouldFetchCampaigns =
         !hasOrgSwitcherFeature &&
         hasCampaignsFeature &&

--- a/packages/campaigns-list/middleware.test.js
+++ b/packages/campaigns-list/middleware.test.js
@@ -19,7 +19,7 @@ describe('middleware', () => {
       dispatch: jest.fn(),
       getState: () => ({
         campaignsList: initialState,
-        user: { features: ['campaigns', 'org_switcher'] },
+        user: { hasCampaignsFeature: true, hasOrgSwitcherFeature: true },
       }),
     };
     middleware(store)(next)(orgSelectedAction);
@@ -37,7 +37,7 @@ describe('middleware', () => {
       dispatch: jest.fn(),
       getState: () => ({
         campaignsList: initialState,
-        user: { features: ['campaigns'] },
+        user: { hasCampaignsFeature: true },
       }),
     };
     middleware(store)(next)(orgSelectedAction);
@@ -55,7 +55,7 @@ describe('middleware', () => {
       dispatch: jest.fn(),
       getState: () => ({
         campaignsList: initialState,
-        user: { features: ['campaigns'] },
+        user: { hasCampaignsFeature: true },
       }),
     };
     const action = {
@@ -96,7 +96,7 @@ describe('middleware', () => {
       dispatch: jest.fn(),
       getState: () => ({
         campaignsList: { ...initialState, campaigns: [] },
-        user: { features: ['campaigns'] },
+        user: { hasCampaignsFeature: true },
       }),
     };
     const action = {
@@ -116,7 +116,7 @@ describe('middleware', () => {
       dispatch: jest.fn(),
       getState: () => ({
         campaignsList: { ...initialState, campaigns: [] },
-        user: { features: ['campaigns', 'org_switcher'] },
+        user: { hasCampaignsFeature: true, hasOrgSwitcherFeature: true },
       }),
     };
     const action = {

--- a/packages/composer/composer/utils/DataImportUtils.js
+++ b/packages/composer/composer/utils/DataImportUtils.js
@@ -188,7 +188,7 @@ const DataImportUtils = {
           hasIGLocationTaggingFeature: userData.hasIGLocationTaggingFeature,
           hasIGDirectVideoFlip: userData.hasIGDirectVideoFlip,
           hasShopgridFlip: hasFeature(userData.features, 'grid_preview'),
-          hasCampaignsFlip: hasFeature(userData.features, 'campaigns'),
+          hasCampaignsFlip: userData.hasCampaignsFeature,
           isProAndUpOrTeamMember: userData.isProAndUpOrTeamMember,
           profileGroups: userData.profile_groups
             ? userData.profile_groups.map(group => ({

--- a/packages/drafts/index.js
+++ b/packages/drafts/index.js
@@ -143,8 +143,7 @@ export default connect(
         isDisconnectedProfile:
           state.profileSidebar.selectedProfile.isDisconnected,
         canStartBusinessTrial: state.user.canStartBusinessTrial ?? true,
-        hasFirstCommentFlip:
-          state.user.features?.includes('first_comment') ?? false,
+        hasFirstCommentFlip: state.user.hasFirstCommentFeature,
       };
     }
     return {};

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -25,9 +25,9 @@ export default hot(
         hasFacebook: state.profileSidebar.hasFacebook,
         hasTwitter: state.profileSidebar.hasTwitter,
         isSearchPopupVisible: state.profileSidebar.isSearchPopupVisible,
-        hasCampaignsFlip: state.user.features?.includes('campaigns') ?? false,
+        hasCampaignsFlip: state.user.hasCampaignsFeature,
         hideSocialShortcuts:
-          state.user.features?.includes('orgSwitcher') &&
+          state.user.hasOrgSwitcherFeature &&
           !state.organizations?.selected?.isAdmin,
         isCampaignsSelected: !!getMatch({
           pathname: state.router?.location?.pathname,

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -84,8 +84,7 @@ export default connect(
           state.profileSidebar.selectedProfile.isDisconnected,
         hasFirstCommentFlip:
           state.user.features?.includes('first_comment') ?? false,
-        hasCampaignsFeature:
-          state.user.features?.includes('campaigns') ?? false,
+        hasCampaignsFeature: state.user.hasCampaignsFeature,
       };
     }
     return {

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -82,8 +82,7 @@ export default connect(
         isInstagramLoading: state.queue.isInstagramLoading,
         isDisconnectedProfile:
           state.profileSidebar.selectedProfile.isDisconnected,
-        hasFirstCommentFlip:
-          state.user.features?.includes('first_comment') ?? false,
+        hasFirstCommentFlip: state.user.hasFirstCommentFeature,
         hasCampaignsFeature: state.user.hasCampaignsFeature,
       };
     }

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -45,8 +45,7 @@ export default connect(
         isDisconnectedProfile:
           state.profileSidebar.selectedProfile.isDisconnected,
         isAnalyzeCustomer: state.user.isAnalyzeCustomer,
-        hasFirstCommentFlip:
-          state.user.features?.includes('first_comment') ?? false,
+        hasFirstCommentFlip: state.user.hasFirstCommentFeature,
         hasCampaignsFeature: state.user.hasCampaignsFeature,
         linkShortening: state.generalSettings.linkShortening,
         hasBitlyPosts: currentProfile.hasBitlyPosts,

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -47,8 +47,7 @@ export default connect(
         isAnalyzeCustomer: state.user.isAnalyzeCustomer,
         hasFirstCommentFlip:
           state.user.features?.includes('first_comment') ?? false,
-        hasCampaignsFeature:
-          state.user.features?.includes('campaigns') ?? false,
+        hasCampaignsFeature: state.user.hasCampaignsFeature,
         linkShortening: state.generalSettings.linkShortening,
         hasBitlyPosts: currentProfile.hasBitlyPosts,
         shouldDisplayBitly: !state?.productFeatures?.isFreeUser,

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -93,4 +93,6 @@ module.exports = userData => ({
   isAnalyzeCustomer: userData.is_analyze_customer,
   isUsingPublishAsTeamMember: userData.is_using_publish_as_team_member,
   hasOrgSwitcherFeature: userData.features.includes('org_switcher'),
+  // Org features
+  hasCampaignsFeature: userData.features.includes('campaigns'),
 });

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -95,4 +95,5 @@ module.exports = userData => ({
   hasOrgSwitcherFeature: userData.features.includes('org_switcher'),
   // Org features
   hasCampaignsFeature: userData.features.includes('campaigns'),
+  hasFirstCommentFeature: userData.features.includes('first_comment'),
 });

--- a/packages/test/generate-data/index.js
+++ b/packages/test/generate-data/index.js
@@ -41,12 +41,12 @@ const buildUser = build('User', {
     isBusinessUser: true,
     isFreeUser: false,
     features: [
-      'campaigns',
       'instagram',
       'first_comment',
       'stories_groups',
       'twitter-march-18-changes',
     ],
+    hasCampaignsFeature: true,
     hasTwentyFourHourTimeFormat: false,
     isOnBusinessTrial: false,
     isProAndUpOrTeamMember: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Move campaigns and first comment feature references to parser

Since they are both for isProOrBusinessOrEnterpriseUserOrTeamMember, with the org switcher we'll need to override the team member option, and adjust the features to be displayed only for pro and up orgs
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
