### PR TITLE
Center images on Shop Grid preview

### DIFF
--- a/packages/shared-components/GridList/index.jsx
+++ b/packages/shared-components/GridList/index.jsx
@@ -39,7 +39,7 @@ const imgWrapperStyle = thumbnail => ({
   position: 'relative',
   width: '100%',
   height: '281.66px',
-  background: 'no-repeat top',
+  background: 'no-repeat center',
   backgroundSize: 'cover',
   cursor: 'pointer',
   backgroundImage: `url(${thumbnail})`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

The images in the `Shop Grid` tab in Publish are positioned "top", but that's not how it's going to be cropped in the Grid. This is a small tweak to make sure we are showing the images as they're going to display later on 😄 

## Context & Notes

I think that for accessibility purposes we could do better by turning these into image tags and allowing alt text: this might be something to consider 🤔 

## Screenshots (if appropriate)

Before / after:

![CleanShot 2020-10-06 at 10 38 32](https://user-images.githubusercontent.com/720667/95178994-5a000c80-07c0-11eb-88c4-44fa116b7dd5.gif)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [x] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [x] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
