### PR TITLE
[PUB-2918] Remove fetchCampaignsIfNeeded

### DIFF
--- a/packages/app-pages/index.test.js
+++ b/packages/app-pages/index.test.js
@@ -327,8 +327,7 @@ describe('AppPages | user interaction', () => {
     expect(rpcCall).toHaveBeenCalledWith('gridPosts', {
       profileId: profileIG.id,
     });
-    expect(rpcCall).toHaveBeenCalledWith('getCampaignsList', {});
-    expect(rpcCall).toHaveBeenCalledTimes(12);
+    expect(rpcCall).toHaveBeenCalledTimes(11);
   });
 
   it('navigates to a campaign on tag click from main queue', async () => {
@@ -429,7 +428,7 @@ describe('AppPages | user interaction', () => {
       profileId: profileIG.id,
       isFetchingMore: false,
     });
-    expect(rpcCall).toHaveBeenCalledTimes(13);
+    expect(rpcCall).toHaveBeenCalledTimes(12);
 
     userEvent.click(storiesSubTab);
 
@@ -440,7 +439,7 @@ describe('AppPages | user interaction', () => {
       profileId: profileIG.id,
       isFetchingMore: false,
     });
-    expect(rpcCall).toHaveBeenCalledTimes(14);
+    expect(rpcCall).toHaveBeenCalledTimes(13);
   });
 
   it('navigates to Analytics tab and renders sent posts', async () => {
@@ -471,7 +470,7 @@ describe('AppPages | user interaction', () => {
       profileId: profileIG.id,
       isFetchingMore: false,
     });
-    expect(rpcCall).toHaveBeenCalledTimes(13);
+    expect(rpcCall).toHaveBeenCalledTimes(12);
   });
 
   it('navigates to Drafts tab and renders drafts posts', async () => {

--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -47,10 +47,6 @@ const ViewCampaign = ({
     }
   }, [campaignId, page]);
 
-  useEffect(() => {
-    actions.fetchCampaignsIfNeeded();
-  }, []);
-
   const { t } = useTranslation();
 
   // Conditions
@@ -142,7 +138,6 @@ ViewCampaign.propTypes = {
     goToAnalyzeReport: PropTypes.func.isRequired,
     onComposerCreateSuccess: PropTypes.func.isRequired,
     onComposerOverlayClick: PropTypes.func.isRequired,
-    fetchCampaignsIfNeeded: PropTypes.func.isRequired,
   }).isRequired,
   hasAnalyticsOnPosts: PropTypes.bool,
   hasTwitterImpressions: PropTypes.bool,

--- a/packages/campaign/components/ViewCampaign/story.jsx
+++ b/packages/campaign/components/ViewCampaign/story.jsx
@@ -85,7 +85,6 @@ const actions = {
   onCreatePostClick: action('create post'),
   onDeleteCampaignClick: action('delete campaign'),
   onEditCampaignClick: action('edit campaign'),
-  fetchCampaignsIfNeeded: action('fetch campaigns if needed'),
   fetchCampaign: action('fetch campaign'),
   goToAnalyzeReport: action('go to analyze report'),
   onComposerCreateSuccess: action('composer sucess'),

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -8,7 +8,6 @@ import {
   campaignSent,
   campaignCreate,
 } from '@bufferapp/publish-routes';
-import { actions as campaignListActions } from '@bufferapp/publish-campaigns-list';
 import { getURL } from '@bufferapp/publish-server/formatters/src';
 import { actions } from './reducer';
 import ViewCampaign from './components/ViewCampaign';
@@ -84,9 +83,6 @@ export default connect(
       },
       fetchCampaign: ({ campaignId, past }) => {
         dispatch(actions.fetchCampaign({ campaignId, past, fullItems: true }));
-      },
-      fetchCampaignsIfNeeded: () => {
-        dispatch(campaignListActions.fetchCampaignsIfNeeded());
       },
     },
     postActions: {

--- a/packages/campaign/index.test.js
+++ b/packages/campaign/index.test.js
@@ -70,6 +70,9 @@ const initialState = {
       canSeeCampaignsReport: true,
     },
   },
+  campaignsList: {
+    campaigns,
+  },
 };
 
 const mockApiCalls = () => {
@@ -179,9 +182,6 @@ describe('ViewCampaign | user interaction', () => {
     expect(totalScheduled).toBeInTheDocument();
     expect(totalSent).toBeInTheDocument();
 
-    expect(rpcCall).toHaveBeenCalledWith('getCampaignsList', {});
-    expect(rpcCall).toHaveBeenCalledTimes(1);
-
     /* Campaign queue assertions */
     userEvent.click(viewCampaignBtn);
 
@@ -217,6 +217,6 @@ describe('ViewCampaign | user interaction', () => {
       fullItems: true,
       past: false,
     });
-    expect(rpcCall).toHaveBeenCalledTimes(2);
+    expect(rpcCall).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/campaigns-list/components/ListCampaigns/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/index.jsx
@@ -53,7 +53,6 @@ const ListCampaigns = ({
   showCampaignActions,
   hideAnalyzeReport,
   hasCampaignsFlip,
-  fetchCampaignsIfNeeded,
   isLoading,
   ownerEmail,
 }) => {
@@ -61,10 +60,6 @@ const ListCampaigns = ({
     window.location = getURL.getPublishUrl();
     return null;
   }
-  // Fetch Data
-  useEffect(() => {
-    fetchCampaignsIfNeeded();
-  }, []);
 
   const { t } = useTranslation();
 
@@ -128,7 +123,6 @@ ListCampaigns.propTypes = {
   showCampaignActions: PropTypes.bool.isRequired,
   hideAnalyzeReport: PropTypes.bool.isRequired,
   hasCampaignsFlip: PropTypes.bool.isRequired,
-  fetchCampaignsIfNeeded: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
   ownerEmail: PropTypes.string,
 };

--- a/packages/campaigns-list/components/ListCampaigns/index.jsx
+++ b/packages/campaigns-list/components/ListCampaigns/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {
   ButtonWithSkeleton,

--- a/packages/campaigns-list/index.js
+++ b/packages/campaigns-list/index.js
@@ -6,7 +6,6 @@ import {
   campaignCreate,
   campaignScheduled,
 } from '@bufferapp/publish-routes';
-import { actions } from './reducer';
 import ListCampaigns from './components/ListCampaigns';
 
 export default connect(
@@ -45,11 +44,8 @@ export default connect(
         );
       }
     },
-    fetchCampaignsIfNeeded: () => {
-      dispatch(actions.fetchCampaignsIfNeeded());
-    },
   })
 )(ListCampaigns);
 
-export reducer, { actions, actionTypes } from './reducer';
+export reducer from './reducer';
 export middleware from './middleware';

--- a/packages/campaigns-list/middleware.js
+++ b/packages/campaigns-list/middleware.js
@@ -4,11 +4,9 @@ import {
 } from '@bufferapp/async-data-fetch';
 import { actionTypes as orgActionTypes } from '@bufferapp/publish-data-organizations';
 import { actions as notificationActions } from '@bufferapp/notifications';
-import { actionTypes } from './reducer';
 
-export default ({ dispatch, getState }) => next => action => {
+export default ({ dispatch }) => next => action => {
   next(action);
-  const state = getState();
   switch (action.type) {
     case orgActionTypes.ORGANIZATION_SELECTED: {
       const { globalOrgId, hasCampaignsFeature } = action.selected;
@@ -17,26 +15,6 @@ export default ({ dispatch, getState }) => next => action => {
           dataFetchActions.fetch({
             name: 'getCampaignsList',
             args: { globalOrgId },
-          })
-        );
-      }
-      break;
-    }
-    // Delete this logic once org switcher is deployed
-    case actionTypes.FETCH_CAMPAIGNS_IF_NEEDED: {
-      /* if a user enters a url directly, the campaign list will need to be fetched.
-       campaign list should only be fetched once while in publish */
-      const { hasCampaignsFeature, hasOrgSwitcherFeature } = state.user;
-      const shouldFetchCampaigns =
-        !hasOrgSwitcherFeature &&
-        hasCampaignsFeature &&
-        !state.campaignsList.campaigns;
-
-      if (shouldFetchCampaigns) {
-        dispatch(
-          dataFetchActions.fetch({
-            name: 'getCampaignsList',
-            args: {},
           })
         );
       }

--- a/packages/campaigns-list/middleware.test.js
+++ b/packages/campaigns-list/middleware.test.js
@@ -2,7 +2,7 @@ import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 import { actionTypes as notificationActionTypes } from '@bufferapp/notifications';
 import { actionTypes as orgActionTypes } from '@bufferapp/publish-data-organizations';
 import middleware from './middleware';
-import { actionTypes, initialState } from './reducer';
+import { initialState } from './reducer';
 
 describe('middleware', () => {
   const next = jest.fn();
@@ -31,87 +31,6 @@ describe('middleware', () => {
     );
   });
 
-  it('fetches getCampaignsList if campaign list state is null', () => {
-    const store = {
-      dispatch: jest.fn(),
-      getState: () => ({
-        campaignsList: initialState,
-        user: { hasCampaignsFeature: true },
-      }),
-    };
-    const action = {
-      type: actionTypes.FETCH_CAMPAIGNS_IF_NEEDED,
-    };
-    middleware(store)(next)(action);
-    expect(next).toBeCalledWith(action);
-    expect(store.dispatch).toBeCalledWith(
-      dataFetchActions.fetch({
-        name: 'getCampaignsList',
-        args: {},
-      })
-    );
-  });
-
-  it('does not fetch campaigns if user has no campaign feature', () => {
-    const store = {
-      dispatch: jest.fn(),
-      getState: () => ({
-        campaignsList: { initialState },
-        user: { features: [] },
-      }),
-    };
-    const action = {
-      type: actionTypes.FETCH_CAMPAIGNS_IF_NEEDED,
-    };
-    middleware(store)(next)(action);
-    expect(next).toBeCalledWith(action);
-    expect(store.dispatch).not.toBeCalledWith(
-      dataFetchActions.fetch({
-        name: 'getCampaignsList',
-        args: {},
-      })
-    );
-  });
-  it('does not fetch campaigns if campaigns is already in campaignsList state', () => {
-    const store = {
-      dispatch: jest.fn(),
-      getState: () => ({
-        campaignsList: { ...initialState, campaigns: [] },
-        user: { hasCampaignsFeature: true },
-      }),
-    };
-    const action = {
-      type: actionTypes.FETCH_CAMPAIGNS_IF_NEEDED,
-    };
-    middleware(store)(next)(action);
-    expect(next).toBeCalledWith(action);
-    expect(store.dispatch).not.toBeCalledWith(
-      dataFetchActions.fetch({
-        name: 'getCampaignsList',
-        args: {},
-      })
-    );
-  });
-  it('does not fetch campaigns if user has org switcher feature', () => {
-    const store = {
-      dispatch: jest.fn(),
-      getState: () => ({
-        campaignsList: { ...initialState, campaigns: [] },
-        user: { hasCampaignsFeature: true, hasOrgSwitcherFeature: true },
-      }),
-    };
-    const action = {
-      type: actionTypes.FETCH_CAMPAIGNS_IF_NEEDED,
-    };
-    middleware(store)(next)(action);
-    expect(next).toBeCalledWith(action);
-    expect(store.dispatch).not.toBeCalledWith(
-      dataFetchActions.fetch({
-        name: 'getCampaignsList',
-        args: {},
-      })
-    );
-  });
   it('triggers a notification if there is an error fetching campaigns', () => {
     const store = {
       dispatch: jest.fn(),

--- a/packages/campaigns-list/reducer.js
+++ b/packages/campaigns-list/reducer.js
@@ -1,12 +1,7 @@
-import keyWrapper from '@bufferapp/keywrapper';
 import { actionTypes as dataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import { actionTypes as campaignActionTypes } from '@bufferapp/publish-campaign';
 import { campaignParser } from '@bufferapp/publish-server/parsers/src';
 import { sortCampaignsByUpdatedAt } from '@bufferapp/publish-queue/reducer';
-
-export const actionTypes = keyWrapper('CAMPAIGNS_LIST', {
-  FETCH_CAMPAIGNS_IF_NEEDED: 0,
-});
 
 export const initialState = {
   campaigns: null,
@@ -72,10 +67,4 @@ export default (state = initialState, action) => {
     default:
       return state;
   }
-};
-
-export const actions = {
-  fetchCampaignsIfNeeded: () => ({
-    type: actionTypes.FETCH_CAMPAIGNS_IF_NEEDED,
-  }),
 };

--- a/packages/campaigns-list/reducer.test.js
+++ b/packages/campaigns-list/reducer.test.js
@@ -171,14 +171,4 @@ describe('reducer', () => {
       expect(reducer(stateBefore, action)).toEqual(stateAfter);
     });
   });
-
-  // Test action creators:
-  describe('action creators', () => {
-    it('creates a FETCH_CAMPAIGNS_IF_NEEDED action', () => {
-      const expectedAction = {
-        type: actionTypes.FETCH_CAMPAIGNS_IF_NEEDED,
-      };
-      expect(actions.fetchCampaignsIfNeeded()).toEqual(expectedAction);
-    });
-  });
 });

--- a/packages/past-reminders/components/PastRemindersPosts/index.jsx
+++ b/packages/past-reminders/components/PastRemindersPosts/index.jsx
@@ -95,7 +95,6 @@ const PastRemindersPosts = ({
   showStoriesComposer,
   isDisconnectedProfile,
   onClosePreviewClick,
-  fetchCampaignsIfNeeded,
   hasShareAgainFeature,
 }) => {
   if (loading) {
@@ -116,10 +115,6 @@ const PastRemindersPosts = ({
       />
     );
   }
-
-  useEffect(() => {
-    fetchCampaignsIfNeeded();
-  }, []);
 
   return (
     <ErrorBoundary>
@@ -184,7 +179,6 @@ PastRemindersPosts.propTypes = {
   userData: PropTypes.shape({
     tags: PropTypes.arrayOf(PropTypes.string),
   }),
-  fetchCampaignsIfNeeded: PropTypes.func.isRequired,
 };
 
 PastRemindersPosts.defaultProps = {

--- a/packages/past-reminders/components/PastRemindersPosts/story.jsx
+++ b/packages/past-reminders/components/PastRemindersPosts/story.jsx
@@ -43,7 +43,6 @@ storiesOf('PastRemindersPosts', module)
       showStoriesComposer={false}
       isDisconnectedProfile={false}
       onClosePreviewClick={action('onClosePreviewClick')}
-      fetchCampaignsIfNeeded={action('fetchCampaignsIfNeeded')}
       hasShareAgainFeature
     />
   ))
@@ -60,7 +59,6 @@ storiesOf('PastRemindersPosts', module)
       showStoriesComposer={false}
       isDisconnectedProfile={false}
       onClosePreviewClick={action('onClosePreviewClick')}
-      fetchCampaignsIfNeeded={action('fetchCampaignsIfNeeded')}
       hasShareAgainFeature
     />
   ))
@@ -77,7 +75,6 @@ storiesOf('PastRemindersPosts', module)
       showStoriesComposer={false}
       isDisconnectedProfile={false}
       onClosePreviewClick={action('onClosePreviewClick')}
-      fetchCampaignsIfNeeded={action('fetchCampaignsIfNeeded')}
       hasShareAgainFeature
     />
   ))
@@ -94,7 +91,6 @@ storiesOf('PastRemindersPosts', module)
       showStoriesComposer={false}
       isDisconnectedProfile={false}
       onClosePreviewClick={action('onClosePreviewClick')}
-      fetchCampaignsIfNeeded={action('fetchCampaignsIfNeeded')}
       hasShareAgainFeature
     />
   ));

--- a/packages/past-reminders/index.js
+++ b/packages/past-reminders/index.js
@@ -1,7 +1,6 @@
 // component vs. container https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0
 import { connect } from 'react-redux';
 import { actions as previewActions } from '@bufferapp/publish-story-preview';
-import { actions as campaignListActions } from '@bufferapp/publish-campaigns-list';
 import { formatPostLists } from '@bufferapp/publish-queue/util';
 // load the presentational component
 import { actions } from './reducer';
@@ -113,9 +112,6 @@ export default connect(
     },
     onClosePreviewClick: () => {
       dispatch(actions.handleClosePreviewClick());
-    },
-    fetchCampaignsIfNeeded: () => {
-      dispatch(campaignListActions.fetchCampaignsIfNeeded());
     },
   })
 )(PastRemindersWrapper);

--- a/packages/queue/components/QueuedPosts/index.jsx
+++ b/packages/queue/components/QueuedPosts/index.jsx
@@ -70,7 +70,6 @@ const QueuedPosts = ({
   onCampaignTagClick,
   hasCampaignsFeature,
   hasCalendarFeature,
-  fetchCampaignsIfNeeded,
   shouldDisplaySingleSlots,
   preserveComposerStateOnClose,
   shouldDisplayRemindersBanner,
@@ -100,10 +99,6 @@ const QueuedPosts = ({
   if (isLockedProfile) {
     return <LockedProfileNotification />;
   }
-
-  useEffect(() => {
-    fetchCampaignsIfNeeded();
-  }, []);
 
   return (
     <ErrorBoundary>
@@ -227,7 +222,6 @@ QueuedPosts.propTypes = {
   onCalendarClick: PropTypes.func.isRequired,
   hasCampaignsFeature: PropTypes.bool,
   hasCalendarFeature: PropTypes.bool,
-  fetchCampaignsIfNeeded: PropTypes.func.isRequired,
   shouldDisplaySingleSlots: PropTypes.bool,
   preserveComposerStateOnClose: PropTypes.bool,
   shouldDisplayIGPersonalNotification: PropTypes.bool,

--- a/packages/queue/components/QueuedPosts/story.jsx
+++ b/packages/queue/components/QueuedPosts/story.jsx
@@ -83,7 +83,6 @@ storiesOf('QueuedPosts', module)
       onDirectPostingClick={action('onDirectPostingClick')}
       onCalendarClick={action('onCalendarClick')}
       onEmptySlotClick={action('onEmptySlotClick')}
-      fetchCampaignsIfNeeded={action('fetchCampaignsIfNeeded')}
     />
   ))
   .add('loading', () => (
@@ -129,7 +128,6 @@ storiesOf('QueuedPosts', module)
       onRequeueClick={action('onRequeueClick')}
       onCalendarClick={action('onCalendarClick')}
       onEmptySlotClick={action('onEmptySlotClick')}
-      fetchCampaignsIfNeeded={action('fetchCampaignsIfNeeded')}
     />
   ))
   .add('paused if Contributor', () => (
@@ -152,7 +150,6 @@ storiesOf('QueuedPosts', module)
       onRequeueClick={action('onRequeueClick')}
       onCalendarClick={action('onCalendarClick')}
       onEmptySlotClick={action('onEmptySlotClick')}
-      fetchCampaignsIfNeeded={action('fetchCampaignsIfNeeded')}
     />
   ))
   .add('locked profile', () => (

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux';
 import { actions as profileSidebarActions } from '@bufferapp/publish-profile-sidebar/reducer';
 import { actions as dataFetchActions } from '@bufferapp/async-data-fetch';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
-import { actions as campaignListActions } from '@bufferapp/publish-campaigns-list';
 import { SEGMENT_NAMES } from '@bufferapp/publish-constants';
 import { getURL } from '@bufferapp/publish-server/formatters/src';
 
@@ -233,9 +232,6 @@ export default connect(
       if (weekOrMonth === 'week' || weekOrMonth === 'month') {
         openCalendarWindow(ownProps.profileId, weekOrMonth);
       }
-    },
-    fetchCampaignsIfNeeded: () => {
-      dispatch(campaignListActions.fetchCampaignsIfNeeded());
     },
   })
 )(QueuedPosts);

--- a/packages/queue/index.test.js
+++ b/packages/queue/index.test.js
@@ -203,9 +203,6 @@ describe('QueuedPosts | user interaction', () => {
       }
     );
 
-    expect(rpcCall).toHaveBeenCalledWith('getCampaignsList', {});
-    expect(rpcCall).toHaveBeenCalledTimes(1);
-
     expect(screen.getByText(post1.postContent.text)).toBeInTheDocument();
     expect(screen.getByText(post1.postDetails.postAction)).toBeInTheDocument();
     expect(screen.getByText(campaign.name)).toBeInTheDocument();

--- a/packages/queue/index.test.js
+++ b/packages/queue/index.test.js
@@ -220,7 +220,7 @@ describe('QueuedPosts | user interaction', () => {
       profileId: profile.id,
       updateId: post1.id,
     });
-    expect(rpcCall).toHaveBeenCalledTimes(2);
+    expect(rpcCall).toHaveBeenCalledTimes(1);
   });
   test('a11y | retiring IG profile banner is accessible', async () => {
     const { container } = render(<RetiringProfileBanner />);

--- a/packages/sent/components/SentPosts/index.jsx
+++ b/packages/sent/components/SentPosts/index.jsx
@@ -100,7 +100,6 @@ const SentPosts = ({
   fetchSentPosts,
   linkShortening,
   hasBitlyPosts,
-  fetchCampaignsIfNeeded,
   profileServiceType,
   profileService,
   hasAnalyticsOnPosts,
@@ -110,10 +109,6 @@ const SentPosts = ({
   useEffect(() => {
     fetchSentPosts();
   }, [profileId]);
-
-  useEffect(() => {
-    fetchCampaignsIfNeeded();
-  }, []);
 
   if (shouldDisplayIGPersonalNotification) {
     return <InstagramPersonalProfileNotification />;
@@ -242,7 +237,6 @@ SentPosts.propTypes = {
     isBitlyConnected: PropTypes.bool,
   }),
   hasBitlyPosts: PropTypes.bool,
-  fetchCampaignsIfNeeded: PropTypes.func.isRequired,
   hasAnalyticsOnPosts: PropTypes.bool,
   hasTwitterImpressions: PropTypes.bool,
   shouldDisplayIGPersonalNotification: PropTypes.bool,

--- a/packages/sent/components/SentPosts/story.jsx
+++ b/packages/sent/components/SentPosts/story.jsx
@@ -39,7 +39,6 @@ storiesOf('SentPosts', module)
       onClickUpgrade={action('onClickUpgrade')}
       onShareAgainClick={action('onShareAgainClick')}
       fetchSentPosts={action('fetchSentPosts')}
-      fetchCampaignsIfNeeded={action('fetchCampaignsIfNeeded')}
       linkShortening={{}}
     />
   ))
@@ -52,7 +51,6 @@ storiesOf('SentPosts', module)
       onClickUpgrade={action('onClickUpgrade')}
       onShareAgainClick={action('onShareAgainClick')}
       fetchSentPosts={action('fetchSentPosts')}
-      fetchCampaignsIfNeeded={action('fetchCampaignsIfNeeded')}
       linkShortening={{}}
       hasAnalyticsOnPosts
       hasTwitterImpressions

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -1,6 +1,5 @@
 // component vs. container https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0
 import { connect } from 'react-redux';
-import { actions as campaignListActions } from '@bufferapp/publish-campaigns-list';
 import { formatPostLists } from '@bufferapp/publish-queue/util';
 // load the presentational component
 import { actions } from './reducer';
@@ -87,9 +86,6 @@ export default connect(
           profileId: ownProps.profileId,
         })
       );
-    },
-    fetchCampaignsIfNeeded: () => {
-      dispatch(campaignListActions.fetchCampaignsIfNeeded());
     },
   })
 )(SentPosts);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Remove fetchCampaignsIfNeeded, only being used by people without the org switcher feature flip
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-2918
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
