### PR TITLE
Add share again logic to campaigns

### DIFF
--- a/packages/campaign/components/ViewCampaign/index.jsx
+++ b/packages/campaign/components/ViewCampaign/index.jsx
@@ -103,6 +103,7 @@ const ViewCampaign = ({
             isSent={sentView}
             hasAnalyticsOnPosts={hasAnalyticsOnPosts}
             hasTwitterImpressions={hasTwitterImpressions}
+            onShareAgainClick={postActions.onShareAgainClick}
           />
         )}
       </main>
@@ -148,6 +149,7 @@ ViewCampaign.propTypes = {
     onSetRemindersClick: PropTypes.func.isRequired,
     onShareNowClick: PropTypes.func.isRequired,
     onRequeueClick: PropTypes.func.isRequired,
+    onShareAgainClick: PropTypes.func.isRequired,
   }).isRequired,
 };
 

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -93,7 +93,7 @@ export default connect(
         dispatch(
           sentActions.handleShareAgainClick({
             post,
-            profileId: ownProps.profileId,
+            profileId: post.profileId,
           })
         );
       },

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
 import { actions as queueActions } from '@bufferapp/publish-queue';
-import { actions as sentActions } from '@bufferapp/publish-sent';
 import { formatPostLists } from '@bufferapp/publish-queue/util';
 import {
   campaignEdit,
@@ -89,9 +88,9 @@ export default connect(
         });
         window.location.assign(reminderUrl);
       },
-      onShareAgainClick: post => {
+      onShareAgainClick: ({ post }) => {
         dispatch(
-          sentActions.handleShareAgainClick({
+          actions.handleShareAgainClick({
             post,
             profileId: post.profileId,
           })

--- a/packages/campaign/index.js
+++ b/packages/campaign/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { actions as modalsActions } from '@bufferapp/publish-modals';
 import { actions as queueActions } from '@bufferapp/publish-queue';
+import { actions as sentActions } from '@bufferapp/publish-sent';
 import { formatPostLists } from '@bufferapp/publish-queue/util';
 import {
   campaignEdit,
@@ -87,6 +88,14 @@ export default connect(
           nextUrl,
         });
         window.location.assign(reminderUrl);
+      },
+      onShareAgainClick: post => {
+        dispatch(
+          sentActions.handleShareAgainClick({
+            post,
+            profileId: ownProps.profileId,
+          })
+        );
       },
       onEditClick: ({ post }) => {
         dispatch(

--- a/packages/campaign/reducer.js
+++ b/packages/campaign/reducer.js
@@ -309,4 +309,12 @@ export const actions = {
     type: actionTypes.POST_SHARE_NOW,
     updateId: post.id,
   }),
+  handleShareAgainClick: ({ post, profileId }) => {
+    return {
+      type: actionTypes.OPEN_COMPOSER,
+      updateId: post.id,
+      editMode: false,
+      profileId,
+    };
+  },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
When we opened up the share again logic to all users, we removed code that caused the share again button to show on campaigns/sent tab without the onClick logic. We likely want the share again logic in the sent tab for campaigns, so I added the onClick logic for it. 

Related: https://buffer.slack.com/archives/CHN88PG2J/p1612961166098000
<!--- Describe your changes in detail. -->

## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
