### PR TITLE
[PUB-2998] Add orgs data to composer

### DIFF
--- a/packages/composer-popover/components/ComposerWrapper/index.jsx
+++ b/packages/composer-popover/components/ComposerWrapper/index.jsx
@@ -99,6 +99,7 @@ export default connect(
       return {
         userData: state.user,
         profiles: getProfiles(state, selectedProfileId),
+        organizations: state.organizations,
         enabledApplicationModes: state.temporaryBanner.enabledApplicationModes,
         environment: state.environment.environment,
         editMode: false,

--- a/packages/composer/composer/AppConstants.js
+++ b/packages/composer/composer/AppConstants.js
@@ -274,6 +274,7 @@ const ActionTypes = keyMirror({
   APP_RESET: null,
   APP_SOFT_RESET: null,
   APP_RECEIVE_USER_DATA: null,
+  APP_RECEIVE_ORGANIZATIONS_DATA: null,
   APP_RECEIVE_METADATA: null,
   APP_RECEIVE_OPTIONS: null,
   APP_RECEIVE_CSRF_TOKEN: null,

--- a/packages/composer/composer/action-creators/AppActionCreators.js
+++ b/packages/composer/composer/action-creators/AppActionCreators.js
@@ -240,10 +240,13 @@ const AppActionCreators = {
           // Did we get an error because the user reached a limit and could upgrade?
           // Don't show it as an 'error' in that case
           if (unsuccessfulResponse.code === UpgradeErrorCodes.queueLimit) {
-            const userData = AppStore.getUserData();
-            const { isFreeUser, isBusinessUser, canStartProTrial } = userData;
+            const organizations = AppStore.getOrganizationsData();
+            const {
+              showUpgradeToBusinessCta,
+              showUpgradeToProCta,
+            } = organizations.selected;
             const scope = `${NotificationScopes.PROFILE_QUEUE_LIMIT}-${unsuccessfulResponse.serviceName}`;
-            const source = 'queue_limit';
+
             NotificationActionCreators.queueInfo({
               scope,
               // Remove the <a> from the response message for now until the backend stops returning it
@@ -259,7 +262,7 @@ const AppActionCreators = {
                 label: 'Show Paid Plans',
                 action: () => {
                   const { environment } = AppStore.getMetaData();
-                  if (isFreeUser) {
+                  if (showUpgradeToProCta) {
                     if (AppStore.isExtension()) {
                       window.open(`${bufferOrigins.get(environment)}/pricing`);
                     } else {
@@ -267,7 +270,7 @@ const AppActionCreators = {
                         actionType: ActionTypes.EVENT_SHOW_SWITCH_PLAN_MODAL,
                       });
                     }
-                  } else if (!isBusinessUser) {
+                  } else if (showUpgradeToBusinessCta) {
                     window.open(`${bufferOrigins.get(environment)}/pricing`);
                   } else {
                     window.open(

--- a/packages/composer/composer/action-creators/AppInitActionCreators.js
+++ b/packages/composer/composer/action-creators/AppInitActionCreators.js
@@ -107,6 +107,13 @@ const loadInitialUserData = userData => {
   });
 };
 
+const loadInitialOrganizationsData = organizationsData => {
+  AppDispatcher.handleViewAction({
+    actionType: ActionTypes.APP_RECEIVE_ORGANIZATIONS_DATA,
+    organizationsData,
+  });
+};
+
 const loadInitialImageDimensionsKey = imageDimensionsKey => {
   AppDispatcher.handleViewAction({
     actionType: ActionTypes.APP_RECEIVE_IMAGE_DIMENSIONS_KEY,
@@ -413,6 +420,7 @@ const AppInitActionCreators = {
    */
   loadInitialData: ({
     profilesData,
+    organizationsData,
     userData,
     metaData,
     csrfToken,
@@ -429,6 +437,7 @@ const AppInitActionCreators = {
     loadInitialOptions(clonedOptions);
     loadInitialProfilesData(cloneDeep(profilesData), clonedOptions);
     loadInitialUserData(cloneDeep({ ...userData, onNewPublish }));
+    loadInitialOrganizationsData(cloneDeep(organizationsData));
 
     AppHooks.handleAppLoaded();
   },

--- a/packages/composer/composer/components/App.jsx
+++ b/packages/composer/composer/components/App.jsx
@@ -30,6 +30,7 @@ function getState() {
     appState: AppStore.getAppState(),
     metaData: AppStore.getMetaData(),
     userData: AppStore.getUserData(),
+    organizations: AppStore.getOrganizationsData(),
     scheduledAt,
     availableSchedulesSlotsForDay: AppStore.getAvailableSchedulesSlotsForDay(
       scheduledAt
@@ -314,6 +315,7 @@ class App extends React.Component {
     const {
       profilesData,
       userData,
+      organizationsData,
       metaData,
       csrfToken,
       draftMode,
@@ -349,6 +351,7 @@ class App extends React.Component {
       AppInitActionCreators.loadInitialData({
         profilesData,
         userData,
+        organizationsData,
         metaData,
         csrfToken,
         draftMode,
@@ -419,6 +422,7 @@ class App extends React.Component {
         appState={this.state.appState}
         profiles={this.state.profiles}
         userData={this.state.userData}
+        organizations={this.state.organizations}
         scheduledAt={this.state.scheduledAt}
         visibleNotifications={this.state.visibleNotifications}
         topLevelNotificationContainerExcludedScopes={

--- a/packages/composer/composer/components/AppStateless.jsx
+++ b/packages/composer/composer/components/AppStateless.jsx
@@ -169,6 +169,7 @@ class AppStateless extends React.Component {
       visibleNotifications,
       topLevelNotificationContainerExcludedScopes,
       userData,
+      organizations,
       scheduledAt,
       areAllDraftsSaved,
       saveButtons,
@@ -256,6 +257,7 @@ class AppStateless extends React.Component {
             isOmniboxEnabled={omniboxEnabled}
             appState={appState}
             profiles={profiles}
+            organizations={organizations}
             shouldShowInlineSubprofileDropdown={this.shouldShowInlineSubprofileDropdown(
               { canSelectProfiles, profiles }
             )}

--- a/packages/composer/composer/components/ComposerSection.jsx
+++ b/packages/composer/composer/components/ComposerSection.jsx
@@ -23,6 +23,7 @@ const ComposerComponent = ({
   index,
   state,
   profiles,
+  organizations,
   isOmniboxEnabled,
   enabledDrafts,
   AppStore,
@@ -68,6 +69,7 @@ const ComposerComponent = ({
       enabledDrafts={enabledDrafts}
       draftsSharedData={draftsSharedData}
       profiles={profiles}
+      organizations={organizations}
       expandedComposerId={
         isOmniboxEnabled ? draft.id : appState.expandedComposerId
       }
@@ -112,6 +114,7 @@ class ComposerSection extends React.Component {
     const {
       appState,
       profiles,
+      organizations,
       visibleNotifications,
       areAllDraftsSaved,
       selectedProfiles,
@@ -160,6 +163,7 @@ class ComposerSection extends React.Component {
               state: this.state,
               draft: omniDraft,
               profiles,
+              organizations,
               isOmniboxEnabled,
               enabledDrafts,
               AppStore,
@@ -190,6 +194,7 @@ class ComposerSection extends React.Component {
                 draft,
                 index,
                 profiles,
+                organizations,
                 isOmniboxEnabled,
                 enabledDrafts,
                 AppStore,

--- a/packages/composer/composer/stores/AppStore.js
+++ b/packages/composer/composer/stores/AppStore.js
@@ -22,6 +22,8 @@ const CHANGE_EVENT = 'change';
 const getInitialState = () => ({
   profiles: [], // Data structure in getNewProfile()
 
+  organizations: {},
+
   // Describe the application state
   appState: {
     isLoaded: false,
@@ -77,6 +79,7 @@ const softResetState = () => {
       isOmniboxEnabled,
     },
     userData,
+    organizations,
     metaData,
     options,
     csrfToken,
@@ -97,6 +100,7 @@ const softResetState = () => {
       domainsOwnedByFacebookPages,
       isOmniboxEnabled: reEnableOmnibox || newState.appState.isOmniboxEnabled,
     },
+    organizations,
     userData,
     metaData,
     options,
@@ -191,6 +195,7 @@ const AppStore = Object.assign({}, EventEmitter.prototype, {
     state.metaData.appEnvironment !== AppEnvironments.WEB_DASHBOARD,
   getAppState: () => state.appState,
   getUserData: () => state.userData,
+  getOrganizationsData: () => state.organizationsData,
   getMetaData: () => state.metaData,
   getOptions: () => state.options,
   getCsrfToken: () => state.csrfToken,
@@ -765,6 +770,7 @@ const setImageDimensionsKey = key => (state.imageDimensionsKey = key);
 const setMetaData = metaData => (state.metaData = metaData);
 const setOptions = options => (state.options = options);
 const setCsrfToken = csrfToken => (state.csrfToken = csrfToken);
+const setOrganizationsData = organizationsData => (state.organizationsData = organizationsData);
 
 const setTwitterAutocompleteBootstrapData = (friends, profilesIds) => {
   state.appState.twitterAutocompleBootstrapData = getNewTwitterAutocompleteBootstrapData(
@@ -1144,6 +1150,11 @@ const onDispatchedPayload = payload => {
     case ActionTypes.APP_RECEIVE_USER_DATA:
       setUserData(action.userData);
       break;
+
+    case ActionTypes.APP_RECEIVE_ORGANIZATIONS_DATA:
+      setOrganizationsData(action.organizationsData);
+      break;
+
     case ActionTypes.APP_RECEIVE_IMAGE_DIMENSIONS_KEY:
       setImageDimensionsKey(action.imageDimensionsKey);
       break;

--- a/packages/composer/composer/tests/action-creators/AppActionCreators.test.js
+++ b/packages/composer/composer/tests/action-creators/AppActionCreators.test.js
@@ -55,6 +55,9 @@ describe('AppActionCreators', () => {
     afterEach(() => jest.resetAllMocks());
 
     it('shows an upgrade notice when the profile queue limit is reached', async () => {
+      AppStore.getOrganizationsData.mockReturnValue({
+        selected: { showUpgradeToProCta: true },
+      });
       WebAPIUtils.saveDrafts.mockReturnValue(
         Promise.resolve({
           successfulResponses: [],

--- a/packages/composer/interfaces/buffer-publish.jsx
+++ b/packages/composer/interfaces/buffer-publish.jsx
@@ -18,6 +18,7 @@ let prevSelectedProfileId = null;
 const ComposerWrapper = ({
   userData,
   profiles,
+  organizations,
   enabledApplicationModes,
   environment,
   editMode,
@@ -130,6 +131,7 @@ const ComposerWrapper = ({
     <Composer
       profilesData={formattedData.profilesData}
       userData={formattedData.userData}
+      organizationsData={organizations}
       metaData={formattedData.metaData}
       imageDimensionsKey={formattedData.imageDimensionsKey}
       options={options}
@@ -153,6 +155,7 @@ ComposerWrapper.propTypes = {
     hasShareNextFeature: PropTypes.bool.isRequired,
     imageDimensionsKey: PropTypes.string.isRequired,
   }).isRequired,
+  organizations: PropTypes.shape({}).isRequired,
   profiles: PropTypes.arrayOf(PropTypes.object).isRequired,
   enabledApplicationModes: PropTypes.arrayOf(PropTypes.string).isRequired,
   onSave: PropTypes.func.isRequired,

--- a/packages/server/parsers/src/orgParser.js
+++ b/packages/server/parsers/src/orgParser.js
@@ -33,7 +33,25 @@ module.exports = orgData => ({
   hasStoriesFeature: orgData.planBase === 'business',
   hasTwitterImpressions: orgData.planBase === 'business',
   hasAnalyticsOnPosts: orgData.planBase !== 'free',
+  hasFirstCommentFeature: orgData.planBase !== 'free',
+  hasShareNextFeature: orgData.planBase !== 'free',
+  hasUserTagFeature: orgData.planBase !== 'free',
+  hasAccessTeamPanel: orgData.planBase === 'business' && orgData.isAdmin,
+
+  // Role Features
+  canManageSocialAccounts: orgData.isAdmin,
+  canSeeCampaignsReport: orgData.isOwner,
+  canModifyCampaigns: orgData.isAdmin,
+  canSeeBillingInfo: orgData.isOwner,
+  canReconnectChannels: orgData.isAdmin,
 
   // Upgrade/ Trial Paths
   showUpgradeToProCta: orgData.planBase === 'free',
+  showUpgradeToBusinessCta: orgData.planBase === 'pro',
+  shouldShowUpgradeButton:
+    orgData.isOwner &&
+    (orgData.planBase === 'free' ||
+      orgData.planBase === 'pro' ||
+      orgData.plan === 'solo_premium_business' ||
+      orgData.plan === 'premium_business'),
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Add orgs data to composer
- Grab orgs data instead of user data in composer queue limit error
- Add plan and role features data to org parser
<!--- Describe your changes in detail. -->

## Context & Notes
Next: Replace user references (isBusinessUser, features) by orgs data in the composer
https://buffer.atlassian.net/browse/PUB-2998
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
