### PR TITLE
[PUB-2953] Fix filtered profiles in composer for org switcher

### DIFF
--- a/packages/drafts/components/DraftList/index.jsx
+++ b/packages/drafts/components/DraftList/index.jsx
@@ -59,6 +59,7 @@ const DraftList = ({
   canStartBusinessTrial,
   hasFirstCommentFlip,
   onComposerOverlayClick,
+  preserveComposerStateOnClose,
 }) => {
   if (features.isProUser()) {
     const startTrial = () =>
@@ -120,7 +121,7 @@ const DraftList = ({
                 <ComposerPopover
                   type="drafts"
                   onSave={onComposerCreateSuccess}
-                  preserveComposerStateOnClose
+                  preserveComposerStateOnClose={preserveComposerStateOnClose}
                   onComposerOverlayClick={onComposerOverlayClick}
                   editMode={editMode}
                 />
@@ -186,9 +187,11 @@ DraftList.propTypes = {
   isDisconnectedProfile: PropTypes.bool,
   hasFirstCommentFlip: PropTypes.bool,
   onComposerOverlayClick: PropTypes.func.isRequired,
+  preserveComposerStateOnClose: PropTypes.bool,
 };
 
 DraftList.defaultProps = {
+  preserveComposerStateOnClose: true,
   loading: true,
   postLists: [],
   showComposer: false,

--- a/packages/drafts/index.js
+++ b/packages/drafts/index.js
@@ -122,6 +122,7 @@ export default connect(
     const currentProfile = state.drafts.byProfileId[profileId];
     if (currentProfile) {
       return {
+        preserveComposerStateOnClose: state.drafts.preserveComposerStateOnClose,
         manager: state.profileSidebar.selectedProfile.isManager,
         drafts: currentProfile.drafts,
         postLists: formatPostLists(

--- a/packages/drafts/reducer.js
+++ b/packages/drafts/reducer.js
@@ -1,5 +1,6 @@
 import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import { actionTypes as profileSidebarActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
+import { actionTypes as orgActionTypes } from '@bufferapp/publish-data-organizations';
 import keyWrapper from '@bufferapp/keywrapper';
 
 export const actionTypes = keyWrapper('DRAFTS', {
@@ -204,6 +205,11 @@ export default (state = initialState, action) => {
         };
       }
       return state;
+    case orgActionTypes.ORGANIZATION_SELECTED:
+      return {
+        ...state,
+        preserveComposerStateOnClose: false,
+      };
     case actionTypes.OPEN_COMPOSER:
       return {
         ...state,
@@ -214,6 +220,7 @@ export default (state = initialState, action) => {
     case actionTypes.HIDE_COMPOSER:
       return {
         ...state,
+        preserveComposerStateOnClose: true,
         showComposer: false,
         editMode: false,
       };

--- a/packages/drafts/reducer.test.js
+++ b/packages/drafts/reducer.test.js
@@ -1,4 +1,5 @@
 import deepFreeze from 'deep-freeze';
+import { actionTypes as orgActionTypes } from '@bufferapp/publish-data-organizations';
 import reducer, { actions, initialState, actionTypes } from './reducer';
 
 const profileId = '123456';
@@ -415,6 +416,7 @@ describe('reducer', () => {
       },
       showComposer: true,
       editMode: true,
+      preserveComposerStateOnClose: false,
     };
     const stateAfter = {
       byProfileId: {
@@ -429,11 +431,29 @@ describe('reducer', () => {
       },
       showComposer: false,
       editMode: false,
+      preserveComposerStateOnClose: true,
     };
 
     const action = {
       type: actionTypes.HIDE_COMPOSER,
       profileId,
+    };
+
+    expect(reducer(stateBefore, action)).toEqual(stateAfter);
+  });
+
+  it('handles ORGANIZATION_SELECTED action type, sets preserveComposerStateOnClose to false to force the composer to refetch profiles on org switcher ', () => {
+    const stateBefore = {
+      ...initialState,
+      preserveComposerStateOnClose: true,
+    };
+    const stateAfter = {
+      ...initialState,
+      preserveComposerStateOnClose: false,
+    };
+
+    const action = {
+      type: orgActionTypes.ORGANIZATION_SELECTED,
     };
 
     expect(reducer(stateBefore, action)).toEqual(stateAfter);

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -72,6 +72,7 @@ const QueuedPosts = ({
   onCampaignTagClick,
   hasCampaignsFeature,
   fetchCampaignsIfNeeded,
+  preserveComposerStateOnClose,
 }) => {
   if (loading) {
     return (
@@ -112,7 +113,7 @@ const QueuedPosts = ({
             {showComposer && !editMode && (
               <ComposerPopover
                 onSave={onComposerCreateSuccess}
-                preserveComposerStateOnClose
+                preserveComposerStateOnClose={preserveComposerStateOnClose}
                 type="queue"
                 onComposerOverlayClick={onComposerOverlayClick}
                 editMode={editMode}
@@ -225,9 +226,11 @@ QueuedPosts.propTypes = {
   isBusinessAccount: PropTypes.bool,
   hasCampaignsFeature: PropTypes.bool,
   fetchCampaignsIfNeeded: PropTypes.func.isRequired,
+  preserveComposerStateOnClose: PropTypes.bool,
 };
 
 QueuedPosts.defaultProps = {
+  preserveComposerStateOnClose: true,
   loading: true,
   moreToLoad: false,
   page: 1,

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -44,6 +44,7 @@ export default connect(
     }
     if (queue && profileData) {
       return {
+        preserveComposerStateOnClose: queue.preserveComposerStateOnClose,
         loading: queue.loading,
         loadingMore: queue.loadingMore,
         moreToLoad: queue.moreToLoad,

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -44,7 +44,7 @@ export default connect(
     }
     if (queue && profileData) {
       return {
-        preserveComposerStateOnClose: queue.preserveComposerStateOnClose,
+        preserveComposerStateOnClose: state.queue.preserveComposerStateOnClose,
         loading: queue.loading,
         loadingMore: queue.loadingMore,
         moreToLoad: queue.moreToLoad,

--- a/packages/queue/reducer.js
+++ b/packages/queue/reducer.js
@@ -1,6 +1,7 @@
 import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import { actionTypes as profileSidebarActionTypes } from '@bufferapp/publish-profile-sidebar/reducer';
 import { actionTypes as draftActionTypes } from '@bufferapp/publish-drafts/reducer';
+import { actionTypes as orgActionTypes } from '@bufferapp/publish-data-organizations';
 import { postParser } from '@bufferapp/publish-server/parsers/src';
 import keyWrapper from '@bufferapp/keywrapper';
 
@@ -386,9 +387,16 @@ export default (state = initialState, action) => {
         isInstagramLoading: false,
       };
 
+    case orgActionTypes.ORGANIZATION_SELECTED:
+      return {
+        ...state,
+        preserveComposerStateOnClose: false,
+      };
+
     case actionTypes.OPEN_COMPOSER:
       return {
         ...state,
+        preserveComposerStateOnClose: true,
         showComposer: true,
         editMode: action.editMode,
         editingPostId: action.updateId,

--- a/packages/queue/reducer.js
+++ b/packages/queue/reducer.js
@@ -396,7 +396,6 @@ export default (state = initialState, action) => {
     case actionTypes.OPEN_COMPOSER:
       return {
         ...state,
-        preserveComposerStateOnClose: true,
         showComposer: true,
         editMode: action.editMode,
         editingPostId: action.updateId,
@@ -406,6 +405,7 @@ export default (state = initialState, action) => {
     case actionTypes.HIDE_COMPOSER:
       return {
         ...state,
+        preserveComposerStateOnClose: true,
         showComposer: false,
         editMode: false,
         emptySlotMode: false,

--- a/packages/queue/reducer.test.js
+++ b/packages/queue/reducer.test.js
@@ -1,4 +1,5 @@
 import deepFreeze from 'deep-freeze';
+import { actionTypes as orgActionTypes } from '@bufferapp/publish-data-organizations';
 import reducer, { initialState, actionTypes } from './reducer';
 
 const profileId = '123456';
@@ -365,6 +366,23 @@ describe('reducer', () => {
       post,
     };
     deepFreeze(action);
+    expect(reducer(stateBefore, action)).toEqual(stateAfter);
+  });
+
+  it('handles ORGANIZATION_SELECTED action type, sets preserveComposerStateOnClose to false to force the composer to refetch profiles on org switcher ', () => {
+    const stateBefore = {
+      ...initialState,
+      preserveComposerStateOnClose: true,
+    };
+    const stateAfter = {
+      ...initialState,
+      preserveComposerStateOnClose: false,
+    };
+
+    const action = {
+      type: orgActionTypes.ORGANIZATION_SELECTED,
+    };
+
     expect(reducer(stateBefore, action)).toEqual(stateAfter);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Fix filtered profiles in composer
<!--- Describe your changes in detail. -->

## Context & Notes
We have a preserveStateOnClose when we open the composer in the queue or drafts. It prevents from re-rendering data again. When we switched orgs, the list of profiles changed, but that logic was blocking us from updating the data accordingly. 

_I guess at some point we should thing about the preserveStateOnClose again. I could see why we would want to preserve the composer message so we open the composer again and it's there. But I don't see why we don't update user and profiles info, this means that without a page refresh, the data in the composer might not be up to date_

https://buffer.atlassian.net/browse/PUB-2953
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
