### PR TITLE
[PUB-2993] Replace features.isFreeUser() and features.isProUser() by orgs features

### DIFF
--- a/packages/analytics/components/Analytics/index.jsx
+++ b/packages/analytics/components/Analytics/index.jsx
@@ -2,7 +2,6 @@ import React, { lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
 
 import { BusinessTrialOrUpgradeCard } from '@bufferapp/publish-shared-components';
-import { WithFeatureLoader } from '@bufferapp/product-features';
 import LockedProfileNotification from '@bufferapp/publish-locked-profile-notification';
 import getErrorBoundary from '@bufferapp/publish-web/components/ErrorBoundary';
 import { getURL } from '@bufferapp/publish-server/formatters/src';
@@ -22,12 +21,12 @@ const LazyAnalyticsList = lazy(() =>
 const ErrorBoundary = getErrorBoundary(true);
 
 const AnalyticsList = ({
-  features,
   profile,
   isAnalyticsSupported,
   isLockedProfile,
   canStartBusinessTrial,
   hasAnalyticsFeature,
+  hasBitlyFeature,
   isInstagramBusiness,
   fetchProfiles,
   selectProfile,
@@ -81,11 +80,11 @@ const AnalyticsList = ({
       <ErrorBoundary>
         <Suspense fallback={<div>Loading...</div>}>
           <LazyAnalyticsList
+            hasBitlyFeature={hasBitlyFeature}
             profile={profile}
             isInstagramBusiness={isInstagramBusiness}
             fetchProfiles={fetchProfiles}
             selectProfile={selectProfile}
-            features={features}
             linkShortening={linkShortening}
             hasBitlyPosts={hasBitlyPosts}
           />
@@ -103,7 +102,7 @@ const AnalyticsList = ({
 };
 
 AnalyticsList.propTypes = {
-  features: PropTypes.object.isRequired, // eslint-disable-line
+  hasBitlyFeature: PropTypes.bool.isRequired,
   canStartBusinessTrial: PropTypes.bool.isRequired,
   isAnalyticsSupported: PropTypes.bool,
   profile: PropTypes.shape(ProfileHeader.propTypes),
@@ -124,4 +123,4 @@ AnalyticsList.defaultProps = {
   isLockedProfile: false,
 };
 
-export default WithFeatureLoader(AnalyticsList);
+export default AnalyticsList;

--- a/packages/analytics/components/Analytics/index.jsx
+++ b/packages/analytics/components/Analytics/index.jsx
@@ -27,15 +27,19 @@ const AnalyticsList = ({
   isAnalyticsSupported,
   isLockedProfile,
   canStartBusinessTrial,
-  isBusinessAccount,
+  hasAnalyticsFeature,
   isInstagramBusiness,
   fetchProfiles,
   selectProfile,
   linkShortening,
   hasBitlyPosts,
 }) => {
-  // user is either a free or pro and is not a team member
-  if (!isBusinessAccount && (features.isProUser() || features.isFreeUser())) {
+  if (isLockedProfile) {
+    return <LockedProfileNotification />;
+  }
+
+  // org has analytics plan feature
+  if (!hasAnalyticsFeature) {
     const startTrial = () =>
       window.location.assign(
         `${getURL.getStartTrialURL({
@@ -72,10 +76,6 @@ const AnalyticsList = ({
     );
   }
 
-  if (isLockedProfile) {
-    return <LockedProfileNotification />;
-  }
-
   if (isAnalyticsSupported) {
     return (
       <ErrorBoundary>
@@ -108,7 +108,7 @@ AnalyticsList.propTypes = {
   isAnalyticsSupported: PropTypes.bool,
   profile: PropTypes.shape(ProfileHeader.propTypes),
   isLockedProfile: PropTypes.bool,
-  isBusinessAccount: PropTypes.bool.isRequired,
+  hasAnalyticsFeature: PropTypes.bool.isRequired,
   isInstagramBusiness: PropTypes.bool.isRequired,
   fetchProfiles: PropTypes.func.isRequired,
   selectProfile: PropTypes.func.isRequired,

--- a/packages/analytics/components/AnalyticsList/index.jsx
+++ b/packages/analytics/components/AnalyticsList/index.jsx
@@ -39,7 +39,7 @@ const AnalyticsList = ({
       <BitlyClickNotification
         hasBitlyPosts={hasBitlyPosts}
         isBitlyConnected={!!linkShortening.isBitlyConnected}
-        isFreeUser={hasBitlyFeature}
+        hasBitlyFeature={hasBitlyFeature}
         marginAfter
       />
       {!isInstagramBusiness && <SummaryTable />}

--- a/packages/analytics/components/AnalyticsList/index.jsx
+++ b/packages/analytics/components/AnalyticsList/index.jsx
@@ -14,11 +14,11 @@ import './analytics.css';
 import './store'; // Injects reducers and middlewares
 
 const AnalyticsList = ({
+  hasBitlyFeature,
   profile,
   isInstagramBusiness,
   fetchProfiles,
   selectProfile,
-  features,
   linkShortening,
   hasBitlyPosts,
 }) => {
@@ -39,16 +39,16 @@ const AnalyticsList = ({
       <BitlyClickNotification
         hasBitlyPosts={hasBitlyPosts}
         isBitlyConnected={!!linkShortening.isBitlyConnected}
-        isFreeUser={features.isFreeUser}
+        isFreeUser={hasBitlyFeature}
         marginAfter
       />
       {!isInstagramBusiness && <SummaryTable />}
       <CompareChart />
       {!isInstagramBusiness && (
-        <React.Fragment>
+        <>
           <AverageTable />
           <PostsTable />
-        </React.Fragment>
+        </>
       )}
     </div>
   );
@@ -59,9 +59,7 @@ AnalyticsList.propTypes = {
   isInstagramBusiness: PropTypes.bool.isRequired,
   fetchProfiles: PropTypes.func.isRequired,
   selectProfile: PropTypes.func.isRequired,
-  features: PropTypes.shape({
-    isFreeUser: PropTypes.func,
-  }).isRequired,
+  hasBitlyFeature: PropTypes.bool.isRequired,
   linkShortening: PropTypes.shape({
     isBitlyConnected: PropTypes.bool,
   }).isRequired,

--- a/packages/analytics/index.js
+++ b/packages/analytics/index.js
@@ -5,6 +5,7 @@ const mapStateToProps = state => ({
   profile: state.profileSidebar.selectedProfile,
   isLockedProfile: state.profileSidebar.isLockedProfile,
   hasAnalyticsFeature: state.organizations.selected.hasAnalyticsFeature,
+  hasBitlyFeature: state.organizations.selected.hasBitlyFeature,
   isInstagramBusiness: state.profileSidebar.selectedProfile.isInstagramBusiness,
   isAnalyticsSupported:
     state.profileSidebar.selectedProfile.isAnalyticsSupported,

--- a/packages/analytics/index.js
+++ b/packages/analytics/index.js
@@ -4,7 +4,7 @@ import Analytics from './components/Analytics';
 const mapStateToProps = state => ({
   profile: state.profileSidebar.selectedProfile,
   isLockedProfile: state.profileSidebar.isLockedProfile,
-  isBusinessAccount: state.profileSidebar.selectedProfile.business,
+  hasAnalyticsFeature: state.organizations.selected.hasAnalyticsFeature,
   isInstagramBusiness: state.profileSidebar.selectedProfile.isInstagramBusiness,
   isAnalyticsSupported:
     state.profileSidebar.selectedProfile.isAnalyticsSupported,

--- a/packages/app-pages/index.test.js
+++ b/packages/app-pages/index.test.js
@@ -36,7 +36,14 @@ const profileIG = buildIGProfile({
 const profiles = [profileTwitter, profileIG];
 const initialState = {
   user: buildUser(),
-  organizations: { selected: { id: organization.id }, loaded: true },
+  organizations: {
+    selected: {
+      id: organization.id,
+      hasCalendarFeature: true,
+      hasShareAgainFeature: true,
+    },
+    loaded: true,
+  },
   profileSidebar: {
     selectedProfileId: profileTwitter.id,
     selectedProfile: profileTwitter,

--- a/packages/past-reminders/components/PastRemindersPosts/index.jsx
+++ b/packages/past-reminders/components/PastRemindersPosts/index.jsx
@@ -97,6 +97,7 @@ const PastRemindersPosts = ({
   isDisconnectedProfile,
   onClosePreviewClick,
   fetchCampaignsIfNeeded,
+  hasShareAgainFeature,
 }) => {
   if (loading) {
     return (
@@ -137,7 +138,7 @@ const PastRemindersPosts = ({
         <QueueItems
           items={items}
           onEditClick={onEditClick}
-          showShareAgainButton
+          showShareAgainButton={hasShareAgainFeature}
           showSendToMobile
           onShareAgainClick={post => onShareAgainClick(post, viewType)}
           onMobileClick={post => onMobileClick(post, viewType)}
@@ -167,6 +168,7 @@ PastRemindersPosts.propTypes = {
       hasCommentEnabled: PropTypes.bool,
     })
   ),
+  hasShareAgainFeature: PropTypes.bool,
   total: PropTypes.number,
   showComposer: PropTypes.bool,
   editMode: PropTypes.bool,
@@ -193,6 +195,7 @@ PastRemindersPosts.defaultProps = {
   loading: true,
   moreToLoad: false,
   page: 1,
+  hasShareAgainFeature: false,
   total: 0,
   showComposer: false,
   showStoriesComposer: false,

--- a/packages/past-reminders/index.js
+++ b/packages/past-reminders/index.js
@@ -46,6 +46,7 @@ export default connect(
           state.profileSidebar.selectedProfile.isDisconnected,
         userData: state.user,
         showStoryPreview: state.pastReminders.showStoryPreview,
+        hasShareAgainFeature: state.organizations.selected.hasShareAgainFeature,
       };
     }
     return {};

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -71,6 +71,7 @@ const QueuedPosts = ({
   onSetRemindersClick,
   onCampaignTagClick,
   hasCampaignsFeature,
+  hasCalendarFeature,
   fetchCampaignsIfNeeded,
   shouldDisplaySingleSlots,
   preserveComposerStateOnClose,
@@ -172,7 +173,7 @@ const QueuedPosts = ({
         isBusinessAccount={isBusinessAccount}
         onCampaignTagClick={onCampaignTagClick}
         hasCampaignsFeature={hasCampaignsFeature}
-        shouldRenderCalendarButtons
+        shouldRenderCalendarButtons={hasCalendarFeature}
         pinned={!shouldDisplaySingleSlots}
       />
     </ErrorBoundary>
@@ -226,6 +227,7 @@ QueuedPosts.propTypes = {
   onCalendarClick: PropTypes.func.isRequired,
   isBusinessAccount: PropTypes.bool,
   hasCampaignsFeature: PropTypes.bool,
+  hasCalendarFeature: PropTypes.bool,
   fetchCampaignsIfNeeded: PropTypes.func.isRequired,
   shouldDisplaySingleSlots: PropTypes.bool,
   preserveComposerStateOnClose: PropTypes.bool,
@@ -255,6 +257,7 @@ QueuedPosts.defaultProps = {
   isManager: false,
   isBusinessAccount: false,
   hasCampaignsFeature: false,
+  hasCalendarFeature: false,
   shouldDisplaySingleSlots: false,
   onCampaignTagClick: () => {},
 };

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -98,6 +98,7 @@ export default connect(
         isInstagramLoading: state.queue.isInstagramLoading,
         hasFirstCommentFlip: state.user.hasFirstCommentFeature,
         hasCampaignsFeature: state.user.hasCampaignsFeature,
+        hasCalendarFeature: state.organizations.selected.hasCalendarFeature,
         shouldDisplaySingleSlots,
         shouldDisplayDisconnectedBanner:
           !shouldDisplayRetiringProfileBanner && isDisconnected,

--- a/packages/queue/index.test.js
+++ b/packages/queue/index.test.js
@@ -45,6 +45,11 @@ const initialState = {
   campaignsList: {
     campaigns: null,
   },
+  organizations: {
+    selected: {
+      hasCalendarFeature: true,
+    },
+  },
 };
 
 // eslint-disable-next-line react/prop-types

--- a/packages/sent/components/SentPosts/index.jsx
+++ b/packages/sent/components/SentPosts/index.jsx
@@ -10,7 +10,6 @@ import { Divider, Text } from '@bufferapp/components';
 import { Button } from '@bufferapp/ui';
 import ComposerPopover from '@bufferapp/publish-composer-popover';
 import LockedProfileNotification from '@bufferapp/publish-locked-profile-notification';
-import { WithFeatureLoader } from '@bufferapp/product-features';
 import getErrorBoundary from '@bufferapp/publish-web/components/ErrorBoundary';
 import ProfilesDisconnectedBanner from '@bufferapp/publish-profiles-disconnected-banner';
 
@@ -41,7 +40,7 @@ const loadMoreButtonStyle = {
   paddingBottom: '3rem',
 };
 
-const NoPostsPublished = ({ total, isBusinessAccount, features }) => {
+const NoPostsPublished = ({ total, has30DaySentPostsLimitFeature }) => {
   if (typeof total === 'undefined' || total > 0) {
     return null;
   }
@@ -50,9 +49,9 @@ const NoPostsPublished = ({ total, isBusinessAccount, features }) => {
       <EmptyState
         height="initial"
         title={
-          isBusinessAccount || !features.isFreeUser()
-            ? 'You haven’t published any posts with this account!'
-            : 'You haven’t published any posts with this account in the past 30 days!'
+          has30DaySentPostsLimitFeature
+            ? 'You haven’t published any posts with this account in the past 30 days!'
+            : 'You haven’t published any posts with this account!'
         }
         subtitle="Once a post has gone live via Buffer, you can track its performance here to learn what works best with your audience!"
         heroImg="https://s3.amazonaws.com/buffer-publish/images/empty-sent2x.png"
@@ -64,14 +63,12 @@ const NoPostsPublished = ({ total, isBusinessAccount, features }) => {
 
 NoPostsPublished.propTypes = {
   total: PropTypes.number,
-  isBusinessAccount: PropTypes.bool,
-  features: PropTypes.shape({ isFreeUser: PropTypes.func }),
+  has30DaySentPostsLimitFeature: PropTypes.bool,
 };
 
 NoPostsPublished.defaultProps = {
   total: undefined,
-  isBusinessAccount: false,
-  features: {},
+  has30DaySentPostsLimitFeature: true,
 };
 
 const SentPosts = ({
@@ -88,7 +85,7 @@ const SentPosts = ({
   isLockedProfile,
   isDisconnectedProfile,
   isBusinessAccount,
-  features,
+  has30DaySentPostsLimitFeature,
   hasFirstCommentFlip,
   hasCampaignsFeature,
   hasBitlyFeature,
@@ -130,16 +127,14 @@ const SentPosts = ({
     loadMore({ profileId, page, tabId });
   };
 
-  const header =
-    isBusinessAccount || !features.isFreeUser()
-      ? 'Your sent posts'
-      : 'Your sent posts for the last 30 days';
+  const header = has30DaySentPostsLimitFeature
+    ? 'Your sent posts for the last 30 days'
+    : 'Your sent posts';
   return (
     <ErrorBoundary>
       {isDisconnectedProfile && <ProfilesDisconnectedBanner />}
       <NoPostsPublished
-        features={features}
-        isBusinessAccount={isBusinessAccount}
+        has30DaySentPostsLimitFeature={has30DaySentPostsLimitFeature}
         total={total}
       />
 
@@ -208,7 +203,7 @@ SentPosts.propTypes = {
   moreToLoad: PropTypes.bool, // eslint-disable-line
   page: PropTypes.number, // eslint-disable-line
   hasBitlyFeature: PropTypes.bool.isRequired,
-  features: PropTypes.object.isRequired, // eslint-disable-line
+  has30DaySentPostsLimitFeature: PropTypes.bool.isRequired,
   items: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string,
@@ -265,4 +260,4 @@ SentPosts.defaultProps = {
   },
 };
 
-export default WithFeatureLoader(SentPosts);
+export default SentPosts;

--- a/packages/sent/components/SentPosts/index.jsx
+++ b/packages/sent/components/SentPosts/index.jsx
@@ -88,6 +88,7 @@ const SentPosts = ({
   has30DaySentPostsLimitFeature,
   hasFirstCommentFlip,
   hasCampaignsFeature,
+  hasShareAgainFeature,
   hasBitlyFeature,
   moreToLoad,
   tabId,
@@ -173,7 +174,7 @@ const SentPosts = ({
               isManager={isManager}
               isBusinessAccount={isBusinessAccount}
               isSent
-              showShareAgainButton
+              showShareAgainButton={hasShareAgainFeature}
               hasFirstCommentFlip={hasFirstCommentFlip}
               hasCampaignsFeature={hasCampaignsFeature}
               showAnalyzeBannerAfterFirstPost={showAnalyzeBannerAfterFirstPost}
@@ -204,6 +205,7 @@ SentPosts.propTypes = {
   page: PropTypes.number, // eslint-disable-line
   hasBitlyFeature: PropTypes.bool.isRequired,
   has30DaySentPostsLimitFeature: PropTypes.bool.isRequired,
+  hasShareAgainFeature: PropTypes.bool,
   items: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string,
@@ -249,6 +251,7 @@ SentPosts.defaultProps = {
   isBusinessAccount: false,
   hasFirstCommentFlip: false,
   hasCampaignsFeature: false,
+  hasShareAgainFeature: false,
   isLockedProfile: false,
   isDisconnectedProfile: false,
   hasBitlyPosts: false,

--- a/packages/sent/components/SentPosts/index.jsx
+++ b/packages/sent/components/SentPosts/index.jsx
@@ -91,6 +91,7 @@ const SentPosts = ({
   features,
   hasFirstCommentFlip,
   hasCampaignsFeature,
+  hasBitlyFeature,
   moreToLoad,
   tabId,
   profileId,
@@ -154,7 +155,7 @@ const SentPosts = ({
             <BitlyClickNotification
               hasBitlyPosts={hasBitlyPosts}
               isBitlyConnected={!!linkShortening.isBitlyConnected}
-              isFreeUser={features.isFreeUser}
+              hasBitlyFeature={hasBitlyFeature}
             />
             <div style={topBarContainerStyle}>
               {showComposer && !editMode && (
@@ -206,6 +207,7 @@ SentPosts.propTypes = {
   loading: PropTypes.bool,
   moreToLoad: PropTypes.bool, // eslint-disable-line
   page: PropTypes.number, // eslint-disable-line
+  hasBitlyFeature: PropTypes.bool.isRequired,
   features: PropTypes.object.isRequired, // eslint-disable-line
   items: PropTypes.arrayOf(
     PropTypes.shape({

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -47,9 +47,9 @@ export default connect(
         analyzeCrossSale: state.user.analyzeCrossSale,
         hasFirstCommentFlip: state.user.hasFirstCommentFeature,
         hasCampaignsFeature: state.user.hasCampaignsFeature,
+        hasBitlyFeature: state.organizations.selected.hasBitlyFeature,
         linkShortening: state.generalSettings.linkShortening,
         hasBitlyPosts: currentProfile.hasBitlyPosts,
-        shouldDisplayBitly: !state?.productFeatures?.isFreeUser,
       };
     }
     return {};

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -47,6 +47,7 @@ export default connect(
         analyzeCrossSale: state.user.analyzeCrossSale,
         hasFirstCommentFlip: state.user.hasFirstCommentFeature,
         hasCampaignsFeature: state.user.hasCampaignsFeature,
+        hasShareAgainFeature: state.organizations.selected.hasShareAgainFeature,
         has30DaySentPostsLimitFeature:
           state.organizations.selected.has30DaySentPostsLimitFeature,
         hasBitlyFeature: state.organizations.selected.hasBitlyFeature,

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -47,6 +47,8 @@ export default connect(
         analyzeCrossSale: state.user.analyzeCrossSale,
         hasFirstCommentFlip: state.user.hasFirstCommentFeature,
         hasCampaignsFeature: state.user.hasCampaignsFeature,
+        has30DaySentPostsLimitFeature:
+          state.organizations.selected.has30DaySentPostsLimitFeature,
         hasBitlyFeature: state.organizations.selected.hasBitlyFeature,
         linkShortening: state.generalSettings.linkShortening,
         hasBitlyPosts: currentProfile.hasBitlyPosts,

--- a/packages/server/parsers/src/orgParser.js
+++ b/packages/server/parsers/src/orgParser.js
@@ -22,7 +22,7 @@ module.exports = orgData => ({
   hasCampaignsFeature: orgData.planBase !== 'free',
   hasAnalyticsFeature: orgData.planBase === 'business',
   hasBitlyFeature: orgData.planBase !== 'free',
-  has30DaySentPostsLimitFeature: orgData.planBase === 'free',
+  has30DaySentPostsLimitFeature: orgData.planBase === 'free', // profiles_controller updates_sent() returns only 30 days of sent posts for free users.
   hasCalendarFeature: orgData.planBase !== 'free',
   hasShareAgainFeature: orgData.planBase !== 'free',
 });

--- a/packages/server/parsers/src/orgParser.js
+++ b/packages/server/parsers/src/orgParser.js
@@ -21,4 +21,5 @@ module.exports = orgData => ({
   // Plan Features
   hasCampaignsFeature: orgData.planBase !== 'free',
   hasAnalyticsFeature: orgData.planBase === 'business',
+  hasBitlyFeature: orgData.planBase !== 'free',
 });

--- a/packages/server/parsers/src/orgParser.js
+++ b/packages/server/parsers/src/orgParser.js
@@ -22,4 +22,7 @@ module.exports = orgData => ({
   hasCampaignsFeature: orgData.planBase !== 'free',
   hasAnalyticsFeature: orgData.planBase === 'business',
   hasBitlyFeature: orgData.planBase !== 'free',
+  has30DaySentPostsLimitFeature: orgData.planBase === 'free',
+  hasCalendarFeature: orgData.planBase !== 'free',
+  hasShareAgainFeature: orgData.planBase !== 'free',
 });

--- a/packages/server/parsers/src/orgParser.js
+++ b/packages/server/parsers/src/orgParser.js
@@ -20,4 +20,5 @@ module.exports = orgData => ({
 
   // Plan Features
   hasCampaignsFeature: orgData.planBase !== 'free',
+  hasAnalyticsFeature: orgData.planBase === 'business',
 });

--- a/packages/shared-components/BitlyClickNotification/index.jsx
+++ b/packages/shared-components/BitlyClickNotification/index.jsx
@@ -33,7 +33,7 @@ const BitlyClickNotification = ({
   marginAfter = false,
 }) => {
   return hasBitlyPosts && !isFreeUser() && !isBitlyConnected ? (
-    <BitlyNotification marginAfter={marginAfter}/>
+    <BitlyNotification marginAfter={marginAfter} />
   ) : null;
 };
 

--- a/packages/shared-components/BitlyClickNotification/index.jsx
+++ b/packages/shared-components/BitlyClickNotification/index.jsx
@@ -27,18 +27,18 @@ BitlyNotification.propTypes = {
 };
 
 const BitlyClickNotification = ({
-  isFreeUser,
+  hasBitlyFeature,
   isBitlyConnected,
   hasBitlyPosts,
   marginAfter = false,
 }) => {
-  return hasBitlyPosts && !isFreeUser() && !isBitlyConnected ? (
+  return hasBitlyPosts && hasBitlyFeature && !isBitlyConnected ? (
     <BitlyNotification marginAfter={marginAfter} />
   ) : null;
 };
 
 BitlyClickNotification.propTypes = {
-  isFreeUser: PropTypes.func.isRequired,
+  hasBitlyFeature: PropTypes.bool.isRequired,
   isBitlyConnected: PropTypes.bool.isRequired,
   hasBitlyPosts: PropTypes.bool.isRequired,
   marginAfter: PropTypes.bool,

--- a/packages/shared-components/QueueItems/PostContent/index.jsx
+++ b/packages/shared-components/QueueItems/PostContent/index.jsx
@@ -11,7 +11,7 @@ import Draft from '../../Draft';
 import PostDragWrapper from '../../PostDragWrapper';
 import PostActionButtons from '../../PostActionButtons';
 import BannerAdvancedAnalytics from '../../BannerAdvancedAnalytics';
-import { PostWrapper } from '../styles';
+import PostWrapper from '../styles';
 
 const ErrorBoundary = getErrorBoundary(true);
 
@@ -222,9 +222,9 @@ const PostContent = ({
   shouldShowAnalyzeBanner,
   ...postProps
 }) => {
-  const { isSent, isPastReminder, isManager, isUserPaid } = postProps;
+  const { isSent, isPastReminder, isManager } = postProps;
   const isPastPost = isSent || isPastReminder;
-  const shouldShowShareAgain = showShareAgainButton && isPastPost && isUserPaid;
+  const shouldShowShareAgain = showShareAgainButton && isPastPost;
   const shouldShowSendToMobile =
     showSendToMobile && isPastReminder && isManager;
 

--- a/packages/shared-components/QueueItems/index.jsx
+++ b/packages/shared-components/QueueItems/index.jsx
@@ -1,29 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { WithFeatureLoader } from '@bufferapp/product-features';
-import { Button, Text } from '@bufferapp/ui';
 
 import Header from './Header';
 import EmptySlot from './EmptySlot';
 import PostContent from './PostContent';
-import { ShowMorePostsWrapper, ViewCalendarWrapper } from './styles';
 
 const isPaidUser = ({ features, isBusinessAccount }) =>
   !features.isFreeUser() || isBusinessAccount;
-
-// eslint-disable-next-line react/prop-types
-const ShowMorePosts = ({ onCalendarClick }) => (
-  <ShowMorePostsWrapper>
-    <Text type="p">Looking for your other posts?</Text>
-    <ViewCalendarWrapper>
-      <Button
-        type="primary"
-        label="View Your Calendar"
-        onClick={() => onCalendarClick('month')}
-      />
-    </ViewCalendarWrapper>
-  </ShowMorePostsWrapper>
-);
 
 const QueueItems = ({
   items,
@@ -51,9 +35,7 @@ const QueueItems = ({
             item={rest}
             isFirstItem={index === 0}
             onCalendarClick={onCalendarClick}
-            shouldRenderCalendarButtons={
-              shouldRenderCalendarButtons && isUserPaid
-            }
+            shouldRenderCalendarButtons={shouldRenderCalendarButtons}
           />
         );
         break;
@@ -70,6 +52,7 @@ const QueueItems = ({
             isUserPaid={isUserPaid}
             isBusinessAccount={isBusinessAccount}
             shouldShowAnalyzeBanner={shouldShowAnalyzeBanner}
+            // eslint-disable-next-line react/jsx-props-no-spreading
             {...propsForPosts}
           />
         );
@@ -89,11 +72,6 @@ const QueueItems = ({
         );
         break;
       }
-      case 'showMorePosts':
-        QueueSection = isUserPaid && (
-          <ShowMorePosts key={rest.id} onCalendarClick={onCalendarClick} />
-        );
-        break;
       default:
         break;
     }

--- a/packages/shared-components/QueueItems/index.jsx
+++ b/packages/shared-components/QueueItems/index.jsx
@@ -6,9 +6,6 @@ import Header from './Header';
 import EmptySlot from './EmptySlot';
 import PostContent from './PostContent';
 
-const isPaidUser = ({ features, isBusinessAccount }) =>
-  !features.isFreeUser() || isBusinessAccount;
-
 const QueueItems = ({
   items,
   type,
@@ -23,7 +20,6 @@ const QueueItems = ({
 }) => {
   return items.map((item, index) => {
     const { queueItemType, slot, ...rest } = item;
-    const isUserPaid = isPaidUser({ features, isBusinessAccount });
 
     let QueueSection = null;
 
@@ -49,7 +45,6 @@ const QueueItems = ({
             index={index}
             post={rest}
             queueType={type}
-            isUserPaid={isUserPaid}
             isBusinessAccount={isBusinessAccount}
             shouldShowAnalyzeBanner={shouldShowAnalyzeBanner}
             // eslint-disable-next-line react/jsx-props-no-spreading

--- a/packages/shared-components/QueueItems/styles.js
+++ b/packages/shared-components/QueueItems/styles.js
@@ -4,7 +4,7 @@ import {
   transitionAnimationType,
 } from '@bufferapp/components/style/animation';
 
-export const PostWrapper = styled.div`
+const PostWrapper = styled.div`
   display: flex;
   align-items: flex-start;
   margin-bottom: 8px;
@@ -19,12 +19,4 @@ export const PostWrapper = styled.div`
     `}
 `;
 
-export const ShowMorePostsWrapper = styled.div`
-  text-align: center;
-  margin: 24px 0px;
-`;
-
-export const ViewCalendarWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-`;
+export default PostWrapper;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Replace features.isFreeUser() and features.isProUser() by orgs features
 - `hasAnalyticsFeature: orgData.planBase === 'business',`
 - `hasBitlyFeature: orgData.planBase !== 'free',`
 - `has30DaySentPostsLimitFeature: orgData.planBase === 'free',`
 - `hasCalendarFeature: orgData.planBase !== 'free',`
 - `hasShareAgainFeature: orgData.planBase !== 'free',`

Delete unused  ShowMorePosts
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2993
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
