### PR TITLE
Don't run Lighthouse CI on Depfu PRs

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,6 +1,9 @@
 name: Lighthouse CI (alpha)
 
-on: [push]
+on: 
+  push:
+    tags-ignore: 
+      - depfu
 
 jobs:
   lighthouse:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,6 +2,8 @@ name: Lighthouse CI (alpha)
 
 on: 
   push:
+    branches: 
+      - '*'
     tags-ignore: 
       - depfu
 


### PR DESCRIPTION
## Description

Depfu is a bot that automatically makes PRs for updating dependencies. It does not trigger a staging build (at least not right now, that might be worth trying in the future though). But since it never triggers a staging build that ALSO means Lighthouse CI hangs for several hours waiting for the site to be deployed, until it finally times out. (You'll see this error in the checks section of all the previous Depfu PRs)

This PR fixes that by disabling the Lighthouse run for depfu tagged PRs.

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
