### PR TITLE
[PUB-2968] Replace reconnect cta for non-admin users in profiles-disconnected-modal

### DIFF
--- a/packages/profiles-disconnected-modal/components/ProfilesDisconnectedModal/index.jsx
+++ b/packages/profiles-disconnected-modal/components/ProfilesDisconnectedModal/index.jsx
@@ -3,12 +3,11 @@ import PropTypes from 'prop-types';
 import { fontWeightBold } from '@bufferapp/ui/style/fonts';
 import { borderRadius } from '@bufferapp/ui/style/borders';
 import { grayLight } from '@bufferapp/ui/style/colors';
-
-
 import { Popover, Card } from '@bufferapp/components';
 import { Text, Button } from '@bufferapp/ui';
 import Avatar from '@bufferapp/ui/Avatar';
 import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
 
 const ExtraMessageWithStyles = styled(Text)`
   margin: 0;
@@ -43,61 +42,73 @@ const Container = styled.div`
   z-index: 3000;
 `;
 
+const PermissionText = styled(Text)`
+  line-height: 32px;
+  margin: 0;
+`;
+
 const ProfilesDisconnectedModal = ({
-  translations,
   disconnectedProfiles,
   reconnectProfile,
   hideModal,
-  extraMessage,
-}) => (
-  <Container>
-    <Popover onOverlayClick={hideModal}>
-      <Card reducedPadding>
-        <ModalContainer>
-          <Text type="h3">{translations.headline}</Text>
-          {extraMessage && (
-            <ExtraMessageWithStyles type="p">
-              {extraMessage}
-            </ExtraMessageWithStyles>
-          )}
-          <Text type="p">{translations.body1}</Text>
-          <Text type="p">{translations.body2}</Text>
-          {disconnectedProfiles.map(p => (
-            <DisconnectedProfile key={p.id}>
-              <AvatarContainer>
-                <Avatar
-                  src={p.avatar_https}
-                  fallbackUrl="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
-                  alt={p.handle}
-                  size="small"
-                  type="social"
-                  network={p.service}
-                />
-                <AvatarName>
-                  <Text>{p.formatted_username}</Text>
-                </AvatarName>
-              </AvatarContainer>
-              <Button
-                disabled={p.reconnecting}
-                onClick={() =>
-                  reconnectProfile({ id: p.id, service: p.service })
-                }
-                size="small"
-                type="primary"
-                label={
-                  p.reconnecting ? translations.reconnecting : translations.cta
-                }
-              />
-            </DisconnectedProfile>
-          ))}
-        </ModalContainer>
-      </Card>
-    </Popover>
-  </Container>
-);
+  displayExtraMessage,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <Container>
+      <Popover onOverlayClick={hideModal}>
+        <Card reducedPadding>
+          <ModalContainer>
+            <Text type="h3">{t('profiles-disconnected-modal.headline')}</Text>
+            {displayExtraMessage && (
+              <ExtraMessageWithStyles type="p">
+                {t('profiles-disconnected-modal.extraMessage.instagram')}
+              </ExtraMessageWithStyles>
+            )}
+            <Text type="p">{t('profiles-disconnected-modal.body1')}</Text>
+            <Text type="p">{t('profiles-disconnected-modal.body2')}</Text>
+            {disconnectedProfiles.map(p => (
+              <DisconnectedProfile key={p.id}>
+                <AvatarContainer>
+                  <Avatar
+                    src={p.avatar_https}
+                    fallbackUrl="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
+                    alt={p.handle}
+                    size="small"
+                    type="social"
+                    network={p.service}
+                  />
+                  <AvatarName>
+                    <Text>{p.formatted_username}</Text>
+                  </AvatarName>
+                </AvatarContainer>
+                {p.isAdmin ? (
+                  <Button
+                    disabled={p.reconnecting}
+                    onClick={() =>
+                      reconnectProfile({ id: p.id, service: p.service })
+                    }
+                    size="small"
+                    type="primary"
+                    label={
+                      p.reconnecting
+                        ? t('profiles-disconnected-modal.reconnecting')
+                        : t('profiles-disconnected-modal.cta')
+                    }
+                  />
+                ) : (
+                  <PermissionText type="p">Contact an org admin</PermissionText>
+                )}
+              </DisconnectedProfile>
+            ))}
+          </ModalContainer>
+        </Card>
+      </Popover>
+    </Container>
+  );
+};
 
 ProfilesDisconnectedModal.propTypes = {
-  translations: PropTypes.object.isRequired, // eslint-disable-line
   disconnectedProfiles: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
@@ -105,11 +116,11 @@ ProfilesDisconnectedModal.propTypes = {
   ).isRequired,
   reconnectProfile: PropTypes.func.isRequired,
   hideModal: PropTypes.func.isRequired,
-  extraMessage: PropTypes.string,
+  displayExtraMessage: PropTypes.bool,
 };
 
 ProfilesDisconnectedModal.defaultProps = {
-  extraMessage: null,
+  displayExtraMessage: false,
 };
 
 export default ProfilesDisconnectedModal;

--- a/packages/profiles-disconnected-modal/components/ProfilesDisconnectedModal/story.jsx
+++ b/packages/profiles-disconnected-modal/components/ProfilesDisconnectedModal/story.jsx
@@ -8,7 +8,7 @@ import ProfilesDisconnectedModal from './index';
 
 storiesOf('ProfilesDisconnectedModal', module)
   .addDecorator(withA11y)
-  .add('should show welcome modal', () => (
+  .add('default', () => (
     <ProfilesDisconnectedModal
       translations={translations['profiles-disconnected-modal']}
       hideModal={action('hide-modal')}
@@ -19,6 +19,23 @@ storiesOf('ProfilesDisconnectedModal', module)
           avatar_https: '',
           service: 'twitter',
           formatted_username: '@hamstu',
+          isAdmin: true,
+        },
+      ]}
+    />
+  ))
+  .add('with non-admin profile', () => (
+    <ProfilesDisconnectedModal
+      translations={translations['profiles-disconnected-modal']}
+      hideModal={action('hide-modal')}
+      reconnectProfile={action('reconnect-profile')}
+      disconnectedProfiles={[
+        {
+          id: '1',
+          avatar_https: '',
+          service: 'twitter',
+          formatted_username: '@hamstu',
+          isAdmin: false,
         },
       ]}
     />

--- a/packages/profiles-disconnected-modal/index.js
+++ b/packages/profiles-disconnected-modal/index.js
@@ -23,9 +23,9 @@ export default connect(
         : accProfiles;
     }, []);
     return {
+      ...state.profilesDisconnectedModal,
       displayExtraMessage: instagramPersonalProfiles?.length > 0,
       disconnectedProfiles: profiles,
-      ...state.profilesDisconnectedModal,
     };
   },
   dispatch => ({

--- a/packages/profiles-disconnected-modal/index.js
+++ b/packages/profiles-disconnected-modal/index.js
@@ -5,8 +5,7 @@ import ProfilesDisconnectedModal from './components/ProfilesDisconnectedModal';
 
 export default connect(
   state => {
-    const translations = state.i18n.translations['profiles-disconnected-modal'];
-    let extraMessage = null;
+    let displayExtraMessage = false;
     const disconnectedProfiles =
       state.profilesDisconnectedModal?.disconnectedProfiles;
     const instagramPersonalProfiles = disconnectedProfiles.filter(
@@ -14,11 +13,21 @@ export default connect(
         profile?.service === 'instagram' && profile?.service_type === 'profile'
     );
     if (instagramPersonalProfiles.length > 0) {
-      extraMessage = translations?.extraMessage?.instagram;
+      displayExtraMessage = true;
     }
+    const organizations = state.organizations?.list;
+
+    const profiles = [];
+    disconnectedProfiles.forEach(profile => {
+      const matchingOrg = organizations.filter(
+        org => profile.organizationId === org.id
+      );
+      profile.isAdmin = matchingOrg[0].isAdmin;
+      profiles.push(profile);
+    });
     return {
-      translations: state.i18n.translations['profiles-disconnected-modal'],
-      extraMessage,
+      displayExtraMessage,
+      disconnectedProfiles: profiles,
       ...state.profilesDisconnectedModal,
     };
   },

--- a/packages/profiles-disconnected-modal/index.js
+++ b/packages/profiles-disconnected-modal/index.js
@@ -12,16 +12,19 @@ export default connect(
         profile?.service === 'instagram' && profile?.service_type === 'profile'
     );
     const organizations = state.organizations?.list;
+    const hasOrgSwitcher = state.user.hasOrgSwitcherFeature;
 
-    const profiles = disconnectedProfiles.reduce((accProfiles, profile) => {
-      const matchingOrg =
-        Array.isArray(organizations) &&
-        organizations.find(org => profile.organizationId === org.id);
+    const profiles = hasOrgSwitcher
+      ? disconnectedProfiles.reduce((accProfiles, profile) => {
+          const matchingOrg =
+            Array.isArray(organizations) &&
+            organizations.find(org => profile.organizationId === org.id);
 
-      return matchingOrg
-        ? [...accProfiles, { ...profile, isAdmin: matchingOrg.isAdmin }]
-        : accProfiles;
-    }, []);
+          return matchingOrg
+            ? [...accProfiles, { ...profile, isAdmin: matchingOrg.isAdmin }]
+            : accProfiles;
+        }, [])
+      : disconnectedProfiles;
     return {
       ...state.profilesDisconnectedModal,
       displayExtraMessage: instagramPersonalProfiles?.length > 0,

--- a/packages/profiles-disconnected-modal/index.js
+++ b/packages/profiles-disconnected-modal/index.js
@@ -5,28 +5,25 @@ import ProfilesDisconnectedModal from './components/ProfilesDisconnectedModal';
 
 export default connect(
   state => {
-    let displayExtraMessage = false;
     const disconnectedProfiles =
       state.profilesDisconnectedModal?.disconnectedProfiles;
     const instagramPersonalProfiles = disconnectedProfiles.filter(
       profile =>
         profile?.service === 'instagram' && profile?.service_type === 'profile'
     );
-    if (instagramPersonalProfiles.length > 0) {
-      displayExtraMessage = true;
-    }
     const organizations = state.organizations?.list;
 
-    const profiles = [];
-    disconnectedProfiles.forEach(profile => {
-      const matchingOrg = organizations.filter(
-        org => profile.organizationId === org.id
-      );
-      profile.isAdmin = matchingOrg[0].isAdmin;
-      profiles.push(profile);
-    });
+    const profiles = disconnectedProfiles.reduce((accProfiles, profile) => {
+      const matchingOrg =
+        Array.isArray(organizations) &&
+        organizations.find(org => profile.organizationId === org.id);
+
+      return matchingOrg
+        ? [...accProfiles, { ...profile, isAdmin: matchingOrg.isAdmin }]
+        : accProfiles;
+    }, []);
     return {
-      displayExtraMessage,
+      displayExtraMessage: instagramPersonalProfiles?.length > 0,
       disconnectedProfiles: profiles,
       ...state.profilesDisconnectedModal,
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Replace reconnect cta for non-admin users in profiles-disconnected-modal
Extra: Use new translations 
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2968
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
**Admin user in disconnected profile:**
<img width="611" alt="Screenshot 2020-08-04 at 19 38 33" src="https://user-images.githubusercontent.com/16758464/89333140-7d0d2380-d68c-11ea-9ce3-44ab1aea0b49.png">
**Non-admin in disconnected profile:**
<img width="644" alt="Screenshot 2020-08-04 at 19 48 43" src="https://user-images.githubusercontent.com/16758464/89333150-80081400-d68c-11ea-8535-fae9d0aecff3.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
