### PR TITLE
Fix calendar buttons condition

### DIFF
--- a/packages/shared-components/QueueItems/Header/index.jsx
+++ b/packages/shared-components/QueueItems/Header/index.jsx
@@ -43,20 +43,24 @@ const Header = ({
       isFirstItem={isFirstItem}
     >
       <QueueHeader id={id} text={text} dayOfWeek={dayOfWeek} date={date} />
-      {shouldDisplayTimezone && isFirstItem && (
+      {isFirstItem && (
         <TimezoneWrapper>
-          <Text type="p" color="grayDark">
-            {formattedTimezone}
-          </Text>
-          <Button
-            as="a"
-            type="text"
-            onClick={onTimezoneClick}
-            icon={<Gear />}
-            hasIconOnly
-            label="Change Timezone"
-            size="small"
-          />
+          {shouldDisplayTimezone && (
+            <>
+              <Text type="p" color="grayDark">
+                {formattedTimezone}
+              </Text>
+              <Button
+                as="a"
+                type="text"
+                onClick={onTimezoneClick}
+                icon={<Gear />}
+                hasIconOnly
+                label="Change Timezone"
+                size="small"
+              />
+            </>
+          )}
 
           {renderCalendarButtons && (
             <CalendarButtons onCalendarClick={onCalendarClick} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Fix condition so calendar buttons render independently from the timezone
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
