### PR TITLE
[PUB-3118] Adjust previous org values for org tracking

### DIFF
--- a/packages/globalAccount/middleware.js
+++ b/packages/globalAccount/middleware.js
@@ -22,6 +22,9 @@ export default ({ dispatch, getState }) => next => action => {
           name: state.user.name,
           email: state.globalAccount.email,
           productSolutionName: state.globalAccount.productSolutionName || null,
+          createdAt: state.user.createdAt.toString(),
+          organizationId: state.organization.selected?.globalOrgId,
+          plan: state.organization.selected?.plan,
         })
       );
       break;

--- a/packages/globalAccount/middleware.js
+++ b/packages/globalAccount/middleware.js
@@ -22,9 +22,6 @@ export default ({ dispatch, getState }) => next => action => {
           name: state.user.name,
           email: state.globalAccount.email,
           productSolutionName: state.globalAccount.productSolutionName || null,
-          createdAt: state.user.createdAt.toString(),
-          organizationId: state.organization.selected?.globalOrgId,
-          plan: state.organization.selected?.plan,
         })
       );
       break;

--- a/packages/organizations/middleware.js
+++ b/packages/organizations/middleware.js
@@ -78,8 +78,7 @@ export default ({ dispatch, getState }) => next => action => {
       dispatch(
         analyticsActions.trackEvent('Organization Switched', {
           organizationId: selected.globalOrgId,
-          publishOrganizationSwitchedTo: organizationId,
-          publishOrganizationSwitchedFrom: selected.id,
+          previousOrganizationId: selected.id,
         })
       );
 


### PR DESCRIPTION
## Description

A quick change that removes publishOrganizationSwitchedTo and publishOrganizationSwitchedFrom and replaces them with 'previousOrganizationId' as requested by the data team.

## Context & Notes
PUB-3118

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
