### PR TITLE
[PUB-2968] Hide reconnect channels for non-admin users

### DIFF
--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -408,6 +408,7 @@
   },
   "profiles-disconnected-banner": {
     "body": "Please make sure that you're logged into this account on the same network, and we'll get you back in business in no time!",
+    "permissionBody": "Reach out to {{email}} or any other Admin.",
     "cta": "Reconnect Account",
     "extraMessage": {
       "instagram": "Due to recent changes to the Instagram API, your personal Instagram profiles will need to be reconnected."

--- a/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/index.jsx
+++ b/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/index.jsx
@@ -34,7 +34,7 @@ const ProfilesDisconnectedBanner = ({
     >
       {displayExtraMessage && (
         <ExtraMessageWithStyles type="p">
-          {t('profiles-disconnected-banner.extraMessage?.instagram')}
+          {t('profiles-disconnected-banner.extraMessage.instagram')}
         </ExtraMessageWithStyles>
       )}
       <TextWithStyles type="p">

--- a/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/index.jsx
+++ b/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
 import { ErrorBanner } from '@bufferapp/publish-shared-components';
 import { Text } from '@bufferapp/ui';
 import { fontWeightBold } from '@bufferapp/ui/style/fonts';
@@ -17,36 +18,49 @@ const ExtraMessageWithStyles = styled(Text)`
 const ProfilesDisconnectedBanner = ({
   profileId,
   service,
-  translations,
   onReconnectProfileClick,
-  extraMessage,
-}) => (
-  <ErrorBanner
-    title={translations.headline}
-    onClick={() => onReconnectProfileClick({ id: profileId, service })}
-    actionLabel={translations.cta}
-  >
-    {extraMessage && (
-      <ExtraMessageWithStyles type="p">{extraMessage}</ExtraMessageWithStyles>
-    )}
-    <TextWithStyles type="p">{translations.body}</TextWithStyles>
-  </ErrorBanner>
-);
+  displayExtraMessage,
+  canReconnectChannels,
+  ownerEmail,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <ErrorBanner
+      title={t('profiles-disconnected-banner.headline')}
+      onClick={() => onReconnectProfileClick({ id: profileId, service })}
+      actionLabel={
+        canReconnectChannels ? t('profiles-disconnected-banner.cta') : null
+      }
+    >
+      {displayExtraMessage && (
+        <ExtraMessageWithStyles type="p">
+          {t('profiles-disconnected-banner.extraMessage?.instagram')}
+        </ExtraMessageWithStyles>
+      )}
+      <TextWithStyles type="p">
+        {canReconnectChannels
+          ? t('profiles-disconnected-banner.body')
+          : t('profiles-disconnected-banner.permissionBody', {
+              email: ownerEmail,
+            })}
+      </TextWithStyles>
+    </ErrorBanner>
+  );
+};
 
 ProfilesDisconnectedBanner.propTypes = {
+  canReconnectChannels: PropTypes.bool,
   profileId: PropTypes.string.isRequired,
   service: PropTypes.string.isRequired,
-  extraMessage: PropTypes.string,
-  translations: PropTypes.shape({
-    headline: PropTypes.string,
-    body: PropTypes.string,
-    cta: PropTypes.string,
-  }).isRequired,
+  displayExtraMessage: PropTypes.bool,
   onReconnectProfileClick: PropTypes.func.isRequired,
+  ownerEmail: PropTypes.string,
 };
 
 ProfilesDisconnectedBanner.defaultProps = {
-  extraMessage: null,
+  displayExtraMessage: false,
+  canReconnectChannels: true,
+  ownerEmail: 'the owner',
 };
 
 export default ProfilesDisconnectedBanner;

--- a/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/story.jsx
+++ b/packages/profiles-disconnected-banner/components/ProfilesDisconnectedBanner/story.jsx
@@ -12,4 +12,12 @@ storiesOf('ProfilesDisconnectedBanner', module)
       translations={translations['profiles-disconnected-banner']}
       onReconnectProfileClick={action('on-reconnect-click')}
     />
+  ))
+  .add('non admin user', () => (
+    <ProfilesDisconnectedBanner
+      translations={translations['profiles-disconnected-banner']}
+      onReconnectProfileClick={action('on-reconnect-click')}
+      canReconnectChannels={false}
+      ownerEmail="ana@buffer.com"
+    />
   ));

--- a/packages/profiles-disconnected-banner/index.js
+++ b/packages/profiles-disconnected-banner/index.js
@@ -4,23 +4,22 @@ import ProfilesDisconnectedBanner from './components/ProfilesDisconnectedBanner'
 
 export default connect(
   state => {
-    let extraMessage = null;
+    let displayExtraMessage = false;
     const selectedProfile = state.profileSidebar?.selectedProfile;
-    const translations =
-      state.i18n.translations['profiles-disconnected-banner'];
 
     if (
       selectedProfile?.service === 'instagram' &&
       selectedProfile?.service_type === 'profile'
     ) {
-      extraMessage = translations?.extraMessage?.instagram;
+      displayExtraMessage = true;
     }
 
     return {
       profileId: selectedProfile?.id,
       service: selectedProfile?.service,
-      translations,
-      extraMessage,
+      displayExtraMessage,
+      canReconnectChannels: state.user.canReconnectChannels,
+      ownerEmail: state.organizations.selected?.ownerEmail,
     };
   },
   dispatch => ({

--- a/packages/profiles-disconnected-banner/index.test.jsx
+++ b/packages/profiles-disconnected-banner/index.test.jsx
@@ -18,6 +18,10 @@ const store = storeFake({
       service: 'instagram',
     },
   },
+  user: {
+    canReconnectChannels: true,
+  },
+  organizations: {},
   i18n: {
     translations: {
       'profiles-disconnected-banner':

--- a/packages/server/formatters/src/getURL.js
+++ b/packages/server/formatters/src/getURL.js
@@ -17,12 +17,6 @@ module.exports = {
     }
     return 'https://buffer.com/back_publish';
   },
-  getManageURL: () => {
-    if (window.location.hostname === 'publish.local.buffer.com') {
-      return 'https://local.buffer.com/manage';
-    }
-    return 'https://buffer.com/manage';
-  },
   getConnectSocialAccountURL: () => {
     if (window.location.hostname === 'publish.local.buffer.com') {
       return 'https://local.buffer.com/manage/accounts/connect';

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -76,6 +76,7 @@ module.exports = userData => ({
   shouldShowBusinessTrialExpiredModal:
     userData.on_trial && userData.trial_expired && !userData.trial_done,
   canSeeOrgSwitcher: false, // temporary value, the important is what's being injected in the rpc
+  canReconnectChannels: true, // temporary value, the important is what's being injected in the rpc
 
   // Org data
   plan:

--- a/packages/server/rpc/user/index.js
+++ b/packages/server/rpc/user/index.js
@@ -99,6 +99,7 @@ module.exports = method(
               hasAccessTeamPanel: planBase === 'business' && isAdmin,
               canSeeBillingInfo: isOwner,
               canSeeOrgSwitcher: orgs && orgs.length >= 2,
+              canReconnectChannels: isAdmin,
               shouldShowUpgradeButton:
                 isOwner &&
                 (planBase === 'free' ||

--- a/packages/server/rpc/user/index.js
+++ b/packages/server/rpc/user/index.js
@@ -69,7 +69,7 @@ module.exports = method(
                 trial.isExpired &&
                 !trial.isDone,
               showBusinessTrialistsOnboarding:
-                planBase === 'business' && trial && trial.onTrial,
+                planBase === 'business' && trial && trial.onTrial && isAdmin,
             };
           }
           // Temporarily injecting org plan data in users. To be removed after org switcher rollout.

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -159,7 +159,7 @@ class TabNavigation extends React.Component {
                   onClick={e => {
                     e.preventDefault();
                     this.setState({ loading: true });
-                    window.location.assign(`${getURL.getManageURL()}`);
+                    window.location.assign(`${getURL.getManageSocialAccountURL()}`);
                   }}
                 />
               </div>

--- a/packages/tabs/components/TabNavigation/index.jsx
+++ b/packages/tabs/components/TabNavigation/index.jsx
@@ -76,6 +76,7 @@ class TabNavigation extends React.Component {
       isDisconnectedProfile,
       draftsNeedApprovalCount,
       draftsCount,
+      canReconnectChannels,
       t,
     } = this.props;
 
@@ -150,7 +151,7 @@ class TabNavigation extends React.Component {
             <Tab tabId="general-settings">{t('tabs.general')}</Tab>
             <Tab tabId="posting-schedule">{t('tabs.postingSchedule')}</Tab>
             {/* Hidding reconnect  button when profile is disconnected, as we have a banner in settings content for that */}
-            {!isDisconnectedProfile && (
+            {!isDisconnectedProfile && canReconnectChannels && (
               <div style={{ display: 'inline-block' }}>
                 <Button
                   type="secondary"
@@ -159,7 +160,9 @@ class TabNavigation extends React.Component {
                   onClick={e => {
                     e.preventDefault();
                     this.setState({ loading: true });
-                    window.location.assign(`${getURL.getManageSocialAccountURL()}`);
+                    window.location.assign(
+                      `${getURL.getManageSocialAccountURL()}`
+                    );
                   }}
                 />
               </div>
@@ -185,9 +188,11 @@ TabNavigation.defaultProps = {
   hasStoriesFlip: false,
   draftsNeedApprovalCount: null,
   draftsCount: null,
+  canReconnectChannels: true,
 };
 
 TabNavigation.propTypes = {
+  canReconnectChannels: PropTypes.bool,
   features: PropTypes.any.isRequired, // eslint-disable-line
   isBusinessAccount: PropTypes.bool,
   isManager: PropTypes.bool,

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -26,6 +26,7 @@ export default connect(
     hasStoriesFlip: state.user.features?.includes('stories_groups') ?? false,
     draftsNeedApprovalCount: state.tabs.draftsNeedApprovalCount,
     draftsCount: state.tabs.draftsCount,
+    canReconnectChannels: state.user.canReconnectChannels,
   }),
   (dispatch, ownProps) => ({
     onTabClick: tabId => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Hide reconnect button in settings tab for non-admin users
- Show custom message in profiles-disconnected-banner for non-admin users

Extra: use new translations in profiles-disconnected-banner
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2968
Next: Adjust the profiles-disconnected-modal
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
**Non admin user:**
<img width="907" alt="Screenshot 2020-08-04 at 14 01 47" src="https://user-images.githubusercontent.com/16758464/89308673-6fdf3d00-d66a-11ea-8d08-b1ce08026794.png">

**Admin user:** 
<img width="1176" alt="Screenshot 2020-08-04 at 13 27 29" src="https://user-images.githubusercontent.com/16758464/89309212-09a6ea00-d66b-11ea-9222-10aafa331378.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`