### PR TITLE
Fix missing endpoint mock in AppPages test

### DIFF
--- a/packages/app-pages/index.test.js
+++ b/packages/app-pages/index.test.js
@@ -114,6 +114,21 @@ const draft = buildPostWithImage({
   },
 });
 
+const linkShorteners = [
+  {
+    domain: 'buff.ly',
+    login: null,
+    selected: true,
+    tracking: false,
+  },
+  {
+    domain: 'No Shortening',
+    login: null,
+    selected: false,
+    tracking: false,
+  },
+];
+
 const mockApiCalls = () => {
   jest.spyOn(RPCClient.prototype, 'call').mockImplementation(name => {
     const result = {
@@ -132,6 +147,7 @@ const mockApiCalls = () => {
       gridPosts: { total: 0, updates: [] },
       draftPosts: { total: 1, drafts: [draft] },
       getCampaign: campaign,
+      getLinkShortener: { linkShorteners },
       default: { fake: 'yes' },
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Fixes a small problem with the App Pages integration tests.

## Context & Notes
While running the tests locally I noticed there is an error, even though the tests aren't broken, there is a reducer (general-settings) that keeps on failing because is missing the mocked response.

## Screenshots
**This is the error thrown**
<img width="1210" alt="Image 2020-07-21 at 3 43 44 PM" src="https://user-images.githubusercontent.com/988972/88063453-54ecd300-cb6a-11ea-82d6-1c7d2e1d1ff9.png">

**This is where it's happening**
<img width="790" alt="Image 2020-07-21 at 3 45 54 PM" src="https://user-images.githubusercontent.com/988972/88063407-4acad480-cb6a-11ea-91ea-8393d91e9919.png">

**This is where we call the endpoint**
<img width="406" alt="Image 2020-07-21 at 4 01 07 PM" src="https://user-images.githubusercontent.com/988972/88064378-81551f00-cb6b-11ea-8738-9d0aa5fb0b80.png">

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
