### PR TITLE
Upgrading buffer-publish chart to 1.1.1

### DIFF
--- a/helm/buffer-publish.yaml
+++ b/helm/buffer-publish.yaml
@@ -4,7 +4,7 @@ namespace: buffer
 replicaCount: 10
 deploymentUrl: "publish.buffer.com"
 chart: "buffercharts/buffer-service"
-chartVersion: "1.0.3"
+chartVersion: "1.1.1"
 cdEnabled: true
 cdBranchEnabled: true
 dockerfile: Dockerfile


### PR DESCRIPTION
Upgraded the chart `buffer-service` used by `buffer-publish` from version 1.0.3 to 1.1.1