### PR TITLE
[PUB-2904] Inject orgs data

### DIFF
--- a/packages/composer/composer/components/App.jsx
+++ b/packages/composer/composer/components/App.jsx
@@ -91,7 +91,7 @@ class App extends React.Component {
       weekStartsMonday: PropTypes.bool.isRequired,
       isFreeUser: PropTypes.bool.isRequired,
       hasCampaignsFlip: PropTypes.bool.isRequired,
-      isProAndUpOrTeamMember: PropTypes.bool.isRequired,
+      hasUserTagFeature: PropTypes.bool.isRequired,
       hasIGLocationTaggingFeature: PropTypes.bool.isRequired,
       hasIGDirectVideoFlip: PropTypes.bool.isRequired,
       isBusinessUser: PropTypes.bool.isRequired,
@@ -225,7 +225,7 @@ class App extends React.Component {
       canStartProTrial: false,
       hasIGDirectVideoFlip: false,
       hasCampaignsFlip: false,
-      isProAndUpOrTeamMember: false,
+      hasUserTagFeature: false,
     },
     options: {
       onSave: () => {},

--- a/packages/composer/composer/components/AppStateless.jsx
+++ b/packages/composer/composer/components/AppStateless.jsx
@@ -193,7 +193,7 @@ class AppStateless extends React.Component {
     });
 
     const shouldDisplayCampaignHeader =
-      userData?.hasCampaignsFlip && userData?.isProAndUpOrTeamMember && !draftMode;
+      userData?.hasCampaignsFlip && !draftMode;
     const campaignId = metaData.campaignDetails?.id ?? null;
     const campaigns = metaData.campaigns ?? [];
 
@@ -270,7 +270,7 @@ class AppStateless extends React.Component {
               userData.hasIGLocationTaggingFeature || false
             }
             hasIGDirectVideoFlip={userData.hasIGDirectVideoFlip || false}
-            isProAndUpOrTeamMember={userData.isProAndUpOrTeamMember || false}
+            hasUserTagFeature={userData.hasUserTagFeature || false}
             hasShopgridFlip={userData.hasShopgridFlip || false}
             hasCampaignsFlip={userData.hasCampaignsFlip || false}
             isFreeUser={userData.isFreeUser || false}

--- a/packages/composer/composer/components/Composer.jsx
+++ b/packages/composer/composer/components/Composer.jsx
@@ -167,7 +167,7 @@ class Composer extends React.Component {
     canStartProTrial: PropTypes.bool,
     hasIGDirectVideoFlip: PropTypes.bool,
     hasShopgridFlip: PropTypes.bool,
-    isProAndUpOrTeamMember: PropTypes.bool,
+    hasUserTagFeature: PropTypes.bool,
     isFreeUser: PropTypes.bool.isRequired,
     isBusinessUser: PropTypes.bool.isRequired,
     draftMode: PropTypes.bool,
@@ -179,7 +179,7 @@ class Composer extends React.Component {
     hasIGLocationTaggingFeature: false,
     canStartProTrial: false,
     hasIGDirectVideoFlip: false,
-    isProAndUpOrTeamMember: false,
+    hasUserTagFeature: false,
     hasShopgridFlip: false,
     profiles: [],
     expandedComposerId: null,
@@ -658,7 +658,7 @@ class Composer extends React.Component {
       composerPosition,
       hasIGLocationTaggingFeature,
       hasIGDirectVideoFlip,
-      isProAndUpOrTeamMember,
+      hasUserTagFeature,
       hasShopgridFlip,
       draftMode,
     } = this.props;
@@ -919,7 +919,7 @@ class Composer extends React.Component {
       draft.instagramFeedback.some(feedback => feedback.code === 'NOT_ENABLED');
 
     const canAddUserTag =
-      isProAndUpOrTeamMember &&
+      hasUserTagFeature &&
       this.isInstagram() &&
       selectedProfiles.some(profile => profile.instagramDirectEnabled) &&
       /* don't allow user to add tag if post is a reminder though its ok if more than one

--- a/packages/composer/composer/components/ComposerSection.jsx
+++ b/packages/composer/composer/components/ComposerSection.jsx
@@ -38,7 +38,7 @@ const ComposerComponent = ({
   canStartProTrial,
   hasIGDirectVideoFlip,
   hasShopgridFlip,
-  isProAndUpOrTeamMember,
+  hasUserTagFeature,
   isFreeUser,
   isBusinessUser,
   draftMode,
@@ -84,7 +84,7 @@ const ComposerComponent = ({
       canStartProTrial={canStartProTrial}
       hasIGDirectVideoFlip={hasIGDirectVideoFlip}
       hasShopgridFlip={hasShopgridFlip}
-      isProAndUpOrTeamMember={isProAndUpOrTeamMember}
+      hasUserTagFeature={hasUserTagFeature}
       isFreeUser={isFreeUser}
       isBusinessUser={isBusinessUser}
       draftMode={draftMode}
@@ -129,7 +129,7 @@ class ComposerSection extends React.Component {
       isBusinessUser,
       canStartProTrial,
       hasShopgridFlip,
-      isProAndUpOrTeamMember,
+      hasUserTagFeature,
       draftMode,
     } = this.props;
 
@@ -181,7 +181,7 @@ class ComposerSection extends React.Component {
               canStartProTrial,
               hasIGDirectVideoFlip,
               hasShopgridFlip,
-              isProAndUpOrTeamMember,
+              hasUserTagFeature,
               isFreeUser,
               isBusinessUser,
               draftMode,
@@ -213,7 +213,7 @@ class ComposerSection extends React.Component {
                 canStartProTrial,
                 hasIGDirectVideoFlip,
                 hasShopgridFlip,
-                isProAndUpOrTeamMember,
+                hasUserTagFeature,
                 isFreeUser,
                 isBusinessUser,
                 draftMode,
@@ -240,7 +240,7 @@ ComposerSection.propTypes = {
   hasIGDirectVideoFlip: PropTypes.bool.isRequired,
   isFreeUser: PropTypes.bool.isRequired,
   hasShopgridFlip: PropTypes.bool,
-  isProAndUpOrTeamMember: PropTypes.bool,
+  hasUserTagFeature: PropTypes.bool,
   isBusinessUser: PropTypes.bool,
   draftMode: PropTypes.bool,
 };
@@ -249,7 +249,7 @@ ComposerSection.defaultProps = {
   isOmniboxEnabled: null,
   composerPosition: null,
   hasShopgridFlip: false,
-  isProAndUpOrTeamMember: false,
+  hasUserTagFeature: false,
   isBusinessUser: false,
   draftMode: false,
 };

--- a/packages/composer/composer/stores/AppStore.js
+++ b/packages/composer/composer/stores/AppStore.js
@@ -163,7 +163,7 @@ const getNewUserData = data => ({
   canStartProTrial: data.canStartProTrial,
   hasShopgridFlip: data.hasShopgridFlip,
   hasCampaignsFlip: data.hasCampaignsFlip,
-  isProAndUpOrTeamMember: data.isProAndUpOrTeamMember,
+  hasUserTagFeature: data.hasUserTagFeature,
 });
 
 const getNewSubprofile = ({ avatar, id, name, isShared }) => ({

--- a/packages/composer/composer/utils/DataImportUtils.js
+++ b/packages/composer/composer/utils/DataImportUtils.js
@@ -189,7 +189,7 @@ const DataImportUtils = {
           hasIGDirectVideoFlip: userData.hasIGDirectVideoFlip,
           hasShopgridFlip: hasFeature(userData.features, 'grid_preview'),
           hasCampaignsFlip: userData.hasCampaignsFeature,
-          isProAndUpOrTeamMember: userData.isProAndUpOrTeamMember,
+          hasUserTagFeature: userData.hasUserTagFeature,
           profileGroups: userData.profile_groups
             ? userData.profile_groups.map(group => ({
                 name: group.name,

--- a/packages/composer/interfaces/buffer-publish.jsx
+++ b/packages/composer/interfaces/buffer-publish.jsx
@@ -82,15 +82,9 @@ const ComposerWrapper = ({
   const metaData = {
     application: 'WEB_DASHBOARD',
     environment: `${environment === 'development' ? 'local' : 'production'}`,
-    should_enable_fb_autocomplete:
-      userData.features &&
-      userData.features.includes('mc_facebook_autocomplete'),
-    enable_twitter_march_18_changes:
-      userData.features &&
-      userData.features.includes('twitter-march-18-changes'),
-    hasIGLocationTaggingFeature:
-      userData.features &&
-      userData.features.includes('instagram-location-tagging'),
+    should_enable_fb_autocomplete: true, // Deprecated features (to delete)
+    enable_twitter_march_18_changes: true, // Deprecated features (to delete)
+    hasIGLocationTaggingFeature: true, // Deprecated features (to delete)
     // TODO: make should_use_new_twitter_autocomplete dynamic based on the
     // value of enabledApplicationModes.includes('web-twitter-typeahead-autocomplete')
     should_use_new_twitter_autocomplete: true,

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -66,7 +66,6 @@ module.exports = userData => ({
         trialPlan: userData.trial_plan,
       },
   showReturnToClassic: userData.has_np_app_switcher,
-  isProAndUpOrTeamMember: userData.is_pro_and_up_org_user, // this includes team members
   hasOrgSwitcherFeature: userData.features.includes('org_switcher'),
 
   // Deprecated features (to delete)
@@ -77,9 +76,8 @@ module.exports = userData => ({
   // Org plan features
   hasCampaignsFeature: userData.features.includes('campaigns'),
   hasFirstCommentFeature: userData.features.includes('first_comment'),
-  hasShareNextFeature:
-    !userData.billing_plan_base === 'free' ||
-    (userData.billing_plan_base === 'free' && userData.is_business_team_member),
+  hasShareNextFeature: userData.is_pro_and_up_org_user,
+  hasUserTagFeature: userData.is_pro_and_up_org_user,
 
   // Org roles features
   canModifyCampaigns: !userData.is_using_publish_as_team_member,

--- a/packages/server/rpc/user/index.js
+++ b/packages/server/rpc/user/index.js
@@ -63,6 +63,7 @@ module.exports = method(
               canModifyCampaigns: isAdmin,
               showUpgradeToProCta: planBase === 'free' && ownerId === user.id,
               hasShareNextFeature: planBase !== 'free',
+              hasUserTagFeature: planBase !== 'free',
               analyzeCrossSale: user.analyzeCrossSale && ownerId === user.id, // to do: return organization products array
             };
           }

--- a/packages/test/generate-data/index.js
+++ b/packages/test/generate-data/index.js
@@ -49,7 +49,7 @@ const buildUser = build('User', {
     hasCampaignsFeature: true,
     hasTwentyFourHourTimeFormat: false,
     isOnBusinessTrial: false,
-    isProAndUpOrTeamMember: true,
+    hasUserTagFeature: true,
     hasIGDirectVideoFlip: true,
     canStartProTrial: true,
     canModifyCampaigns: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
 Inject orgs data in hasUserTag feature
<!--- Describe your changes in detail. -->

## Context & Notes
So far we've been checking if we display certain features based on pro or up and if user is team member. With the org switcher we will no longer care about team members, just the org plan.
https://buffer.atlassian.net/browse/PUB-2904
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
