### PR TITLE
[PUB-3167] Add validation to Pinterest source url

### DIFF
--- a/packages/composer/composer/components/Editor.jsx
+++ b/packages/composer/composer/components/Editor.jsx
@@ -640,6 +640,9 @@ class Editor extends React.Component {
   shouldEnableHashtagAutocomplete = () =>
     this.props.draft.service.name === 'twitter';
 
+  shouldDisabledShortenLinks = () =>
+    this.props.draft.service.name === 'pinterest';
+
   render() {
     const {
       draft,
@@ -753,7 +756,7 @@ class Editor extends React.Component {
             onLinkUnshortened={this.onLinkUnshortened}
           />
         )}
-        {isComposerExpanded && (
+        {isComposerExpanded && !this.shouldDisabledShortenLinks && (
           <UnshortenedLinkTooltip
             classNames={textZoneTooltipClassNames}
             onLinkReshortened={this.onLinkReshortened}

--- a/packages/composer/composer/components/SourceUrl.jsx
+++ b/packages/composer/composer/components/SourceUrl.jsx
@@ -25,10 +25,10 @@ class SourceUrl extends React.Component {
   render() {
     return (
       <span className={styles.sourceUrlContainer}>
-        <span className={styles.sourceUrlLabel}>Source: </span>
+        <span className={styles.sourceUrlLabel}>Destination URL: </span>
         <Input
           value={this.props.sourceUrl}
-          placeholder="Enter source url..."
+          placeholder="Enter destination URL..."
           onChange={this.saveSourceUrl}
           className={styles.sourceUrlInput}
         />

--- a/packages/composer/composer/components/SourceUrl.jsx
+++ b/packages/composer/composer/components/SourceUrl.jsx
@@ -25,10 +25,10 @@ class SourceUrl extends React.Component {
   render() {
     return (
       <span className={styles.sourceUrlContainer}>
-        <span className={styles.sourceUrlLabel}>Destination URL: </span>
+        <span className={styles.sourceUrlLabel}>Destination link: </span>
         <Input
           value={this.props.sourceUrl}
-          placeholder="Enter destination URL..."
+          placeholder="Enter destination link..."
           onChange={this.saveSourceUrl}
           className={styles.sourceUrlInput}
         />

--- a/packages/composer/composer/lib/validation/ValidateDraft.js
+++ b/packages/composer/composer/lib/validation/ValidateDraft.js
@@ -69,26 +69,24 @@ const validateDraftFunctions = [
 
   function pinterestLinkWithoutSourceUrl(draft) {
     const isPinterest = draft.service.name === 'pinterest';
-    if (isPinterest) {
-      const isPinterestSourceUrlUsingLinkShortener =
-        isPinterest &&
-        (draft.sourceLink?.url?.includes('bit.ly/') ||
-          draft.sourceLink?.url?.includes('buff.ly/') ||
-          draft.sourceLink?.url?.includes('j.mp/'));
+    const isPinterestSourceUrlUsingLinkShortener =
+      isPinterest &&
+      (draft.sourceLink?.url?.includes('bit.ly/') ||
+        draft.sourceLink?.url?.includes('buff.ly/') ||
+        draft.sourceLink?.url?.includes('j.mp/'));
 
-      const contentText = draft.editorState.getCurrentContent().getPlainText();
-      const linksInText = twitterText.extractUrls(contentText);
+    const contentText = draft.editorState.getCurrentContent().getPlainText();
+    const linksInText = twitterText.extractUrls(contentText);
 
-      const hasPinterestLinkWithoutSourceUrl =
-        isPinterest && linksInText.length > 0 && !draft.sourceLink;
-      if (
-        hasPinterestLinkWithoutSourceUrl ||
-        isPinterestSourceUrlUsingLinkShortener
-      ) {
-        return new ValidationFail(
-          `Please include a destination link (without link shortener)`
-        );
-      }
+    const hasPinterestLinkWithoutSourceUrl =
+      isPinterest && linksInText.length > 0 && !draft.sourceLink;
+    if (
+      hasPinterestLinkWithoutSourceUrl ||
+      isPinterestSourceUrlUsingLinkShortener
+    ) {
+      return new ValidationFail(
+        `Please include a destination link without link shortener`
+      );
     }
     return new ValidationSuccess();
   },

--- a/packages/composer/composer/stores/ComposerStore.js
+++ b/packages/composer/composer/stores/ComposerStore.js
@@ -251,7 +251,8 @@ const ComposerStore = {
         const isPinterestSourceUrlUsingLinkShortener =
           isPinterest &&
           (draft.sourceLink?.url.includes('bit.ly/') ||
-            draft.sourceLink?.url.includes('buff.ly/'));
+            draft.sourceLink?.url.includes('buff.ly/') ||
+            draft.sourceLink?.url.includes('j.mp/'));
 
         const contentText = contentState.getPlainText();
         const linksInText = twitterText.extractUrls(contentText);

--- a/packages/composer/composer/stores/ComposerStore.js
+++ b/packages/composer/composer/stores/ComposerStore.js
@@ -250,8 +250,8 @@ const ComposerStore = {
         const isPinterest = draft.service.name === 'pinterest';
         const isPinterestSourceUrlUsingLinkShortener =
           isPinterest &&
-          (draft.sourceLink?.url.includes('bit.ly') ||
-            draft.sourceLink?.url.includes('buff.ly'));
+          (draft.sourceLink?.url.includes('bit.ly/') ||
+            draft.sourceLink?.url.includes('buff.ly/'));
 
         const contentText = contentState.getPlainText();
         const linksInText = twitterText.extractUrls(contentText);
@@ -331,14 +331,15 @@ const ComposerStore = {
             messages.push('Please include at least some text or an attachment');
           }
 
-          if (hasPinterestLinkWithoutSourceUrl) {
-            messages.push(`Please include a source url`);
+          if (
+            hasPinterestLinkWithoutSourceUrl ||
+            isPinterestSourceUrlUsingLinkShortener
+          ) {
+            messages.push(
+              `Please include a source url without a link shortener`
+            );
           } else if (!isSourceUrlUnrequiredOrValid) {
             messages.push('Please include a valid source url');
-          } else if (isPinterestSourceUrlUsingLinkShortener) {
-            messages.push(
-              'Please include a source url without a link shortener'
-            );
           }
 
           if (validationResultVideo.isInvalid()) {

--- a/packages/composer/composer/stores/ComposerStore.js
+++ b/packages/composer/composer/stores/ComposerStore.js
@@ -338,10 +338,10 @@ const ComposerStore = {
             isPinterestSourceUrlUsingLinkShortener
           ) {
             messages.push(
-              `Please include a source url without a link shortener`
+              `Please include a destination link without a link shortener`
             );
           } else if (!isSourceUrlUnrequiredOrValid) {
-            messages.push('Please include a valid source url');
+            messages.push('Please include a valid destination link');
           }
 
           if (validationResultVideo.isInvalid()) {

--- a/packages/composer/composer/stores/ComposerStore.js
+++ b/packages/composer/composer/stores/ComposerStore.js
@@ -243,24 +243,6 @@ const ComposerStore = {
           (draft.service.requiredAttachmentType === AttachmentTypes.MEDIA &&
             hasMediaAttached);
 
-        const isSourceUrlUnrequiredOrValid =
-          !draft.service.canHaveSourceUrl ||
-          draft.sourceLink === null ||
-          twitterText.isValidUrl(draft.sourceLink.url, true, false);
-
-        const isPinterest = draft.service.name === 'pinterest';
-        const isPinterestSourceUrlUsingLinkShortener =
-          isPinterest &&
-          (draft.sourceLink?.url.includes('bit.ly/') ||
-            draft.sourceLink?.url.includes('buff.ly/') ||
-            draft.sourceLink?.url.includes('j.mp/'));
-
-        const contentText = contentState.getPlainText();
-        const linksInText = twitterText.extractUrls(contentText);
-
-        const hasPinterestLinkWithoutSourceUrl =
-          isPinterest && linksInText.length > 0 && !draft.sourceLink;
-
         const hasRequiredText = !draft.service.requiresText || hasText;
 
         let validationResultVideo = new ValidationSuccess();
@@ -281,11 +263,8 @@ const ComposerStore = {
           (!hasText && !hasAnyAttachment) ||
           !hasRequiredAttachmentAttached ||
           !hasRequiredText ||
-          !isSourceUrlUnrequiredOrValid ||
           validationResultVideo.isInvalid() ||
-          validationResults.isInvalid() ||
-          hasPinterestLinkWithoutSourceUrl ||
-          isPinterestSourceUrlUsingLinkShortener;
+          validationResults.isInvalid();
 
         if (isInvalid) {
           let messages = [];
@@ -331,17 +310,6 @@ const ComposerStore = {
             messages.push('Please include some text');
           } else if (!hasText && !hasAnyAttachment) {
             messages.push('Please include at least some text or an attachment');
-          }
-
-          if (
-            hasPinterestLinkWithoutSourceUrl ||
-            isPinterestSourceUrlUsingLinkShortener
-          ) {
-            messages.push(
-              `Please include a destination link without a link shortener`
-            );
-          } else if (!isSourceUrlUnrequiredOrValid) {
-            messages.push('Please include a valid destination link');
           }
 
           if (validationResultVideo.isInvalid()) {

--- a/packages/composer/composer/tests/lib/validation/ValidateDraft.test.js
+++ b/packages/composer/composer/tests/lib/validation/ValidateDraft.test.js
@@ -335,6 +335,21 @@ describe('validateDraft', () => {
         'Please include a valid destination link'
       );
     });
+
+    it('returns ValidationFail if source url has link shortened', () => {
+      const service = Services.get('pinterest');
+
+      const draft = new Draft(service, EditorState.createEmpty());
+
+      draft.sourceLink = { url: 'bit.ly/aa' };
+
+      const results = validateDraft(draft);
+
+      expect(results.isInvalid()).toBeTruthy();
+      expect(results.getErrorMessages()).toContain(
+        'Please include a destination link without link shortener'
+      );
+    });
   });
 
   describe('characters validation', () => {

--- a/packages/composer/composer/tests/lib/validation/ValidateDraft.test.js
+++ b/packages/composer/composer/tests/lib/validation/ValidateDraft.test.js
@@ -320,6 +320,23 @@ describe('validateDraft', () => {
     });
   });
 
+  describe('validateSourceUrlforPinterest', () => {
+    it('returns ValidationFail if source url is an invalid link', () => {
+      const service = Services.get('pinterest');
+
+      const draft = new Draft(service, EditorState.createEmpty());
+
+      draft.sourceLink = 'blabla';
+
+      const results = validateDraft(draft);
+
+      expect(results.isInvalid()).toBeTruthy();
+      expect(results.getErrorMessages()).toContain(
+        'Please include a valid destination link'
+      );
+    });
+  });
+
   describe('characters validation', () => {
     // draft.characterCommentCount is updated in the ComposerStore when the text changes
     // in updateDraftCommentCharacterCount but we can force the value

--- a/packages/composer/composer/utils/StringUtils.js
+++ b/packages/composer/composer/utils/StringUtils.js
@@ -116,4 +116,5 @@ export {
   removeLinkFromErrorMessageText,
   getBaseUrl,
   isUrlOnBlocklist,
+  ensureUrlProtocol,
 };

--- a/packages/composer/composer/utils/WebAPIUtils.js
+++ b/packages/composer/composer/utils/WebAPIUtils.js
@@ -1,7 +1,6 @@
 import fetchJsonp from 'fetch-jsonp';
 import partition from 'lodash.partition';
 import lruCache from 'lru-cache';
-import twitterText from 'twitter-text';
 import Request from '@bufferapp/buffer-js-request';
 import { AppEnvironments } from '@bufferapp/publish-constants';
 import AppActionCreators from '../action-creators/AppActionCreators';
@@ -800,28 +799,13 @@ function getFormattedAPIData(serviceName, unformattedData) {
 
     if (serviceDraft.service.canHaveSourceUrl) {
       const { sourceLink } = serviceDraft;
-      const hasPinterestWithoutSourceUrl =
-        sourceLink === null && serviceDraft.service.name === 'pinterest';
-      let sourceUrl = null;
 
       if (sourceLink !== null) {
-        sourceUrl = sourceLink.url;
-      }
+        let sourceUrl = sourceLink.url;
+        if (sourceUrl.indexOf('http') !== 0) sourceUrl = `http://${sourceUrl}`;
 
-      // If Pinterest has text description with links and without a source url,
-      // we need to define one of the links as a source to be able to post the description
-      if (hasPinterestWithoutSourceUrl) {
-        const linksInText = twitterText.extractUrls(serviceDraftText);
-        if (linksInText.length > 0) {
-          sourceUrl = linksInText[0];
-        }
+        conditionalFields.source_url = sourceUrl;
       }
-
-      if (sourceUrl && sourceUrl.indexOf('http') !== 0) {
-        sourceUrl = `http://${sourceUrl}`;
-      }
-
-      if (sourceUrl) conditionalFields.source_url = sourceUrl;
     }
 
     if (serviceDraft.service.canHaveLocation) {

--- a/packages/composer/composer/utils/WebAPIUtils.js
+++ b/packages/composer/composer/utils/WebAPIUtils.js
@@ -9,6 +9,7 @@ import AppStore from '../stores/AppStore';
 import API from './API';
 import { observeStore } from '../utils/StoreUtils';
 import { extractSavedUpdatesIdsFromResponses } from '../utils/APIDataTransforms';
+import { ensureUrlProtocol } from './StringUtils';
 import {
   getComposerSource,
   getSegmentCampaignMetadata,
@@ -801,9 +802,7 @@ function getFormattedAPIData(serviceName, unformattedData) {
       const { sourceLink } = serviceDraft;
 
       if (sourceLink !== null) {
-        let sourceUrl = sourceLink.url;
-        if (sourceUrl.indexOf('http') !== 0) sourceUrl = `http://${sourceUrl}`;
-
+        const sourceUrl = ensureUrlProtocol(sourceLink.url);
         conditionalFields.source_url = sourceUrl;
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Undo https://github.com/bufferapp/buffer-publish/pull/1619, that automatically picks the first link as the source url when Pinterest posts have links.
- Make source field mandatory for Pinterest when there are links in the post.
- Since Pinterest marks most url shorteners as spam, block users from inserting buff.ly and bit.ly source urls.
- **NEW:** Unshorten Pinterest links when moving from omni to individual composer
<!--- Describe your changes in detail. -->

## Context & Notes
Pinterest blocks most url shorteners. Our Pinterest profiles don't have the option to select link shorteners in their settings. If users are composing to multiple profiles at the same time, and one of them has link shortening available, all the profiles including Pinterest will get it in the frontend - we then remove the link shortener for Pinterest in the backend.
https://buffer.atlassian.net/browse/PUB-3167
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)
<img width="727" alt="Screenshot 2021-03-03 at 16 38 24" src="https://user-images.githubusercontent.com/16758464/109839356-f0850c80-7c3e-11eb-8f14-fb07f74cea30.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [x] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`

