### PR TITLE
[PUB-3007] Move org roles dependable props

### DIFF
--- a/packages/app-shell/index.js
+++ b/packages/app-shell/index.js
@@ -30,7 +30,7 @@ export default connect(
      * Org Switcher
      * Needs organizations and profiles.
      */
-    canSeeOrgSwitcher: state.user.canSeeOrgSwitcher,
+    canSeeOrgSwitcher: state.organizations.canSeeOrgSwitcher,
     organizations: getOrgsAlfabeticalOrder(state.organizations.list) || [],
     selectedOrganizationId: state.organizations.selected?.id,
     profiles: state.profileSidebar.profileList,

--- a/packages/organizations/reducer.js
+++ b/packages/organizations/reducer.js
@@ -14,6 +14,7 @@ export default (state = { loaded: false }, action) => {
         list: organizations,
         selected: selectedOrganization,
         loaded: true,
+        canSeeOrgSwitcher: organizations?.length >= 2,
       };
     }
     case actionTypes.ORGANIZATION_SELECTED: {

--- a/packages/sent/index.js
+++ b/packages/sent/index.js
@@ -42,11 +42,13 @@ export default connect(
         isLockedProfile: state.profileSidebar.isLockedProfile,
         isDisconnectedProfile:
           state.profileSidebar.selectedProfile.isDisconnected,
-        analyzeCrossSale: state.user.analyzeCrossSale,
+        analyzeCrossSale:
+          state.user.analyzeCrossSale && state.organizations.selected?.isOwner, // Analyze doesn't support team members
         hasFirstCommentFlip:
           state.organizations.selected?.hasFirstCommentFeature,
         hasCampaignsFeature: state.organizations.selected?.hasCampaignsFeature,
-        hasShareAgainFeature: state.organizations.selected?.hasShareAgainFeature,
+        hasShareAgainFeature:
+          state.organizations.selected?.hasShareAgainFeature,
         has30DaySentPostsLimitFeature:
           state.organizations.selected?.has30DaySentPostsLimitFeature,
         hasBitlyFeature: state.organizations.selected?.hasBitlyFeature,

--- a/packages/server/parsers/src/orgParser.js
+++ b/packages/server/parsers/src/orgParser.js
@@ -62,7 +62,7 @@ module.exports = orgData => ({
 
   // Upgrade/ Trial Paths
   showUpgradeToProCta: orgData.planBase === 'free',
-  showUpgradeToBusinessCta: orgData.planBase === 'pro',
+  showUpgradeToBusinessCta: orgData.planBase === 'pro' && orgData.isOwner,
   shouldShowUpgradeButton:
     orgData.isOwner &&
     (orgData.planBase === 'free' ||
@@ -73,13 +73,15 @@ module.exports = orgData => ({
     orgData.trial &&
     orgData.trial.plan === 'pro' &&
     orgData.trial.onTrial &&
-    orgData.trial.isExpired,
+    orgData.trial.isExpired &&
+    orgData.isOwner,
   shouldShowBusinessTrialExpiredModal:
     orgData.trial &&
     orgData.trial.plan !== 'pro' &&
     orgData.trial.onTrial &&
     orgData.trial.isExpired &&
-    !orgData.trial.isDone,
+    !orgData.trial.isDone &&
+    orgData.isOwner,
   showBusinessTrialistsOnboarding:
     orgData.planBase === 'business' &&
     orgData.trial &&

--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -32,6 +32,7 @@ export default ({ dispatch, getState }) => next => action => {
           we initialize the thirdParty apps on user fetch success. And vice versa.
       */
       const { user } = getState();
+      const { canSeeOrgSwitcher } = getState()?.organizations;
       if (user && Object.keys(user).length > 0) {
         dispatch({
           type: actionTypes.FULLSTORY,
@@ -40,7 +41,10 @@ export default ({ dispatch, getState }) => next => action => {
         });
         dispatch({
           type: actionTypes.APPCUES,
-          organization: action.selected,
+          organization: {
+            ...action.selected,
+            canSeeOrgSwitcher,
+          },
           user,
         });
       }
@@ -55,6 +59,7 @@ export default ({ dispatch, getState }) => next => action => {
         selectedOrganization &&
         Object.keys(selectedOrganization).length > 0
       ) {
+        const { canSeeOrgSwitcher } = getState()?.organizations;
         dispatch({
           type: actionTypes.FULLSTORY,
           user: action.result,
@@ -63,7 +68,10 @@ export default ({ dispatch, getState }) => next => action => {
         dispatch({
           type: actionTypes.APPCUES,
           user: action.result,
-          organization: selectedOrganization,
+          organization: {
+            ...selectedOrganization,
+            canSeeOrgSwitcher,
+          },
         });
       }
 
@@ -108,7 +116,7 @@ export default ({ dispatch, getState }) => next => action => {
             });
           }
         } else if (window.Appcues) {
-          const { id, createdAt, canSeeOrgSwitcher, tags } = action.user;
+          const { id, createdAt, tags } = action.user;
           let { plan } = action.organization;
           const {
             planBase,
@@ -116,6 +124,7 @@ export default ({ dispatch, getState }) => next => action => {
             trial,
             usersCount,
             profilesCount,
+            canSeeOrgSwitcher,
           } = action.organization; // org selected data
           if (shouldIdentifyWithAppcues({ plan, tags })) {
             dispatch({

--- a/packages/thirdParty/middleware.js
+++ b/packages/thirdParty/middleware.js
@@ -32,7 +32,7 @@ export default ({ dispatch, getState }) => next => action => {
           we initialize the thirdParty apps on user fetch success. And vice versa.
       */
       const { user } = getState();
-      const { canSeeOrgSwitcher } = getState()?.organizations;
+      const { canSeeOrgSwitcher } = getState()?.organizations || {};
       if (user && Object.keys(user).length > 0) {
         dispatch({
           type: actionTypes.FULLSTORY,
@@ -59,7 +59,7 @@ export default ({ dispatch, getState }) => next => action => {
         selectedOrganization &&
         Object.keys(selectedOrganization).length > 0
       ) {
-        const { canSeeOrgSwitcher } = getState()?.organizations;
+        const { canSeeOrgSwitcher } = getState()?.organizations || {};
         dispatch({
           type: actionTypes.FULLSTORY,
           user: action.result,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Move analyzeCrossSale and canSeeOrgSwitcher
- Add isOwner prop to trial expired modals
<!--- Describe your changes in detail. -->

## Context & Notes
https://buffer.atlassian.net/browse/PUB-3007
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
