### PR TITLE
[PUB-3061] Add notification setting for post failures

### DIFF
--- a/packages/account-notifications/components/Notifications/index.jsx
+++ b/packages/account-notifications/components/Notifications/index.jsx
@@ -11,6 +11,7 @@ const Notifications = ({
   queue,
   newsletter,
   milestones,
+  postFailure,
 }) => {
   const { t } = useTranslation();
 
@@ -25,6 +26,14 @@ const Notifications = ({
         onToggleClick={onToggleClick}
         toggleIsEnabled={queue}
         type="queueNotifications"
+      />
+      <Divider />
+      <Notification
+        title={t('preferences.notifications.postFailure')}
+        description={t('preferences.notifications.postFailureEmail')}
+        onToggleClick={onToggleClick}
+        toggleIsEnabled={postFailure}
+        type="postFailureNotifications"
       />
       <Divider />
       <Notification
@@ -60,6 +69,7 @@ Notifications.propTypes = {
   queue: PropTypes.bool.isRequired,
   newsletter: PropTypes.bool.isRequired,
   milestones: PropTypes.bool.isRequired,
+  postFailure: PropTypes.bool.isRequired,
 };
 
 export default Notifications;

--- a/packages/account-notifications/index.js
+++ b/packages/account-notifications/index.js
@@ -8,6 +8,7 @@ export default connect(
     queue: state.accountNotifications.queueNotifications,
     newsletter: state.accountNotifications.newsletterNotifications,
     milestones: state.accountNotifications.milestonesNotifications,
+    postFailure: state.accountNotifications.postFailureNotifications,
   }),
   dispatch => ({
     onToggleClick: (newToggleValue, type) => {

--- a/packages/account-notifications/reducer.js
+++ b/packages/account-notifications/reducer.js
@@ -10,6 +10,7 @@ export const initialState = {
   queue: null,
   newsletter: null,
   milestones: null,
+  postFailure: null,
 };
 
 export default (state = initialState, action) => {

--- a/packages/i18n/translations/en-us.json
+++ b/packages/i18n/translations/en-us.json
@@ -369,8 +369,10 @@
       "collaborationEmail": "Send me emails about contributions from team members. For example, if a post is awaiting approval.",
       "newsletter": "Newsletter",
       "newsletterEmail": "Send me emails with product updates, tips, and best practices.",
-      "queue": "Post & Queue",
-      "queueEmail": "Send me emails about changes to the status of my queue and scheduled posts. For example, if a post fails or if my queue becomes empty.",
+      "queue": "Queue Status Updates",
+      "queueEmail": "Send me emails about changes to the status of my queue and scheduled posts. For example, when a post successfully publishes or if my queue becomes empty. ",
+      "postFailure": "Post Failures",
+      "postFailureEmail": "Send me an email if a post in my queue fails to be published.",
       "celebrations": "Celebrations",
       "celebrationsEmail": "Send me emails celebrating my social media achievements with Buffer."
     },

--- a/packages/server/parsers/src/userParser.js
+++ b/packages/server/parsers/src/userParser.js
@@ -32,6 +32,9 @@ module.exports = userData => ({
     milestonesNotifications: userData.email_notifications.includes(
       'milestonesNotifications'
     ),
+    postFailureNotifications: userData.email_notifications.includes(
+      'postFailureNotifications'
+    ),
   },
   hasOrgSwitcherFeature: userData.features.includes('org_switcher'),
   hasPublishBeta: userData.features.includes('new_publish_beta'),


### PR DESCRIPTION
## Description
The purpose of this change is to add an additional setting for post failed notifications.

This will also require [buffer-web changes](https://github.com/bufferapp/buffer-web/pull/17332#issue-511746402) to be deployed before this can be merged.

## Context & Notes
PUB-3061

## Screenshots (if appropriate)
https://share.buffer.com/Wnur8jqD

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
