### PR TITLE
PUB-3407 | Add entitlements in orgParser for campaigns

### DIFF
--- a/packages/server/formatters/entitlements.js
+++ b/packages/server/formatters/entitlements.js
@@ -1,5 +1,3 @@
 module.exports = {
   CAMPAIGNS: 'campaigns',
-  PINTEREST: 'pinterest',
-  FIRST_COMMENT: 'first_comment',
 };

--- a/packages/server/formatters/entitlements.js
+++ b/packages/server/formatters/entitlements.js
@@ -1,0 +1,5 @@
+module.exports = {
+  CAMPAIGNS: 'campaigns',
+  PINTEREST: 'pinterest',
+  FIRST_COMMENT: 'first_comment',
+};

--- a/packages/server/formatters/index.js
+++ b/packages/server/formatters/index.js
@@ -2,6 +2,7 @@ const { getDateString, isInThePast, daysAgoTimestamp } = require('./date');
 const buildPostMap = require('./buildPostMap');
 const getURL = require('./getURL');
 const abbreviateNumber = require('./abbreviateNumber');
+const entitlements = require('./entitlements');
 
 module.exports = {
   getDateString,
@@ -10,4 +11,5 @@ module.exports = {
   buildPostMap,
   getURL,
   abbreviateNumber,
+  entitlements,
 };

--- a/packages/server/parsers/index.js
+++ b/packages/server/parsers/index.js
@@ -2,7 +2,7 @@ const postParser = require('./postParser');
 const profileParser = require('./profileParser');
 const userParser = require('./userParser');
 const linkParsing = require('./linkParsing');
-const orgParser = require('./orgParser').default;
+const orgParser = require('./orgParser');
 const storyGroupParser = require('./storyGroupParser');
 const { campaignParser, campaignItemParser } = require('./campaignParser');
 

--- a/packages/server/parsers/index.js
+++ b/packages/server/parsers/index.js
@@ -2,7 +2,7 @@ const postParser = require('./postParser');
 const profileParser = require('./profileParser');
 const userParser = require('./userParser');
 const linkParsing = require('./linkParsing');
-const orgParser = require('./orgParser');
+const orgParser = require('./orgParser').default;
 const storyGroupParser = require('./storyGroupParser');
 const { campaignParser, campaignItemParser } = require('./campaignParser');
 

--- a/packages/server/parsers/orgParser.js
+++ b/packages/server/parsers/orgParser.js
@@ -1,6 +1,6 @@
-const entitlements = require('../formatters/entitlements');
+import { CAMPAIGNS } from '../formatters/entitlements';
 
-module.exports = orgData => ({
+export default orgData => ({
   id: orgData.id,
   globalOrgId: orgData.globalOrgId,
   locked: orgData.locked,
@@ -28,7 +28,7 @@ module.exports = orgData => ({
   },
 
   // Plan Features
-  hasCampaignsFeature: orgData.entitlements.includes(entitlements.CAMPAIGNS),
+  hasCampaignsFeature: orgData.entitlements.includes(CAMPAIGNS),
   hasBitlyFeature: orgData.planBase !== 'free',
   has30DaySentPostsLimitFeature: orgData.planBase === 'free', // profiles_controller updates_sent() returns only 30 days of sent posts for free users.
   hasCalendarFeature: orgData.planBase !== 'free',

--- a/packages/server/parsers/orgParser.js
+++ b/packages/server/parsers/orgParser.js
@@ -1,6 +1,6 @@
-import { CAMPAIGNS } from '../formatters/entitlements';
+const entitlements = require('../formatters/entitlements');
 
-export default orgData => ({
+module.exports = orgData => ({
   id: orgData.id,
   globalOrgId: orgData.globalOrgId,
   locked: orgData.locked,
@@ -28,7 +28,7 @@ export default orgData => ({
   },
 
   // Plan Features
-  hasCampaignsFeature: orgData.entitlements.includes(CAMPAIGNS),
+  hasCampaignsFeature: orgData.entitlements.includes(entitlements.CAMPAIGNS),
   hasBitlyFeature: orgData.planBase !== 'free',
   has30DaySentPostsLimitFeature: orgData.planBase === 'free', // profiles_controller updates_sent() returns only 30 days of sent posts for free users.
   hasCalendarFeature: orgData.planBase !== 'free',

--- a/packages/server/parsers/orgParser.js
+++ b/packages/server/parsers/orgParser.js
@@ -1,3 +1,5 @@
+const entitlements = require('../formatters/entitlements');
+
 module.exports = orgData => ({
   id: orgData.id,
   globalOrgId: orgData.globalOrgId,
@@ -26,7 +28,7 @@ module.exports = orgData => ({
   },
 
   // Plan Features
-  hasCampaignsFeature: orgData.planBase !== 'free',
+  hasCampaignsFeature: orgData.entitlements.includes(entitlements.CAMPAIGNS),
   hasBitlyFeature: orgData.planBase !== 'free',
   has30DaySentPostsLimitFeature: orgData.planBase === 'free', // profiles_controller updates_sent() returns only 30 days of sent posts for free users.
   hasCalendarFeature: orgData.planBase !== 'free',


### PR DESCRIPTION
## Description
Add a constant file with entitlements and replace campaigns plan check with entitlement coming from the backend.

## Context & Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->
PUB-3407: We are accessing the features/entitlements from the backend, so we are replacing the `orgParser` from plan checks to entitlements that come from the API, for now, we are just testing with campaigns.

## ⚠️ Note to the reviewers: ⚠️ 
The e2e tests are failing because we haven't deployed the changes in the backend, as soon as those are merged, the tests should no longer fail.

## Checklist
-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
