### PR TITLE
[PUB-3043] Add temporary banner for retiring IG personal profiles

### DIFF
--- a/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
+++ b/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
@@ -42,14 +42,6 @@ const TemporaryDashboardBanner = ({
   const getEnabledApplicationMode = tag =>
     enabledApplicationModes.filter(mode => mode.tag === tag)[0];
 
-  if (
-    !enabledApplicationModes &&
-    !displayRemindersBanner &&
-    !shouldDisplayIGRetirementBanner
-  ) {
-    return null;
-  }
-
   // Displays Temporary Banner With Admin Message.
   if (enabledApplicationModes && getEnabledApplicationMode(dashboardBanner)) {
     const { content } = getEnabledApplicationMode(dashboardBanner);

--- a/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
+++ b/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
@@ -15,12 +15,15 @@ const TopBanner = ({
   content,
   onCloseBanner,
   themeColor = 'orange',
+  actionButton,
 }) => (
   <div style={getContainerStyle(status)}>
     <Banner
       themeColor={themeColor}
-      customHTML={{ __html: content }}
       onCloseBanner={onCloseBanner}
+      actionButton={actionButton}
+      customHTML={actionButton ? null : { __html: content }}
+      text={actionButton ? content : null}
     />
   </div>
 );
@@ -53,12 +56,20 @@ const TemporaryDashboardBanner = ({
   }
   // Displays temporary banner for Retiring IG personal profiles. Should remove in Oct.
   if (shouldDisplayIGRetirementBanner) {
+    const actionButton = {
+      label: 'Follow our guide',
+      action: () => {
+        window.location.assign(
+          'https://support.buffer.com/hc/en-us/articles/360052978413-Deprecating-Instagram-Personal-Profiles'
+        );
+      },
+    };
     return TopBanner({
       status: hidden,
-      content: `Beginning in October, we’ll no longer support personal Instagram
-          accounts. Learn how to convert
-          <a href="https://support.buffer.com/hc/en-us/articles/360052978413-Deprecating-Instagram-Personal-Profiles">to business here.</a>`,
+      content:
+        'From October 2020, we will no longer be able to support Instagram accounts where Direct Scheduling is not enabled.',
       onCloseBanner: onCloseBannerClick,
+      actionButton,
     });
   }
 

--- a/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
+++ b/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
@@ -30,6 +30,7 @@ const TopBanner = ({
 const TemporaryDashboardBanner = ({
   enabledApplicationModes,
   displayRemindersBanner,
+  shouldDisplayIGRetirementBanner,
   usernamesRemindersList,
 }) => {
   const [hidden, hideBanner] = useState(false);
@@ -41,7 +42,11 @@ const TemporaryDashboardBanner = ({
   const getEnabledApplicationMode = tag =>
     enabledApplicationModes.filter(mode => mode.tag === tag)[0];
 
-  if (!enabledApplicationModes && !displayRemindersBanner) {
+  if (
+    !enabledApplicationModes &&
+    !displayRemindersBanner &&
+    !shouldDisplayIGRetirementBanner
+  ) {
     return null;
   }
 
@@ -51,6 +56,16 @@ const TemporaryDashboardBanner = ({
     return TopBanner({
       status: hidden,
       content,
+      onCloseBanner: onCloseBannerClick,
+    });
+  }
+  // Displays temporary banner for Retiring IG personal profiles. Should remove in Oct.
+  if (shouldDisplayIGRetirementBanner) {
+    return TopBanner({
+      status: hidden,
+      content: `Beginning in October, we’ll no longer support personal Instagram
+          accounts. Learn how to convert
+          <a href="https://support.buffer.com/hc/en-us/articles/360052978413-Deprecating-Instagram-Personal-Profiles">to business here.</a>`,
       onCloseBanner: onCloseBannerClick,
     });
   }
@@ -76,11 +91,13 @@ TemporaryDashboardBanner.propTypes = {
     PropTypes.objectOf(PropTypes.string)
   ),
   displayRemindersBanner: PropTypes.bool,
+  shouldDisplayIGRetirementBanner: PropTypes.bool,
   usernamesRemindersList: PropTypes.string,
 };
 
 TemporaryDashboardBanner.defaultProps = {
   enabledApplicationModes: [],
+  shouldDisplayIGRetirementBanner: false,
 };
 
 export default TemporaryDashboardBanner;

--- a/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
+++ b/packages/temporary-banner/components/TemporaryDashboardBanner/index.jsx
@@ -57,7 +57,7 @@ const TemporaryDashboardBanner = ({
   // Displays temporary banner for Retiring IG personal profiles. Should remove in Oct.
   if (shouldDisplayIGRetirementBanner) {
     const actionButton = {
-      label: 'Follow our guide',
+      label: 'Enable Direct Scheduling',
       action: () => {
         window.location.assign(
           'https://support.buffer.com/hc/en-us/articles/360052978413-Deprecating-Instagram-Personal-Profiles'

--- a/packages/temporary-banner/components/TemporaryDashboardBanner/story.jsx
+++ b/packages/temporary-banner/components/TemporaryDashboardBanner/story.jsx
@@ -38,4 +38,13 @@ storiesOf('TemporaryDashboardBanner', module)
   .add(
     'should not show TemporaryDashboardBanner if enabledApplication is null',
     () => <TemporaryDashboardBanner enabledApplicationModes={null} />
+  )
+  .add(
+    'should show TemporaryDashboardBanner if displayIGRetirementBanner is true',
+    () => (
+      <TemporaryDashboardBanner
+        enabledApplicationModes={null}
+        displayIGRetirementBanner
+      />
+    )
   );

--- a/packages/temporary-banner/components/TemporaryDashboardBanner/story.jsx
+++ b/packages/temporary-banner/components/TemporaryDashboardBanner/story.jsx
@@ -40,7 +40,7 @@ storiesOf('TemporaryDashboardBanner', module)
     () => <TemporaryDashboardBanner enabledApplicationModes={null} />
   )
   .add(
-    'should show TemporaryDashboardBanner if displayIGRetirementBanner is true',
+    'should show IGRetirementBanner if displayIGRetirementBanner is true',
     () => (
       <TemporaryDashboardBanner
         enabledApplicationModes={null}

--- a/packages/temporary-banner/index.js
+++ b/packages/temporary-banner/index.js
@@ -14,6 +14,9 @@ export default connect(state => {
         remindersStatus
       )) ||
     false;
+  const shouldDisplayIGRetirementBanner = state.profileSidebar.profiles?.some(
+    profile => profile.service === 'instagram' && !profile.isInstagramBusiness
+  );
   let usernamesList = '';
   if (displayRemindersBanner) {
     usernamesList = getUsernamesOfProfilesWithRemindersAndNoPushNotifications(
@@ -23,6 +26,7 @@ export default connect(state => {
   return {
     enabledApplicationModes: state.temporaryBanner.enabledApplicationModes,
     displayRemindersBanner,
+    shouldDisplayIGRetirementBanner,
     usernamesRemindersList: usernamesList,
   };
 })(TemporaryDashboardBanner);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Add temporary banner for retiring IG personal profiles
https://buffer.atlassian.net/browse/PUB-3043
<!--- Describe your changes in detail. -->

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
The copy will likely change, waiting to hear back from Mike E.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
