### PR TITLE
Fix disconnect modal reconnect button for non org switcher users

### DIFF
--- a/packages/profiles-disconnected-modal/components/ProfilesDisconnectedModal/index.jsx
+++ b/packages/profiles-disconnected-modal/components/ProfilesDisconnectedModal/index.jsx
@@ -82,7 +82,9 @@ const ProfilesDisconnectedModal = ({
                     <Text>{p.formatted_username}</Text>
                   </AvatarName>
                 </AvatarContainer>
-                {p.isAdmin ? (
+                {p.isAdmin && p.isAdmin === 'false' ? (
+                  <PermissionText type="p">Contact an org admin</PermissionText>
+                ) : (
                   <Button
                     disabled={p.reconnecting}
                     onClick={() =>
@@ -96,8 +98,6 @@ const ProfilesDisconnectedModal = ({
                         : t('profiles-disconnected-modal.cta')
                     }
                   />
-                ) : (
-                  <PermissionText type="p">Contact an org admin</PermissionText>
                 )}
               </DisconnectedProfile>
             ))}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Fix disconnect modal reconnect button: users without the org switcher flip weren't seen the right option
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
