### PR TITLE
[PUB-2993] Replace features.isFreeUser() by org features

### DIFF
--- a/packages/grid/components/GridPosts/story.jsx
+++ b/packages/grid/components/GridPosts/story.jsx
@@ -4,9 +4,7 @@ import { storiesOf } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
 import { action } from '@storybook/addon-actions';
 import GridPosts from './index';
-import {
-  gridPosts,
-} from './postData';
+import { gridPosts } from './postData';
 
 const storeFake = state => ({
   default: () => {},
@@ -21,7 +19,8 @@ const profile = {
   business: true,
   service: 'instagram',
   timezone: 'Europe/London',
-  avatar_https: 'https://buffer-media-uploads-dev.s3.amazonaws.com/5b8e886dbee2c512007b23c6/5c829d3838da0900d16ee5e4/3a9dd6c260165524ba20b2fd174a0873.original.jpg',
+  avatar_https:
+    'https://buffer-media-uploads-dev.s3.amazonaws.com/5b8e886dbee2c512007b23c6/5c829d3838da0900d16ee5e4/3a9dd6c260165524ba20b2fd174a0873.original.jpg',
 };
 
 const store = storeFake({
@@ -34,18 +33,10 @@ const store = storeFake({
   stripe: {},
   publicGridUrl: 'https://shopgr.id/my-brand',
   profile,
-  productFeatures: {
-    planName: 'business',
-    features: {},
-  },
 });
 
-const features = { isFreeUser: () => false };
-
 const UpgradeModalDecorator = storyFn => (
-  <Provider store={store}>
-    {storyFn()}
-  </Provider>
+  <Provider store={store}>{storyFn()}</Provider>
 );
 
 storiesOf('GridPosts', module)
@@ -65,7 +56,6 @@ storiesOf('GridPosts', module)
       onChangePostUrl={action('onChangePostUrl')}
       onSavePostUrl={action('onSavePostUrl')}
       publicGridUrl="https://shopgr.id/my-brand"
-      features={features}
       hasWriteAccess
     />
   ))
@@ -83,7 +73,6 @@ storiesOf('GridPosts', module)
       onChangePostUrl={action('onChangePostUrl')}
       onSavePostUrl={action('onSavePostUrl')}
       publicGridUrl="https://shopgr.id/my-brand"
-      features={features}
       hasWriteAccess={false}
     />
   ));

--- a/packages/locked-profile-notification/components/LockedProfileNotification/index.jsx
+++ b/packages/locked-profile-notification/components/LockedProfileNotification/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { WithFeatureLoader } from '@bufferapp/product-features';
 import { Card } from '@bufferapp/components';
 import { Text, Button } from '@bufferapp/ui';
 import WarningIcon from '@bufferapp/ui/Icon/Icons/Warning';
@@ -85,27 +84,23 @@ const renderButton = ({ type, onClickUpgrade }) => {
   );
 };
 
-const selectedLockedType = (isOwner, features) => {
+const selectedLockedType = (isOwner, planBase) => {
   if (!isOwner) {
     return 'teamMember';
-  } else if (features.isFreeUser()) {
-    return 'free';
-  } else if (features.isProUser()) {
-    return 'pro';
   }
-  return 'business';
+  return planBase;
 };
 
 /* eslint-enable react/prop-types */
 
 const LockedProfileNotification = ({
-  features,
+  planBase,
   isOwner,
   onClickUpgrade,
   profileLimit,
   ownerEmail,
 }) => {
-  const type = selectedLockedType(isOwner, features);
+  const type = selectedLockedType(isOwner, planBase);
 
   return (
     <Card reducedPadding>
@@ -123,7 +118,7 @@ const LockedProfileNotification = ({
 };
 
 LockedProfileNotification.propTypes = {
-  features: PropTypes.object.isRequired, // eslint-disable-line
+  planBase: PropTypes.string.isRequired, // eslint-disable-line
   onClickUpgrade: PropTypes.func,
   profileLimit: PropTypes.number,
   isOwner: PropTypes.bool.isRequired,
@@ -134,4 +129,4 @@ LockedProfileNotification.defaultProps = {
   ownerEmail: 'the owner',
 };
 
-export default WithFeatureLoader(LockedProfileNotification);
+export default LockedProfileNotification;

--- a/packages/locked-profile-notification/components/LockedProfileNotification/story.jsx
+++ b/packages/locked-profile-notification/components/LockedProfileNotification/story.jsx
@@ -1,62 +1,39 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { Provider } from 'react-redux';
 import { withA11y } from '@storybook/addon-a11y';
 import LockedProfileNotification from './index';
-
-const storeFake = state => ({
-  default: () => {},
-  subscribe: () => {},
-  dispatch: () => {},
-  getState: () => ({ ...state }),
-});
-
-function createMockStore(type) {
-  return storeFake({
-    productFeatures: {
-      planName: type,
-      features: {},
-    },
-  });
-}
-
-const storeTeamMember = createMockStore('teamMember');
-const storeFree = createMockStore('free');
-const storePro = createMockStore('pro');
-const storeBusiness = createMockStore('business');
 
 storiesOf('Locked Profile Notification', module)
   .addDecorator(withA11y)
   .add('free user', () => (
-    <Provider store={storeFree}>
-      <LockedProfileNotification
-        onClickUpgrade={action('onClickUpgrade')}
-        profileLimit={3}
-        isOwner
-      />
-    </Provider>
+    <LockedProfileNotification
+      onClickUpgrade={action('onClickUpgrade')}
+      profileLimit={3}
+      isOwner
+      planBase="free"
+    />
   ))
   .add('pro user', () => (
-    <Provider store={storePro}>
-      <LockedProfileNotification
-        onClickUpgrade={action('onClickUpgrade')}
-        profileLimit={8}
-        isOwner
-      />
-    </Provider>
+    <LockedProfileNotification
+      onClickUpgrade={action('onClickUpgrade')}
+      profileLimit={8}
+      isOwner
+      planBase="pro"
+    />
   ))
   .add('business', () => (
-    <Provider store={storeBusiness}>
-      <LockedProfileNotification
-        onClickUpgrade={action('onClickUpgrade')}
-        profileLimit={100}
-        isOwner
-      />
-    </Provider>
+    <LockedProfileNotification
+      onClickUpgrade={action('onClickUpgrade')}
+      profileLimit={100}
+      isOwner
+      planBase="business"
+    />
   ))
   .add('teamMember', () => (
-    <Provider store={storeTeamMember}>
-      <LockedProfileNotification isOwner={false} ownerEmail="ana@buffer.com" />
-    </Provider>
+    <LockedProfileNotification
+      isOwner={false}
+      ownerEmail="ana@buffer.com"
+      planBase="free"
+    />
   ));

--- a/packages/locked-profile-notification/index.js
+++ b/packages/locked-profile-notification/index.js
@@ -10,6 +10,7 @@ export default connect(
     profileLimit: state.user.profileLimit,
     isOwner: state.organizations.selected?.isOwner,
     ownerEmail: state.organizations.selected?.ownerEmail,
+    planBase: state.organizations.selected?.planBase,
   }),
   dispatch => ({
     onClickUpgrade: plan => {

--- a/packages/locked-profile-notification/index.test.jsx
+++ b/packages/locked-profile-notification/index.test.jsx
@@ -23,6 +23,7 @@ const store = storeFake({
     selected: {
       isOwner: false,
       ownerEmail: '',
+      planBase: 'free',
     },
   },
 });

--- a/packages/profile-sidebar/components/ProfileConnectShortcut/index.jsx
+++ b/packages/profile-sidebar/components/ProfileConnectShortcut/index.jsx
@@ -1,28 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Text } from '@bufferapp/components';
-import { WithFeatureLoader } from '@bufferapp/product-features';
 import { ProfileBadgeIcon } from '../ProfileBadge';
 
 const handleProfileLimitReached = (
-  features,
+  showUpgradeToProCta,
   showSwitchPlanModal,
   goToConnectSocialAccount
-) =>
-  features.isFreeUser() ? showSwitchPlanModal() : goToConnectSocialAccount();
+) => (showUpgradeToProCta ? showSwitchPlanModal() : goToConnectSocialAccount());
 
 const handleClick = (
   network,
   url,
   profiles,
   profileLimit,
-  features,
+  showUpgradeToProCta,
   showSwitchPlanModal,
   goToConnectSocialAccount
 ) => {
   if (profiles.length >= profileLimit) {
     handleProfileLimitReached(
-      features,
+      showUpgradeToProCta,
       showSwitchPlanModal,
       goToConnectSocialAccount
     );
@@ -76,7 +74,7 @@ class ProfileConnectShortcut extends React.Component {
       url,
       profiles,
       profileLimit,
-      features,
+      showUpgradeToProCta,
       showSwitchPlanModal,
       goToConnectSocialAccount,
     } = this.props;
@@ -94,7 +92,7 @@ class ProfileConnectShortcut extends React.Component {
             url,
             profiles,
             profileLimit,
-            features,
+            showUpgradeToProCta,
             showSwitchPlanModal,
             goToConnectSocialAccount
           )
@@ -121,9 +119,9 @@ ProfileConnectShortcut.propTypes = {
     })
   ).isRequired,
   profileLimit: PropTypes.number.isRequired,
-  features: PropTypes.object.isRequired, // eslint-disable-line
+  showUpgradeToProCta: PropTypes.bool.isRequired,
   goToConnectSocialAccount: PropTypes.func.isRequired,
   showSwitchPlanModal: PropTypes.func.isRequired,
 };
 
-export default WithFeatureLoader(ProfileConnectShortcut);
+export default ProfileConnectShortcut;

--- a/packages/profile-sidebar/components/ProfileSidebar/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/index.jsx
@@ -105,6 +105,7 @@ const ProfileSidebar = ({
   hasCampaignsFlip,
   onCampaignsButtonClick,
   isCampaignsSelected,
+  showUpgradeToProCta,
 }) => {
   const { t } = useTranslation();
 
@@ -176,6 +177,7 @@ const ProfileSidebar = ({
                   profiles={profiles}
                   showSwitchPlanModal={showSwitchPlanModal}
                   goToConnectSocialAccount={goToConnectSocialAccount}
+                  showUpgradeToProCta={showUpgradeToProCta}
                 />
               )}
               {!hasFacebook && (
@@ -187,6 +189,7 @@ const ProfileSidebar = ({
                   profiles={profiles}
                   showSwitchPlanModal={showSwitchPlanModal}
                   goToConnectSocialAccount={goToConnectSocialAccount}
+                  showUpgradeToProCta={showUpgradeToProCta}
                 />
               )}
               {!hasTwitter && (
@@ -198,6 +201,7 @@ const ProfileSidebar = ({
                   profiles={profiles}
                   showSwitchPlanModal={showSwitchPlanModal}
                   goToConnectSocialAccount={goToConnectSocialAccount}
+                  showUpgradeToProCta={showUpgradeToProCta}
                 />
               )}
             </>
@@ -244,6 +248,7 @@ ProfileSidebar.propTypes = {
   isCampaignsSelected: PropTypes.bool,
   onCampaignsButtonClick: PropTypes.func,
   ownerEmail: PropTypes.string,
+  showUpgradeToProCta: PropTypes.bool,
 };
 
 ProfileSidebar.defaultProps = {
@@ -260,6 +265,7 @@ ProfileSidebar.defaultProps = {
   hasCampaignsFlip: false,
   isCampaignsSelected: false,
   ownerEmail: 'the owner',
+  showUpgradeToProCta: true,
 };
 
 export default ProfileSidebar;

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -32,6 +32,7 @@ export default hot(
           pathname: state.router?.location?.pathname,
           route: campaignsPage.route,
         }),
+        showUpgradeToProCta: state.organizations.selected?.showUpgradeToProCta,
       };
     },
     (dispatch, ownProps) => ({

--- a/packages/queue/middleware.test.js
+++ b/packages/queue/middleware.test.js
@@ -7,18 +7,6 @@ import {
 import { actionTypes, actions } from './reducer';
 import middleware from './middleware';
 
-const getStateWithPaidUser = () => ({
-  user: {
-    isFreeUser: false,
-  },
-  profileSidebar: {
-    selectedProfileId: 'id1',
-    selectedProfile: {
-      service_type: 'profile',
-    },
-  },
-});
-
 describe('middleware', () => {
   const next = jest.fn();
   const dispatch = jest.fn();
@@ -34,7 +22,7 @@ describe('middleware', () => {
         id: 'id1',
       },
     };
-    middleware({ dispatch, getState: getStateWithPaidUser })(next)(action);
+    middleware({ dispatch })(next)(action);
     expect(next).toBeCalledWith(action);
     expect(dispatch).toBeCalledWith(
       dataFetchActions.fetch({
@@ -55,7 +43,7 @@ describe('middleware', () => {
         profileId: 'id1',
       },
     };
-    middleware({ dispatch, getState: getStateWithPaidUser })(next)(action);
+    middleware({ dispatch })(next)(action);
     expect(next).toBeCalledWith(action);
     expect(dispatch).toBeCalledWith(
       dataFetchActions.fetch({
@@ -76,7 +64,7 @@ describe('middleware', () => {
         profileId: 'id1',
       },
     };
-    middleware({ dispatch, getState: getStateWithPaidUser })(next)(action);
+    middleware({ dispatch })(next)(action);
     expect(next).toBeCalledWith(action);
     expect(dispatch).toBeCalledWith(
       dataFetchActions.fetch({
@@ -117,7 +105,7 @@ describe('middleware', () => {
         profileId: 'id1',
       },
     });
-    middleware({ dispatch, getState: getStateWithPaidUser })(next)(action);
+    middleware({ dispatch })(next)(action);
     expect(next).toBeCalledWith(action);
     expect(dispatch).toBeCalledWith(
       dataFetchActions.fetch({

--- a/packages/server/parsers/src/orgParser.js
+++ b/packages/server/parsers/src/orgParser.js
@@ -27,4 +27,5 @@ module.exports = orgData => ({
   hasShareAgainFeature: orgData.planBase !== 'free',
   hasCustomizingUtmParamsFeature:
     orgData.planBase === 'business' && orgData.isOwner,
+  showUpgradeToProCta: orgData.planBase === 'free',
 });

--- a/packages/server/rpc/preferences/changeDateTimePreferences/test.js
+++ b/packages/server/rpc/preferences/changeDateTimePreferences/test.js
@@ -18,6 +18,7 @@ const mockUser = {
   email_notifications: [],
   feature_trials: [],
   tags: [],
+  id: 'id1',
 };
 describe('rpc/changeDateTimePreferences', () => {
   beforeEach(() => {
@@ -54,6 +55,6 @@ describe('rpc/changeDateTimePreferences', () => {
       },
       { session }
     );
-    expect(response.isFreeUser).toBeTruthy();
+    expect(response).toHaveProperty('id', 'id1');
   });
 });

--- a/packages/stories/middleware.js
+++ b/packages/stories/middleware.js
@@ -6,7 +6,7 @@ import {
 import { actions as notificationActions } from '@bufferapp/notifications';
 import { actionTypes } from './reducer';
 
-export default ({ dispatch, getState }) => next => action => {
+export default ({ dispatch }) => next => action => {
   next(action);
   switch (action.type) {
     case profileActionTypes.SELECT_PROFILE:

--- a/packages/stories/middleware.test.js
+++ b/packages/stories/middleware.test.js
@@ -2,12 +2,6 @@ import { actionTypes as profileActionTypes } from '@bufferapp/publish-profile-si
 import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 import middleware from './middleware';
 
-const getStateWithPaidUser = () => ({
-  user: {
-    isFreeUser: false,
-  },
-});
-
 describe('middleware', () => {
   const next = jest.fn();
   const dispatch = jest.fn();
@@ -23,7 +17,7 @@ describe('middleware', () => {
         id: 'id1',
       },
     };
-    middleware({ dispatch, getState: getStateWithPaidUser })(next)(action);
+    middleware({ dispatch })(next)(action);
     expect(next).toBeCalledWith(action);
     expect(dispatch).toBeCalledWith(
       dataFetchActions.fetch({

--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -68,12 +68,9 @@ export default ({ dispatch, getState }) => next => action => {
             /(local\.buffer)|(dev\.buffer\.com)/
           ),
         });
-        const { id } = action.result;
-        const {
-          productFeatures: { planName },
-        } = getState();
+        const { id, planBase } = action.result;
         FullStory.identify(id, {
-          pricingPlan_str: planName,
+          pricingPlan_str: planBase,
         });
       }
       break;

--- a/packages/thirdParty/middleware.test.js
+++ b/packages/thirdParty/middleware.test.js
@@ -18,6 +18,7 @@ const mockUser = {
   createdAt: 'date',
   plan: 'business',
   planCode: '100',
+  planBase: 'business',
   trial: {},
   orgUserCount: 2,
   profileCount: 3,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Replace features.isFreeUser() and features.isProUser() by orgs features
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2993
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
