### PR TITLE
Fix redirect to shared channels page on InstagramFirstCommentModal

### DIFF
--- a/packages/ig-first-comment-modal/components/InstagramFirstCommentModal/index.jsx
+++ b/packages/ig-first-comment-modal/components/InstagramFirstCommentModal/index.jsx
@@ -175,7 +175,9 @@ class InstagramFirstCommentModal extends React.Component {
       hideModal,
       profile,
       launchRequestMorePermission,
+      shouldRedirectToAccountChannels,
     } = this.props;
+
     const canPostComment = this.canPostComment();
 
     if (typeof canPostComment === 'undefined' || canPostComment) {
@@ -219,7 +221,6 @@ class InstagramFirstCommentModal extends React.Component {
       );
     }
     if (this.state.canRequestMorePermission) {
-      const { shouldRedirectToAccountChannels } = this.props;
       return (
         <div
           style={{
@@ -252,7 +253,7 @@ class InstagramFirstCommentModal extends React.Component {
                   <BDSButton
                     onClick={() =>
                       launchRequestMorePermission({
-                        id: missingPermisisonProfile.id,
+                        profileId: missingPermisisonProfile.id,
                         shouldRedirectToAccountChannels,
                       })
                     }
@@ -316,7 +317,10 @@ class InstagramFirstCommentModal extends React.Component {
                   </BDSButton>
                   <BDSButton
                     onClick={() =>
-                      launchRequestMorePermission(missingPermisisonProfile.id)
+                      launchRequestMorePermission({
+                        profileId: missingPermisisonProfile.id,
+                        shouldRedirectToAccountChannels,
+                      })
                     }
                   >
                     {translations.continue}
@@ -359,7 +363,10 @@ class InstagramFirstCommentModal extends React.Component {
                 </BDSButton>
                 <BDSButton
                   onClick={() =>
-                    launchRequestMorePermission(missingPermisisonProfile.id)
+                    launchRequestMorePermission({
+                      profileId: missingPermisisonProfile.id,
+                      shouldRedirectToAccountChannels,
+                    })
                   }
                 >
                   {translations.continue}


### PR DESCRIPTION
## Description

To redirect shared channels users that need to fix their comment permissions to https://account.buffer.com/channels when they see this modal:


![](https://p-bofz5w.t2.n0.cdn.getcloudapp.com/items/z8uPNJDj/5416aad7-e625-461e-8910-164f2cc89ecd.jpg)


## Context & Notes

<!--- Why is this change required? What problem does it solve? -->
<!--- Is there a related JIRA card? Please link to it here. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style and guidelines of this project. <!--- eslint -->
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have tested different user stories. <!--- e.g. team members, different plans -->
-   [ ] I have identified similar or related features and tested they are still working.
-   [x] I have performed a self-review of my own code.
-   [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I kept accessibility in mind by following the [a11y checklist.](https://www.notion.so/buffer/Workflow-Checklist-e64d86eb795140bcbfdc16d1c72e573f)
-   [ ] I have considered [security, abuse & compliance](https://www.notion.so/buffer/Engineering-Wiki-f34142d290304c35bebadf76cc9cc89e#cc6dcc7617184227b77da2e1b262a563) implications of my changes.

#### Staging Deployment

To visit the URL of the staging deployment, please click "Show all checks" at the bottom of this PR and click "details" next to `bufferbotbrains/cicd-buffer-publish-legacy`
