### PR TITLE
Remove check from IG location checkbox when no profiles with FB accounts w/ location associated

### DIFF
--- a/packages/composer/composer/components/LocationComposerBar.jsx
+++ b/packages/composer/composer/components/LocationComposerBar.jsx
@@ -106,7 +106,7 @@ function LocationComposerBar({
       <InputWrapper>
         <Checkbox
           type="button"
-          checked={checked}
+          checked={shouldDisableLocationCheck ? false : checked}
           aria-label="Tag with connected Facebook Page location"
           onClick={handleClick}
           disabled={shouldDisableLocationCheck}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Remove check from location checkbox when there are no IG profiles with FB accounts w/ location associated
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
