### PR TITLE
[PUB-2990] Replace plan === 'pro' references by planBase

### DIFF
--- a/packages/plans/components/Plans/index.jsx
+++ b/packages/plans/components/Plans/index.jsx
@@ -29,6 +29,7 @@ const ContainerStyle = styled.div`
 const Plans = ({
   onChoosePlanClick,
   currentPlan,
+  currentPlanBase,
   onBackToDashboardClick,
   selectedProfileId,
   profiles,
@@ -38,93 +39,98 @@ const Plans = ({
   selectedPremiumPlan,
   shouldSeeSoloPlanOption,
   onProTrial = false,
-}) => (
-  <ContainerStyle>
-    <ButtonStyle>
-      <Button
-        type="secondary"
-        size="small"
-        icon={<ArrowLeft color={gray} />}
-        label={translations.buttonDashboardText}
-        onClick={() =>
-          onBackToDashboardClick({
-            selectedProfileId,
-            profiles,
-          })
-        }
-      />
-    </ButtonStyle>
-    <div style={{ textAlign: 'center' }}>
-      <HeaderStyle type="h1">{translations.headerText}</HeaderStyle>
-      {!shouldSeeSoloPlanOption && (
-        <ColumnContainerStyle>
-          <PlanColumn
-            {...translations.pro}
-            imageSrc="https://static.buffer.com/marketing/static/illustrations/publish-pricing-pro@2x.jpeg"
-            currentPlan={currentPlan}
-            onChoosePlanClick={onChoosePlanClick}
-            source={getSource({ newPlan: 'pro', currentPlan })}
-            isNonprofit={isNonprofit}
-          />
-          <PlanColumn
-            {...translations.premium}
-            imageSrc="https://static.buffer.com/marketing/static/illustrations/publish-pricing-premium@2x.jpeg"
-            currentPlan={currentPlan}
-            onChoosePlanClick={onChoosePlanClick}
-            source={getSource({ newPlan: 'premium_business', currentPlan })}
-            isNonprofit={isNonprofit}
-          />
-          <PlanColumn
-            {...translations.small}
-            imageSrc="https://static.buffer.com/marketing/static/illustrations/publish-pricing-business@2x.jpeg"
-            currentPlan={currentPlan}
-            onChoosePlanClick={onChoosePlanClick}
-            source={getSource({ newPlan: 'small', currentPlan })}
-            isNonprofit={isNonprofit}
-          />
-        </ColumnContainerStyle>
-      )}
-      {shouldSeeSoloPlanOption && (
-        <ColumnContainerStyle>
-          <PlanColumnWithPremiumSolo
-            {...translations.proExperiment}
-            imageSrc="https://static.buffer.com/marketing/static/illustrations/publish-pricing-pro@2x.jpeg"
-            currentPlan={currentPlan}
-            onChoosePlanClick={onChoosePlanClick}
-            source={getSource({ newPlan: 'pro', currentPlan })}
-            isNonprofit={isNonprofit}
-            onProTrial={onProTrial}
-          />
-          <PlanColumnWithPremiumSolo
-            {...translations.premiumExperiment}
-            imageSrc="https://static.buffer.com/marketing/static/illustrations/publish-pricing-premium@2x.jpeg"
-            currentPlan={currentPlan}
-            onChoosePlanClick={onChoosePlanClick}
-            source={getSource({
-              newPlan:
-                selectedPremiumPlan === 1
-                  ? 'solo_premium_business'
-                  : 'premium_business',
-              currentPlan,
-            })}
-            isNonprofit={isNonprofit}
-            onPremiumPlanClick={onPremiumPlanClick}
-            selectedPremiumPlan={selectedPremiumPlan}
-            onProTrial={onProTrial}
-          />
-        </ColumnContainerStyle>
-      )}
-    </div>
-  </ContainerStyle>
-);
+}) => {
+  // We use the planName (free, pro8, pro5, premium_business, ...) but are expecting to receive the planBase label for pro plans.
+  if (currentPlanBase === 'pro') currentPlan = currentPlanBase;
+  return (
+    <ContainerStyle>
+      <ButtonStyle>
+        <Button
+          type="secondary"
+          size="small"
+          icon={<ArrowLeft color={gray} />}
+          label={translations.buttonDashboardText}
+          onClick={() =>
+            onBackToDashboardClick({
+              selectedProfileId,
+              profiles,
+            })
+          }
+        />
+      </ButtonStyle>
+      <div style={{ textAlign: 'center' }}>
+        <HeaderStyle type="h1">{translations.headerText}</HeaderStyle>
+        {!shouldSeeSoloPlanOption && (
+          <ColumnContainerStyle>
+            <PlanColumn
+              {...translations.pro}
+              imageSrc="https://static.buffer.com/marketing/static/illustrations/publish-pricing-pro@2x.jpeg"
+              currentPlan={currentPlan}
+              onChoosePlanClick={onChoosePlanClick}
+              source={getSource({ newPlan: 'pro', currentPlan })}
+              isNonprofit={isNonprofit}
+            />
+            <PlanColumn
+              {...translations.premium}
+              imageSrc="https://static.buffer.com/marketing/static/illustrations/publish-pricing-premium@2x.jpeg"
+              currentPlan={currentPlan}
+              onChoosePlanClick={onChoosePlanClick}
+              source={getSource({ newPlan: 'premium_business', currentPlan })}
+              isNonprofit={isNonprofit}
+            />
+            <PlanColumn
+              {...translations.small}
+              imageSrc="https://static.buffer.com/marketing/static/illustrations/publish-pricing-business@2x.jpeg"
+              currentPlan={currentPlan}
+              onChoosePlanClick={onChoosePlanClick}
+              source={getSource({ newPlan: 'small', currentPlan })}
+              isNonprofit={isNonprofit}
+            />
+          </ColumnContainerStyle>
+        )}
+        {shouldSeeSoloPlanOption && (
+          <ColumnContainerStyle>
+            <PlanColumnWithPremiumSolo
+              {...translations.proExperiment}
+              imageSrc="https://static.buffer.com/marketing/static/illustrations/publish-pricing-pro@2x.jpeg"
+              currentPlan={currentPlan}
+              onChoosePlanClick={onChoosePlanClick}
+              source={getSource({ newPlan: 'pro', currentPlan })}
+              isNonprofit={isNonprofit}
+              onProTrial={onProTrial}
+            />
+            <PlanColumnWithPremiumSolo
+              {...translations.premiumExperiment}
+              imageSrc="https://static.buffer.com/marketing/static/illustrations/publish-pricing-premium@2x.jpeg"
+              currentPlan={currentPlan}
+              onChoosePlanClick={onChoosePlanClick}
+              source={getSource({
+                newPlan:
+                  selectedPremiumPlan === 1
+                    ? 'solo_premium_business'
+                    : 'premium_business',
+                currentPlan,
+              })}
+              isNonprofit={isNonprofit}
+              onPremiumPlanClick={onPremiumPlanClick}
+              selectedPremiumPlan={selectedPremiumPlan}
+              onProTrial={onProTrial}
+            />
+          </ColumnContainerStyle>
+        )}
+      </div>
+    </ContainerStyle>
+  );
+};
 
 Plans.propTypes = {
   onChoosePlanClick: PropTypes.func.isRequired,
   currentPlan: PropTypes.string.isRequired,
+  currentPlanBase: PropTypes.string.isRequired,
   onBackToDashboardClick: PropTypes.func.isRequired,
   selectedProfileId: ProfileSidebarComponent.propTypes.selectedProfileId,
   profiles: ProfileSidebarComponent.propTypes.profiles.isRequired,
-  translations: PropTypes.object.isRequired,  // eslint-disable-line
+  translations: PropTypes.object.isRequired, // eslint-disable-line
   isNonprofit: PropTypes.bool.isRequired,
 };
 

--- a/packages/plans/index.js
+++ b/packages/plans/index.js
@@ -9,7 +9,8 @@ import { actions } from './reducer';
 
 export default connect(
   state => ({
-    currentPlan: state.user.plan,
+    currentPlan: state.organizations?.selected?.plan,
+    currentPlanBase: state.organizations?.selected?.planBase,
     onProTrial:
       state.user.trial?.onTrial &&
       !state.profileSidebar.selectedProfile.business,
@@ -18,7 +19,7 @@ export default connect(
     translations: state.i18n.translations['plans-page'],
     isNonprofit: state.user.isNonprofit,
     selectedPremiumPlan: state.plans.selectedPremiumPlan,
-    shouldSeeSoloPlanOption: state.user.plan === 'pro',
+    shouldSeeSoloPlanOption: state.organizations?.selected?.planBase === 'pro',
   }),
   dispatch => ({
     onPremiumPlanClick: ({ selectedPlan }) => {

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -76,11 +76,7 @@ module.exports = userData => ({
   canReconnectChannels: true, // temporary value, the important is what's being injected in the rpc
 
   // Org data
-  plan:
-    userData.billing_plan_tier === 'pro8' ||
-    userData.billing_plan_tier === 'pro15'
-      ? 'pro'
-      : userData.billing_plan_tier, // temporary, as we transition from userData.plan. Safe to delete the conditions once we remove the plan ==='pro' checks in the codebase .
+  plan: userData.billing_plan_tier,
   planBase: userData.billing_plan_base,
   planCode: userData.plan_code,
   isBusinessUser: userData.billing_plan_base === 'business',

--- a/packages/server/rpc/user/index.js
+++ b/packages/server/rpc/user/index.js
@@ -76,7 +76,7 @@ module.exports = method(
           if (hasOrgSwitcher) {
             return {
               ...user,
-              plan: plan === 'pro8' || plan === 'pro15' ? 'pro' : plan,
+              plan,
               planCode,
               planBase,
               features: ownerFeatures,

--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -10,9 +10,9 @@ import * as FullStory from '@fullstory/browser';
 
 import { actionTypes } from './reducer';
 
-const shouldIdentifyWithAppcues = ({ isBusinessUser, plan, tags }) => {
+const shouldIdentifyWithAppcues = ({ plan, tags }) => {
   // We identify with Appcues for all Business and Pro users
-  if (isBusinessUser || plan === 'pro') {
+  if (plan !== 'free') {
     return true;
   }
   // We also identify with any team members of migrated Awesome users
@@ -86,30 +86,32 @@ export default ({ dispatch, getState }) => next => action => {
             });
           }
         } else if (window.Appcues) {
+          let { plan } = action.result;
           const {
             id,
             createdAt,
-            plan,
+            planBase,
             planCode,
             trial,
             orgUserCount,
             profileCount,
-            isBusinessUser,
             tags,
             canSeeOrgSwitcher,
           } = action.result; // user
-          if (shouldIdentifyWithAppcues({ isBusinessUser, plan, tags })) {
+          if (shouldIdentifyWithAppcues({ plan, tags })) {
             dispatch({
               type: actionTypes.APPCUES_LOADED,
               loaded: true,
             });
+            // We use the planName (free, pro8, pro5, premium_business, ...) but are expecting to receive the planBase label for pro plans.
+            if (planBase === 'pro') plan = planBase;
 
             const modalsShowing = modalReducers.isShowingModals(getState());
             window.Appcues.identify(id, {
               modalsShowing,
               name: id, // current user's name
               createdAt, // Unix timestamp of user signup date
-              plan, // Current user’s plan type
+              plan, // Current user’s plan name
               planCode, // Current user’s plan tier
               onTrial: trial.onTrial,
               trialLength: trial.trialLength,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Replace plan === 'pro' references by planBase

I've made sure the single source of truth for the planName (the org) is storing the same values as the API. However, on the AppCues and the plans page, I'm still overriding that value, as 1) the plans page is eventually gonna disappear, 2) changing the appCues would require Mike E to change the conditions set in the platform.

<!--- Describe your changes in detail. -->

## Context & Notes
We have 2 different fields for plans names:
`billing_plan_tier` is the name of plan (free, pro8, pro15, solo_premium_business, premium_business)
`billing_plan_base` is the group of the plan (free, pro, business
Currently we store the billing_plan_tier in plan and billing_plan_base in planBase, but our frontend expects plan to be a mix between both.

https://buffer.atlassian.net/browse/PUB-2990
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
