### PR TITLE
Task/disable location checkbox

### DIFF
--- a/packages/composer/composer/components/App.jsx
+++ b/packages/composer/composer/components/App.jsx
@@ -46,6 +46,7 @@ class App extends React.Component {
       PropTypes.shape({
         id: PropTypes.string.isRequired,
         canPostComment: PropTypes.bool,
+        canAssociateLocation: PropTypes.bool,
         serviceName: PropTypes.string.isRequired,
         serviceUsername: PropTypes.string.isRequired,
         serviceFormattedUsername: PropTypes.string.isRequired,

--- a/packages/composer/composer/components/LocationComposerBar.jsx
+++ b/packages/composer/composer/components/LocationComposerBar.jsx
@@ -96,6 +96,10 @@ function LocationComposerBar({
     ComposerActionCreators.updateDraftIsTaggingPageLocation(draftId, !checked);
   };
 
+  const shouldDisableLocationCheck = !selectedProfiles.some(
+    profile => profile.canAssociateLocation
+  );
+
   return shouldShow ? (
     <Container>
       <LabelWrapper>Location</LabelWrapper>
@@ -105,10 +109,15 @@ function LocationComposerBar({
           checked={checked}
           aria-label="Tag with connected Facebook Page location"
           onClick={handleClick}
+          disabled={shouldDisableLocationCheck}
         >
           <Check />
         </Checkbox>
-        <CheckboxLabel type="button" onClick={handleClick}>
+        <CheckboxLabel
+          type="button"
+          onClick={handleClick}
+          disabled={shouldDisableLocationCheck}
+        >
           Connected Facebook Page location{' '}
         </CheckboxLabel>
         <LearnMoreLink

--- a/packages/composer/composer/stores/AppStore.js
+++ b/packages/composer/composer/stores/AppStore.js
@@ -134,6 +134,7 @@ const getNewProfile = data => ({
   instagramDirectEnabled:
     data.instagramDirectEnabled && data.serviceName === 'instagram',
   canPostComment: data.canPostComment,
+  canAssociateLocation: data.canAssociateLocation,
   hasPushNotifications: data.hasPushNotifications,
   profileHasPostingSchedule: data.profileHasPostingSchedule,
   // Profile-specific app state

--- a/packages/composer/composer/utils/DataImportUtils.js
+++ b/packages/composer/composer/utils/DataImportUtils.js
@@ -150,6 +150,7 @@ const DataImportUtils = {
         subprofiles,
         hasPushNotifications: importedProfile.hasPushNotifications,
         canPostComment: importedProfile.canPostComment,
+        canAssociateLocation: importedProfile.canAssociateLocation,
         profileHasPostingSchedule: importedProfile.schedules.some(
           item => item.times.length > 0
         ),

--- a/packages/server/parsers/src/profileParser.js
+++ b/packages/server/parsers/src/profileParser.js
@@ -38,6 +38,7 @@ module.exports = profile => ({
   isDisconnected: profile.oauth_broken,
   location: profile.location,
   shouldHideAdvancedAnalytics: profile.should_hide_advanced_analytics,
+  canAssociateLocation: profile.can_associate_location,
   // Remove when publish stops importing Analyze components
   organizationId: profile.organization_id,
   username: profile.service_username,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Disable location checkbox when none of the IG accounts selected in the composer have a FB page with location associated
<!--- Describe your changes in detail. -->

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
