### PR TITLE
[PUB-2947] Fix org switcher bug

### DIFF
--- a/packages/default-page/index.js
+++ b/packages/default-page/index.js
@@ -6,6 +6,5 @@ export default connect(state => ({
   orgName: state.organizations.selected?.name,
   ownerEmail: state.organizations.selected?.ownerEmail,
   showPermissionsEmptyPage:
-    state.user.features?.includes('org_switcher') &&
-    !state.organizations.selected?.isAdmin,
+    state.user.hasOrgSwitcherFeature && !state.organizations.selected?.isAdmin,
 }))(DefaultPage);

--- a/packages/default-page/index.test.js
+++ b/packages/default-page/index.test.js
@@ -19,7 +19,7 @@ describe('DefaultPage', () => {
             ownerEmail: 'ana@buffer.com',
           },
         },
-        user: { features: ['org_switcher'] },
+        user: { hasOrgSwitcherFeature: true, features: ['org_switcher'] },
       },
     });
     expect(screen.getByRole('heading')).toHaveTextContent(/joined Cool Org/i);

--- a/packages/profile-sidebar/reducer.js
+++ b/packages/profile-sidebar/reducer.js
@@ -264,8 +264,7 @@ export default (state = initialState, action) => {
         ...state,
         userId: action.result.id,
         isFreeUser: action.result.isFreeUser,
-        isOrganizationSwitcherEnabled:
-          action.result.features?.includes('org_switcher') ?? false,
+        isOrganizationSwitcherEnabled: action.result.hasOrgSwitcherFeature,
       };
     }
     default:

--- a/packages/profile-sidebar/reducer.test.js
+++ b/packages/profile-sidebar/reducer.test.js
@@ -184,7 +184,7 @@ describe('reducer', () => {
         result: {
           id: stateAfter.userId,
           isFreeUser: stateAfter.isFreeUser,
-          features: [],
+          hasOrgSwitcherFeature: false,
         },
       };
 
@@ -207,7 +207,7 @@ describe('reducer', () => {
         result: {
           id: stateAfter.userId,
           isFreeUser: stateAfter.isFreeUser,
-          features: ['org_switcher'],
+          hasOrgSwitcherFeature: true,
         },
       };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Fix bug for the org switcher. When we have the org switcher, we are getting the features from the selected org owner. 
However, rollout features should belong to the user only.
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2947
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
