### PR TITLE
[PUB-2936]Task/add org switcher appcues

### DIFF
--- a/packages/app-shell/components/AppShell/index.jsx
+++ b/packages/app-shell/components/AppShell/index.jsx
@@ -99,7 +99,7 @@ function generateUserMenuItems({
 }
 
 const generateOrgSwitcherItems = ({
-  hasOrgSwitcherFeature,
+  canSeeOrgSwitcher,
   organizations,
   selectedOrganizationId,
   profiles,
@@ -108,7 +108,7 @@ const generateOrgSwitcherItems = ({
   /**
    * Only show if user has feature and 2+ organizations
    */
-  const shouldShow = hasOrgSwitcherFeature && organizations?.length >= 2;
+  const shouldShow = canSeeOrgSwitcher;
   if (!shouldShow) {
     return null;
   }
@@ -152,7 +152,7 @@ const AppShell = ({
   hideAppShell,
   enabledProducts,
   featureFlips,
-  hasOrgSwitcherFeature,
+  canSeeOrgSwitcher,
   organizations,
   selectedOrganizationId,
   profiles,
@@ -186,7 +186,7 @@ const AppShell = ({
       }}
       helpMenuItems={helpMenuItems(t)}
       orgSwitcher={generateOrgSwitcherItems({
-        hasOrgSwitcherFeature,
+        canSeeOrgSwitcher,
         organizations,
         selectedOrganizationId,
         profiles,
@@ -229,7 +229,7 @@ AppShell.propTypes = {
   hideAppShell: PropTypes.bool.isRequired,
   enabledProducts: PropTypes.arrayOf(PropTypes.string).isRequired,
   featureFlips: PropTypes.arrayOf(PropTypes.string).isRequired,
-  hasOrgSwitcherFeature: PropTypes.bool,
+  canSeeOrgSwitcher: PropTypes.bool,
   organizations: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string,
@@ -252,7 +252,7 @@ AppShell.propTypes = {
 };
 
 AppShell.defaultProps = {
-  hasOrgSwitcherFeature: false,
+  canSeeOrgSwitcher: false,
   showReturnToClassic: false,
   showSwitchPlan: false,
   showManageTeam: false,

--- a/packages/app-shell/index.js
+++ b/packages/app-shell/index.js
@@ -31,7 +31,7 @@ export default connect(
      * Org Switcher
      * Needs organizations and profiles.
      */
-    hasOrgSwitcherFeature: state.user.hasOrgSwitcherFeature,
+    canSeeOrgSwitcher: state.user.canSeeOrgSwitcher,
     organizations: getOrgsAlfabeticalOrder(state.organizations.list) || [],
     selectedOrganizationId: state.organizations.selected?.id,
     profiles: state.publishProfiles,

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -75,6 +75,7 @@ module.exports = userData => ({
     !userData.has_cancelled,
   shouldShowBusinessTrialExpiredModal:
     userData.on_trial && userData.trial_expired && !userData.trial_done,
+  canSeeOrgSwitcher: false, // temporary value, the important is what's being injected in the rpc
 
   // Org data
   plan:

--- a/packages/server/rpc/user/index.js
+++ b/packages/server/rpc/user/index.js
@@ -98,6 +98,7 @@ module.exports = method(
               canManageSocialAccounts: isAdmin,
               hasAccessTeamPanel: planBase === 'business' && isAdmin,
               canSeeBillingInfo: isOwner,
+              canSeeOrgSwitcher: orgs && orgs.length >= 2,
               shouldShowUpgradeButton:
                 isOwner &&
                 (planBase === 'free' ||

--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -54,6 +54,7 @@ export default ({ dispatch, getState }) => next => action => {
           trialTimeRemaining: result.trial.trialTimeRemaining,
           orgUserCount: result.orgUserCount,
           profileCount: result.profileCount,
+          canSeeOrgSwitcher: result.canSeeOrgSwitcher,
         });
       }
       break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Add `canSeeOrgSwitcher` flag for AppCues
- Simplify org switcher display logic in AppShell by using canSeeOrgSwitcher
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2936
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
