### PR TITLE
Add temporary way for buffer admin to connect personal ig profile

### DIFF
--- a/packages/profile-sidebar/components/ProfileSidebar/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/index.jsx
@@ -184,7 +184,7 @@ const ProfileSidebar = ({
               )}
               {canSeeIGPersonalProfileConnect && (
                 <ProfileConnectShortcut
-                  label="Connect Personal IG"
+                  label="Connect Personal IG (Admin)"
                   network="instagram"
                   url="https://buffer.com/oauth/instagram"
                   profileLimit={profileLimit}

--- a/packages/profile-sidebar/components/ProfileSidebar/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/index.jsx
@@ -106,7 +106,7 @@ const ProfileSidebar = ({
   onCampaignsButtonClick,
   isCampaignsSelected,
   showUpgradeToProCta,
-  // temp allows buffer admin to connect personal ig profiles
+  // temporarily allows buffer admin to connect personal ig profiles
   canSeeIGPersonalProfileConnect,
 }) => {
   const { t } = useTranslation();

--- a/packages/profile-sidebar/components/ProfileSidebar/index.jsx
+++ b/packages/profile-sidebar/components/ProfileSidebar/index.jsx
@@ -106,6 +106,8 @@ const ProfileSidebar = ({
   onCampaignsButtonClick,
   isCampaignsSelected,
   showUpgradeToProCta,
+  // temp allows buffer admin to connect personal ig profiles
+  canSeeIGPersonalProfileConnect,
 }) => {
   const { t } = useTranslation();
 
@@ -173,6 +175,18 @@ const ProfileSidebar = ({
                   label={t('profile-sidebar.connectInstagram')}
                   network="instagram"
                   url={`https://${getURL.getBaseURL()}/oauth/instagram/choose_business?cta=publish-app-sidebar-addProfile-1`}
+                  profileLimit={profileLimit}
+                  profiles={profiles}
+                  showSwitchPlanModal={showSwitchPlanModal}
+                  goToConnectSocialAccount={goToConnectSocialAccount}
+                  showUpgradeToProCta={showUpgradeToProCta}
+                />
+              )}
+              {canSeeIGPersonalProfileConnect && (
+                <ProfileConnectShortcut
+                  label="Connect Personal IG"
+                  network="instagram"
+                  url="https://buffer.com/oauth/instagram"
                   profileLimit={profileLimit}
                   profiles={profiles}
                   showSwitchPlanModal={showSwitchPlanModal}
@@ -249,6 +263,7 @@ ProfileSidebar.propTypes = {
   onCampaignsButtonClick: PropTypes.func,
   ownerEmail: PropTypes.string,
   showUpgradeToProCta: PropTypes.bool,
+  canSeeIGPersonalProfileConnect: PropTypes.bool,
 };
 
 ProfileSidebar.defaultProps = {
@@ -266,6 +281,7 @@ ProfileSidebar.defaultProps = {
   isCampaignsSelected: false,
   ownerEmail: 'the owner',
   showUpgradeToProCta: true,
+  canSeeIGPersonalProfileConnect: false,
 };
 
 export default ProfileSidebar;

--- a/packages/profile-sidebar/index.js
+++ b/packages/profile-sidebar/index.js
@@ -33,6 +33,8 @@ export default hot(
           route: campaignsPage.route,
         }),
         showUpgradeToProCta: state.organizations.selected?.showUpgradeToProCta,
+        canSeeIGPersonalProfileConnect:
+          state.user.canSeeIGPersonalProfileConnect,
       };
     },
     (dispatch, ownProps) => ({

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -111,6 +111,6 @@ module.exports = userData => ({
 
   // Org owner data
   features: userData.features,
-  // add temporarily way for buffer admin to connect personal ig profile
+  // add temporary way for buffer admin to connect personal ig profile
   canSeeIGPersonalProfileConnect: userData.is_admin,
 });

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -111,4 +111,6 @@ module.exports = userData => ({
 
   // Org owner data
   features: userData.features,
+  // add temporarily way for buffer admin to connect personal ig profile
+  canSeeIGPersonalProfileConnect: userData.is_admin,
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Currently, there is no way for users to connect new personal instagram profiles. However, as we're still supporting old personal ig profiles, advocates would like a way to connect personal profiles for debugging purposes. We're only displaying personal ig connect button if the `is_admin` field on the user object is true. 
<!--- Describe your changes in detail. -->

## Context & Notes
"The user collection in mongo has a role field which can be set to admin or customer or possibly affiliate." - Mick
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
