### PR TITLE
[PUB-3118] Add org id to all tracked events

### DIFF
--- a/packages/analytics-middleware/middleware.js
+++ b/packages/analytics-middleware/middleware.js
@@ -1,6 +1,6 @@
 import { actionTypes } from './actions';
 
-export default () => next => action => {
+export default ({ getState }) => next => action => {
   // eslint-disable-line no-unused-vars
   next(action);
   switch (action.type) {
@@ -14,6 +14,7 @@ export default () => next => action => {
         window.analytics.track(action.eventName, {
           product: window.PRODUCT_TRACKING_KEY,
           clientName: window.CLIENT_NAME,
+          organizationId: getState().organizations.selected?.globalOrgId,
           ...action.payload,
         });
       }

--- a/packages/analytics-middleware/middleware.test.js
+++ b/packages/analytics-middleware/middleware.test.js
@@ -2,7 +2,13 @@ import './analytics.mock';
 import { actionTypes } from './actions';
 import middleware from './middleware';
 
-const state = {};
+const state = {
+  organizations: {
+    selected: {
+      globalOrgId: 'org1',
+    },
+  },
+};
 
 describe('middleware', () => {
   const next = jest.fn();
@@ -56,6 +62,7 @@ describe('middleware', () => {
       bar: 'bar',
       product: 'publish',
       clientName: 'publishWeb',
+      organizationId: 'org1',
     });
   });
 


### PR DESCRIPTION
## Description

This change is to add the user's global organization ID to all events tracked in our Segment tracking plan.

## Context & Notes
PUB-3118

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`