### PR TITLE
Add close button to Engage Promo Modal

### DIFF
--- a/packages/engagement-promo-modal/components/EngagementPromoModal/index.jsx
+++ b/packages/engagement-promo-modal/components/EngagementPromoModal/index.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { fontWeightBold } from '@bufferapp/ui/style/fonts';
 import { Text, Button, Modal, Link } from '@bufferapp/ui';
+import { Cross } from '@bufferapp/ui/Icon';
 
 const Title = styled(Text)`
   margin: 320px 0 20px;
@@ -40,6 +41,12 @@ const ButtonContainer = styled.div`
   }
 `;
 
+const CloseButton = styled(Button)`
+  position: absolute;
+  right: 0;
+  top: 0;
+`;
+
 const EngagementPromoModal = ({
   dismissModal,
   startTrial,
@@ -48,6 +55,12 @@ const EngagementPromoModal = ({
   if (alreadySawModal) return null;
   return (
     <Modal background="url('https://s3.amazonaws.com/buffer-publish/images/engagement-promo-modal.png') no-repeat">
+      <CloseButton
+        type="text"
+        icon={<Cross size="large" />}
+        hasIconOnly
+        onClick={() => dismissModal()}
+      />
       <TextContainer>
         <Title type="h2">New! Reply to Instagram comments</Title>
         <Text type="p">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

<!--- Describe your changes in detail. -->
- Add close button to modal, so users can dismiss it when for some reason they can't see the "Dismiss" button.
- 
## Context & Notes
Some users with zoom > 100% are complaining they can't see the dismiss button. We are adding a quick fix with a close button here so they can dismiss the modal. However, I'm opening an issue to investigate the real problem: how can users with zoom > 100% get access to our modals entirely.
<!--- Why is this change required? What problem does it solve? -->

<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
<img width="662" alt="Screenshot 2021-01-27 at 17 05 25" src="https://user-images.githubusercontent.com/16758464/106026771-22480800-60c2-11eb-9685-1015f7b138da.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
