### PR TITLE
[PUB-2976] Add empty state variation for non admin

### DIFF
--- a/packages/campaigns-list/components/ListCampaigns/EmptyState/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/EmptyState/index.jsx
@@ -37,35 +37,49 @@ const LinkWithStyles = styled(Link)`
   padding: 16px;
 `;
 
-const EmptyState = ({ onOpenCreateCampaignClick }) => {
+const EmptyState = ({
+  onOpenCreateCampaignClick,
+  showCampaignActions,
+  ownerEmail,
+}) => {
   const { t } = useTranslation();
 
   return (
     <EmptyStateContainer>
       <Content>
         <Text type="h1">{t('campaigns.emptyState.title')}</Text>
-        <Text type="p">{t('campaigns.emptyState.subtext')}</Text>
-        <Checklist
-          items={[
-            t('campaigns.emptyState.item1'),
-            t('campaigns.emptyState.item2'),
-            t('campaigns.emptyState.item3'),
-          ]}
-        />
-        <div style={{ alignSelf: 'flex-end', paddingTop: '30px' }}>
-          <Button
-            type="primary"
-            size="large"
-            label={t('campaigns.common.createCampaign')}
-            onClick={onOpenCreateCampaignClick}
-          />
-          <LinkWithStyles
-            href="https://support.buffer.com/hc/en-us/articles/360046266313-creating-and-managing-campaigns"
-            newTab
-          >
-            {t('campaigns.emptyState.learnMore')}
-          </LinkWithStyles>
-        </div>
+        {showCampaignActions ? (
+          <>
+            <Text type="p">{t('campaigns.emptyState.subtext')}</Text>
+            <Checklist
+              items={[
+                t('campaigns.emptyState.item1'),
+                t('campaigns.emptyState.item2'),
+                t('campaigns.emptyState.item3'),
+              ]}
+            />
+            <div style={{ alignSelf: 'flex-end', paddingTop: '30px' }}>
+              <Button
+                type="primary"
+                size="large"
+                label={t('campaigns.common.createCampaign')}
+                onClick={onOpenCreateCampaignClick}
+              />
+              <LinkWithStyles
+                href="https://support.buffer.com/hc/en-us/articles/360046266313-creating-and-managing-campaigns"
+                newTab
+              >
+                {t('campaigns.emptyState.learnMore')}
+              </LinkWithStyles>
+            </div>
+          </>
+        ) : (
+          <Text type="p">
+            {t('campaigns.emptyState.permission', {
+              email: ownerEmail,
+            })}
+          </Text>
+        )}
       </Content>
       <Image
         src="https://buffer-publish.s3.amazonaws.com/images/campaigns-empty-state-screenshot.png"
@@ -77,6 +91,12 @@ const EmptyState = ({ onOpenCreateCampaignClick }) => {
 
 EmptyState.propTypes = {
   onOpenCreateCampaignClick: PropTypes.func.isRequired,
+  showCampaignActions: PropTypes.bool.isRequired,
+  ownerEmail: PropTypes.string,
+};
+
+EmptyState.defaultProps = {
+  ownerEmail: 'the owner',
 };
 
 export default EmptyState;

--- a/packages/campaigns-list/components/ListCampaigns/EmptyState/story.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/EmptyState/story.jsx
@@ -8,5 +8,15 @@ import EmptyState from './index';
 storiesOf('Campaigns|EmptyState', module)
   .addDecorator(withA11y)
   .add('default', () => (
-    <EmptyState onOpenCreateCampaignClick={action('createCampaign')} />
+    <EmptyState
+      onOpenCreateCampaignClick={action('createCampaign')}
+      showCampaignActions
+    />
+  ))
+  .add('non-admin', () => (
+    <EmptyState
+      onOpenCreateCampaignClick={action('createCampaign')}
+      showCampaignActions={false}
+      ownerEmail="ana@buffer.com"
+    />
   ));

--- a/packages/campaigns-list/components/ListCampaigns/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/index.jsx
@@ -55,6 +55,7 @@ const ListCampaigns = ({
   hasCampaignsFlip,
   fetchCampaignsIfNeeded,
   isLoading,
+  ownerEmail,
 }) => {
   if (!hasCampaignsFlip) {
     window.location = getURL.getPublishUrl();
@@ -68,7 +69,13 @@ const ListCampaigns = ({
   const { t } = useTranslation();
 
   if (!isLoading && (!campaigns || campaigns.length === 0)) {
-    return <EmptyState onOpenCreateCampaignClick={onOpenCreateCampaignClick} />;
+    return (
+      <EmptyState
+        onOpenCreateCampaignClick={onOpenCreateCampaignClick}
+        showCampaignActions={showCampaignActions}
+        ownerEmail={ownerEmail}
+      />
+    );
   }
 
   return (
@@ -123,6 +130,7 @@ ListCampaigns.propTypes = {
   hasCampaignsFlip: PropTypes.bool.isRequired,
   fetchCampaignsIfNeeded: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
+  ownerEmail: PropTypes.string,
 };
 
 ListCampaigns.defaultProps = {
@@ -131,6 +139,7 @@ ListCampaigns.defaultProps = {
   onDeleteCampaignClick: () => {},
   onViewCampaignClick: () => {},
   goToAnalyzeReport: () => {},
+  ownerEmail: 'the owner',
 };
 
 export default ListCampaigns;

--- a/packages/campaigns-list/index.js
+++ b/packages/campaigns-list/index.js
@@ -17,6 +17,7 @@ export default connect(
       hideAnalyzeReport: !state.user.canSeeCampaignsReport,
       isLoading: state.campaignsList.isLoading,
       hasCampaignsFlip: state.user.hasCampaignsFeature,
+      ownerEmail: state.organizations.selected?.ownerEmail,
     };
   },
   (dispatch, ownProps) => ({

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -49,7 +49,8 @@
       "item3": "Review campaign performance and hit your goals.",
       "learnMore": "Learn More",
       "subtext": "Keep track of multichannel campaigns and create a healthy mix of content on social media.",
-      "title": "Get a clearer picture of your social media strategy"
+      "title": "Get a clearer picture of your social media strategy",
+      "permission": "It looks like your organization doesn't have any campaigns yet, and only admin users can create them. Request access from {{email}} or any other Admin."
     },
     "viewCampaign": {
       "allPostsSent": {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Add empty campaigns state for non-admin users, as they can't create campaigns.
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2976
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

<img width="1431" alt="Screenshot 2020-08-05 at 22 43 14" src="https://user-images.githubusercontent.com/16758464/89467841-3e4f9a00-d76e-11ea-9ba8-7e3fd94d9ea1.png">
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
