### PR TITLE
Fix Twitter Hashtag Autocomplete in Composer

### DIFF
--- a/packages/composer/composer/utils/WebAPIUtils.js
+++ b/packages/composer/composer/utils/WebAPIUtils.js
@@ -509,7 +509,7 @@ function getTwitterACPublicSearchHashtagSuggestions(search) {
   )
     .then(response => response.json())
     .then(response =>
-      response.hashtags.map(({ hashtag }) => [hashtag, { name: hashtag }])
+      response.topics.map(({ topic }) => [topic, { name: topic }])
     )
     .catch(error => {
       if (


### PR DESCRIPTION
## Description

Should fix up https://buffer.atlassian.net/browse/PUB-3237 by using the new topics array instead of hashtags which is now empty.

## Context & Notes

https://buffer.atlassian.net/browse/PUB-3237

## Screenshots (if appropriate)

https://share.buffer.com/xQuYGnPm

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
